### PR TITLE
Simplify DI registration for BusinessCentralClient

### DIFF
--- a/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
+++ b/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>Dynamics365.BusinessCentral</PackageId>
-        <Version>1.0.0-beta2</Version>
+        <Version>1.0.0-beta3</Version>
         <Authors>Daniel Rückenbach</Authors>
         <Company>KRAL GmbH</Company>
 

--- a/src/Dynamics365.BusinessCentral/ServiceCollectionExtensions.cs
+++ b/src/Dynamics365.BusinessCentral/ServiceCollectionExtensions.cs
@@ -3,7 +3,6 @@ using Dynamics365.BusinessCentral.Diagnostics;
 using Dynamics365.BusinessCentral.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Dynamics365.BusinessCentral;
@@ -21,19 +20,7 @@ public static class ServiceCollectionExtensions
             .Validate(ValidateOption, "BusinessCentralOptions contain invalid configuration.")
             .ValidateOnStart();
 
-        services.AddHttpClient<BusinessCentralClient>()
-            .AddTypedClient((http, sp) =>
-            {
-                var observer = sp.GetService<IBusinessCentralObserver>();
-
-                return new BusinessCentralClient(
-                    http,
-                    sp.GetRequiredService<IOptions<BusinessCentralOptions>>(),
-                    observer);
-            });
-
-        services.TryAddTransient<IBusinessCentralClient>(sp =>
-            sp.GetRequiredService<BusinessCentralClient>());
+        services.AddHttpClient<IBusinessCentralClient, BusinessCentralClient>();
 
         return services;
     }

--- a/test/Dynamics365.BusinessCentral.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using Dynamics365.BusinessCentral;
-using Dynamics365.BusinessCentral.Client;
+﻿using Dynamics365.BusinessCentral.Client;
 using Dynamics365.BusinessCentral.Diagnostics;
 using Dynamics365.BusinessCentral.Options;
 using Microsoft.Extensions.DependencyInjection;
@@ -28,13 +27,10 @@ public class ServiceCollectionExtensionsTests
 
         var provider = services.BuildServiceProvider();
 
-        var client = provider.GetService<BusinessCentralClient>();
-        var clientInterface = provider.GetService<IBusinessCentralClient>();
+        var client = provider.GetService<IBusinessCentralClient>();
 
         Assert.NotNull(client);
-        Assert.IsAssignableFrom<IBusinessCentralClient>(client);
-        Assert.NotNull(clientInterface);
-        Assert.IsType<BusinessCentralClient>(clientInterface);
+        Assert.IsType<BusinessCentralClient>(client);
     }
 
     [Fact]
@@ -48,10 +44,10 @@ public class ServiceCollectionExtensionsTests
 
         var provider = services.BuildServiceProvider();
 
-        var client = provider.GetService<BusinessCentralClient>();
+        var client = provider.GetService<IBusinessCentralClient>();
 
         Assert.NotNull(client);
-        Assert.IsAssignableFrom<IBusinessCentralClient>(client);
+        Assert.IsType<BusinessCentralClient>(client);
 
         // Ensure observer itself is resolvable
         var observer = provider.GetService<IBusinessCentralObserver>();

--- a/test/Dynamics365.BusinessCentral.Tests/TestBase.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/TestBase.cs
@@ -2,7 +2,6 @@
 using Dynamics365.BusinessCentral.Diagnostics;
 using Dynamics365.BusinessCentral.Options;
 using Dynamics365.BusinessCentral.Tests.Utils;
-using Microsoft.Extensions.Options;
 
 namespace Dynamics365.BusinessCentral.Tests;
 


### PR DESCRIPTION
Simplify DI registration for BusinessCentralClient

Refactored DI setup to directly register BusinessCentralClient as IBusinessCentralClient using AddHttpClient, removing manual AddTypedClient logic and redundant service mappings. Updated tests to resolve and assert IBusinessCentralClient only. Incremented package version to 1.0.0-beta3 and cleaned up unused usings.