### PR TITLE
Enhance error handling with OData-aware exception factory

### DIFF
--- a/src/Dynamics365.BusinessCentral/Errors/BusinessCentralException.cs
+++ b/src/Dynamics365.BusinessCentral/Errors/BusinessCentralException.cs
@@ -1,4 +1,6 @@
 ﻿using System.Net;
+using System.Text;
+using System.Text.Json.Serialization;
 
 namespace Dynamics365.BusinessCentral.Errors;
 
@@ -8,6 +10,8 @@ public abstract class BusinessCentralException : Exception
     public string Method { get; }
     public string? RequestUrl { get; }
     public string? ResponseBody { get; }
+    public string? ODataErrorCode { get; }
+    public string? CorrelationId { get; }
 
     protected BusinessCentralException(
         string message,
@@ -15,36 +19,120 @@ public abstract class BusinessCentralException : Exception
         string method,
         string? requestUrl,
         string? responseBody,
+        string? odataErrorCode = null,
+        string? correlationId = null,
         Exception? inner = null)
-        : base(message, inner)
+        : base(BuildMessage(message, statusCode, method, requestUrl, responseBody, odataErrorCode, correlationId), inner)
     {
         StatusCode = statusCode;
         Method = method;
         RequestUrl = requestUrl;
         ResponseBody = responseBody;
+        ODataErrorCode = odataErrorCode;
+        CorrelationId = correlationId;
     }
+
+    private static string BuildMessage(
+        string message,
+        HttpStatusCode status,
+        string method,
+        string? url,
+        string? body,
+        string? odataErrorCode,
+        string? correlationId)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine(message);
+        sb.AppendLine($"Status: {(int)status} {status}");
+        sb.AppendLine($"Method: {method}");
+        sb.AppendLine($"URL: {url}");
+
+        if (!string.IsNullOrWhiteSpace(odataErrorCode))
+            sb.AppendLine($"OData Code: {odataErrorCode}");
+
+        if (!string.IsNullOrWhiteSpace(correlationId))
+            sb.AppendLine($"CorrelationId: {correlationId}");
+
+        if (!string.IsNullOrWhiteSpace(body))
+        {
+            sb.AppendLine("Response:");
+            sb.AppendLine(body);
+        }
+
+        return sb.ToString();
+    }
+
+    public override string ToString() => Message;
 }
 
 public sealed class BusinessCentralNotFoundException : BusinessCentralException
 {
-    public BusinessCentralNotFoundException(string message, HttpStatusCode code, string method, string? url, string? body, Exception? inner = null)
-        : base(message, code, method, url, body, inner) { }
+    public BusinessCentralNotFoundException(
+        string message,
+        HttpStatusCode code,
+        string method,
+        string? url,
+        string? body,
+        string? odataErrorCode = null,
+        string? correlationId = null,
+        Exception? inner = null)
+        : base(message, code, method, url, body, odataErrorCode, correlationId, inner) { }
 }
 
 public sealed class BusinessCentralAuthException : BusinessCentralException
 {
-    public BusinessCentralAuthException(string message, HttpStatusCode code, string method, string? url, string? body, Exception? inner = null)
-        : base(message, code, method, url, body, inner) { }
+    public BusinessCentralAuthException(
+        string message,
+        HttpStatusCode code,
+        string method,
+        string? url,
+        string? body,
+        string? odataErrorCode = null,
+        string? correlationId = null,
+        Exception? inner = null)
+        : base(message, code, method, url, body, odataErrorCode, correlationId, inner) { }
 }
 
 public sealed class BusinessCentralValidationException : BusinessCentralException
 {
-    public BusinessCentralValidationException(string message, HttpStatusCode code, string method, string? url, string? body, Exception? inner = null)
-        : base(message, code, method, url, body, inner) { }
+    public BusinessCentralValidationException(
+        string message,
+        HttpStatusCode code,
+        string method,
+        string? url,
+        string? body,
+        string? odataErrorCode = null,
+        string? correlationId = null,
+        Exception? inner = null)
+        : base(message, code, method, url, body, odataErrorCode, correlationId, inner) { }
 }
 
 public sealed class BusinessCentralServerException : BusinessCentralException
 {
-    public BusinessCentralServerException(string message, HttpStatusCode code, string method, string? url, string? body, Exception? inner = null)
-        : base(message, code, method, url, body, inner) { }
+    public BusinessCentralServerException(
+        string message,
+        HttpStatusCode code,
+        string method,
+        string? url,
+        string? body,
+        string? odataErrorCode = null,
+        string? correlationId = null,
+        Exception? inner = null)
+        : base(message, code, method, url, body, odataErrorCode, correlationId, inner) { }
+}
+
+internal sealed class BusinessCentralODataError
+{
+    [JsonPropertyName("error")]
+    public BusinessCentralODataErrorDetail? Error { get; set; }
+}
+
+internal sealed class BusinessCentralODataErrorDetail
+{
+    [JsonPropertyName("code")]
+    public string? Code { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
 }

--- a/src/Dynamics365.BusinessCentral/Errors/BusinessCentralExceptionFactory.cs
+++ b/src/Dynamics365.BusinessCentral/Errors/BusinessCentralExceptionFactory.cs
@@ -1,0 +1,76 @@
+﻿using System.Net;
+using System.Text.Json;
+
+namespace Dynamics365.BusinessCentral.Errors;
+
+public static class BusinessCentralExceptionFactory
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static async Task<BusinessCentralException> CreateAsync(
+        HttpResponseMessage res,
+        CancellationToken ct)
+    {
+        var body = await res.Content.ReadAsStringAsync(ct);
+
+        var url = res.RequestMessage?.RequestUri?.ToString();
+        var method = res.RequestMessage?.Method.Method ?? "UNKNOWN";
+
+        string? odataCode = null;
+        string? odataMessage = null;
+        string? correlationId = null;
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<BusinessCentralODataError>(body, _jsonOptions);
+
+            if (parsed?.Error != null)
+            {
+                odataCode = parsed.Error.Code;
+                odataMessage = parsed.Error.Message;
+
+                correlationId = ExtractCorrelationId(parsed.Error.Message);
+            }
+        }
+        catch
+        {
+            // ignore parsing errors - we still have raw body
+        }
+
+        var message = odataMessage ?? $"Business Central returned {(int)res.StatusCode} {res.StatusCode}.";
+
+        return res.StatusCode switch
+        {
+            HttpStatusCode.NotFound => new BusinessCentralNotFoundException(
+                message, res.StatusCode, method, url, body, odataCode, correlationId),
+
+            HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => new BusinessCentralAuthException(
+                message, res.StatusCode, method, url, body, odataCode, correlationId),
+
+            HttpStatusCode.BadRequest => new BusinessCentralValidationException(
+                message, res.StatusCode, method, url, body, odataCode, correlationId),
+
+            _ => new BusinessCentralServerException(
+                message, res.StatusCode, method, url, body, odataCode, correlationId)
+        };
+    }
+
+    private static string? ExtractCorrelationId(string? message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return null;
+
+        const string marker = "CorrelationId:";
+
+        var index = message.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (index < 0)
+            return null;
+
+        return message[(index + marker.Length)..]
+            .Trim()
+            .TrimEnd('.');
+    }
+}

