### PR TITLE
Release version 1.0.0 stable of Dynamics365.BusinessCentral

### DIFF
--- a/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
+++ b/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>Dynamics365.BusinessCentral</PackageId>
-        <Version>1.0.0-beta3</Version>
+        <Version>1.0.0</Version>
         <Authors>Daniel Rückenbach</Authors>
         <Company>KRAL GmbH</Company>
 


### PR DESCRIPTION
Release version 1.0.0 stable of Dynamics365.BusinessCentral

Updated the package version from 1.0.0-beta3 to 1.0.0, marking the transition from beta to the first stable release.