--- a/test/Dynamics365.BusinessCentral.Tests/BusinessCentralExceptionFactoryTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/BusinessCentralExceptionFactoryTests.cs
@@ -1,0 +1,51 @@
+using Dynamics365.BusinessCentral.Errors;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+public class BusinessCentralExceptionFactoryTests
+{
+    [Fact]
+    public async Task CreateAsync_Parses_OData_Error_Details()
+    {
+        const string body = "{\"error\":{\"code\":\"Test.Code\",\"message\":\"Invalid data. CorrelationId: abc-123.\"}}";
+
+        var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent(body),
+            RequestMessage = new HttpRequestMessage(HttpMethod.Post, "https://test/resource")
+        };
+
+        var exception = await BusinessCentralExceptionFactory.CreateAsync(response, CancellationToken.None);
+
+        var validationException = Assert.IsType<BusinessCentralValidationException>(exception);
+        Assert.Equal(HttpStatusCode.BadRequest, validationException.StatusCode);
+        Assert.Equal("Test.Code", validationException.ODataErrorCode);
+        Assert.Equal("abc-123", validationException.CorrelationId);
+        Assert.Equal(body, validationException.ResponseBody);
+        Assert.Contains("OData Code: Test.Code", validationException.Message);
+        Assert.Contains("CorrelationId: abc-123", validationException.Message);
+    }
+
+    [Fact]
+    public async Task CreateAsync_Uses_Default_Message_When_OData_Message_Missing()
+    {
+        const string body = "{\"unexpected\":true}";
+
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent(body),
+            RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://test/resource")
+        };
+
+        var exception = await BusinessCentralExceptionFactory.CreateAsync(response, CancellationToken.None);
+
+        var serverException = Assert.IsType<BusinessCentralServerException>(exception);
+        Assert.Equal(HttpStatusCode.InternalServerError, serverException.StatusCode);
+        Assert.Equal(body, serverException.ResponseBody);
+        Assert.Contains("500", serverException.Message);
+        Assert.Contains("InternalServerError", serverException.Message);
+    }
+}


### PR DESCRIPTION
Enhance error handling with OData-aware exception factory

Introduce BusinessCentralExceptionFactory to centralize and improve error handling by parsing OData error details (including error code and CorrelationId) from HTTP responses. Update all BusinessCentralException types to store and display these details. Refactor BusinessCentralClient to use the new factory, remove legacy exception creation logic, and improve deserialization error reporting. Add tests to verify OData error parsing and fallback behavior. Clean up code for clarity and maintainability.