### PR TITLE
2.0: fix six defects and overhaul the consumer-facing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [2.0.0] - 2026-07-28
+## [2.0.0-alpha] - 2026-07-28
+
+**Prerelease.** Published for validation against real Business Central environments before
+2.0.0 stable. Everything below is complete and tested, but every test runs against a fake
+HTTP handler — see *Unverified* at the end of this entry for what still needs confirming
+against a live tenant.
+
+Install with `dotnet add package Dynamics365.BusinessCentral --prerelease`, or pin the
+version explicitly.
 
 Six defects and a rework of the consumer-facing API. **Upgrading from 1.x? Start with
 [MIGRATION.md](MIGRATION.md)** — most code keeps compiling, but several behavioural changes
@@ -108,6 +116,17 @@ are silent.
 - No Native AOT or trimming support yet; `System.Text.Json` reflection and the reflection
   used for typed selectors both block it.
 
+### Unverified
+
+Known gaps in this prerelease, to be confirmed before 2.0.0 stable:
+
+- `GetCompaniesAsync` targets `{BaseUrl}/Company`. `BusinessCentralCompany.Name` is
+  reliable; `DisplayName`, `Id` and `IsEvaluationCompany` are best-effort and null when the
+  endpoint does not return them. Not checked against a live tenant.
+- Whether Business Central honours `Prefer: return=representation` on a given endpoint,
+  which determines how often the `204 No Content` path is taken on writes.
+- Paging against a real dataset large enough to trigger server-driven `@odata.nextLink`.
+
 ## [1.0.0] - 2026-01-20
 
 First stable release.
@@ -130,6 +149,6 @@ First stable release.
 Initial pre-release line: OData querying with fluent filters, client-credentials
 authentication, DI integration, multi-targeting and NuGet packaging.
 
-[Unreleased]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v2.0.0...HEAD
-[2.0.0]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v1.0.0...v2.0.0
+[Unreleased]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v2.0.0-alpha...HEAD
+[2.0.0-alpha]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v1.0.0...v2.0.0-alpha
 [1.0.0]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v0.1.10...v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ are silent.
   previously always restarted from the first page.
 - **Abandoned responses are disposed** on the retry paths, and responses consumed internally
   are scoped with `using`.
+- **`QueryRawAsync<JsonElement>` compiles.** The README has shown that call since 1.0, but
+  `TResponse` was constrained to reference types, so the documented example never built for
+  consumers. The constraint is removed, matching the unconstrained result type on the
+  two-generic write overloads.
+- **Retry backoff cannot overflow.** A large `BaseDelay` combined with a high `MaxAttempts`
+  produced a value `TimeSpan` cannot represent, and `TimeSpan.FromMilliseconds` throws on
+  that — turning a transient failure into an unrelated crash. Delays are now clamped, and
+  negative configured values floor at zero.
 - `BusinessCentralErrorInfo.ResponseBody` was declared but never populated.
 - The constructor no longer mutates the injected `HttpClient`, which may be pooled.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ are silent.
   `BusinessCentralServerException` rather than a subclass. `catch (BusinessCentralServerException)`
   no longer sees it. (The same was already true of `400`/`401`/`403`/`404` — see
   [MIGRATION.md](MIGRATION.md).)
-- Test suite grew from 80 to 141, green on net8.0/net9.0/net10.0 with zero warnings.
+- Test suite grew from 80 to 159, green on net8.0/net9.0/net10.0 with zero warnings.
 - No Native AOT or trimming support yet; `System.Text.Json` reflection and the reflection
   used for typed selectors both block it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,126 @@
+# Changelog
+
+All notable changes to **Dynamics365.BusinessCentral** are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0] - 2026-07-28
+
+Six defects and a rework of the consumer-facing API. **Upgrading from 1.x? Start with
+[MIGRATION.md](MIGRATION.md)** — most code keeps compiling, but several behavioural changes
+are silent.
+
+### Fixed
+
+- **Access tokens are no longer re-fetched on every injection.** The cache lived on the
+  client, but typed `HttpClient`s are registered transient, so every resolution of
+  `IBusinessCentralClient` triggered a fresh token request. It now lives on a singleton.
+- **`QueryRawAsync` accepts a query string.** It previously percent-encoded the whole path,
+  turning `salesOrders?$top=5` into `salesOrders%3F%24top%3D5` — the documented usage never
+  worked. Path separators are also preserved now, so navigation paths work.
+- **Entity keys keep their OData syntax.** `Uri.EscapeDataString` was applied to the whole
+  key, mangling alternate keys such as `No='1000'` into `No%3D%271000%27`.
+- **`BaseUrl` placeholders are substituted.** `{tenant}` was documented but never replaced,
+  so the README's own example put a literal placeholder into every request URL.
+- **`204 No Content` on a write is a success.** `POST`/`PATCH`/`PUT` previously raised
+  `BusinessCentralServerException` for a write the server had applied.
+- **`@odata.nextLink` is followed.** `QueryAllAsync` silently truncated whenever Business
+  Central drove paging with a page smaller than the requested `$top`.
+- **`OnRequestFailed` is raised once per failure**, not twice.
+- **Chained ordering no longer discards keys.** `OrderByAsc(a).OrderByAsc(b)` dropped `a`;
+  use the new `ThenByAsc`/`ThenByDesc` to append.
+- **`Filter.In` with an empty collection** yields `false` instead of the invalid OData
+  expression `field in ()`.
+- `BusinessCentralErrorInfo.ResponseBody` was declared but never populated.
+- The constructor no longer mutates the injected `HttpClient`, which may be pooled.
+
+### Added
+
+- **Typed query builder.** `client.Query<T>()` with `Where`, `OrderBy`/`ThenBy`, `Select`,
+  `Expand`, `Top`, `Skip`, `PageSize`, and terminal `ToListAsync`, `ToAllAsync`,
+  `StreamAsync`, `ToPageAsync`, `FirstOrDefaultAsync`, `CountAsync`. Field names come from
+  property selectors resolved through the same `JsonSerializerOptions` used for
+  deserialization, so filters and projections cannot drift from the model.
+- **`[BusinessCentralEntity]`** binds a type to its OData entity set, so the path is not
+  repeated at every call site.
+- **Typed `Filter` overloads** — `Filter.Equals<SalesOrder>(o => o.Status, "Open")` — for
+  every existing operator.
+- **Automatic retry** of throttled and transient failures, honouring `Retry-After`.
+  Configurable through `BusinessCentralOptions.Retry`.
+- **`BusinessCentralThrottledException`** for `429`, plus `IsTransient` and `RetryAfter` on
+  every exception.
+- **`$expand` and `$count`**, via the builder or `QueryOptions`.
+- **Streaming** — `QueryStreamAsync` and `IBusinessCentralQuery.StreamAsync` return
+  `IAsyncEnumerable<T>` and stop fetching when enumeration stops.
+- **Multi-company support** — `ForCompany(name)` shares the HTTP client and token cache;
+  `GetCompaniesAsync()` lists the tenant's companies.
+- **`AddBusinessCentral(IConfiguration)`** for `appsettings.json` binding.
+- **Payload/result write overloads** — `PostAsync<TPayload, TResult>` and the same for
+  `PATCH`/`PUT`, so posting an anonymous object and reading back a typed entity no longer
+  requires `dynamic`.
+- **`QueryOptions.WithPageSize`**, distinct from `WithTop`.
+- **`OnTokenServedFromCache` and `OnRequestRetrying`** observer events, both default
+  interface methods so existing observers keep compiling.
+- **XML documentation ships in the package** — consumers previously got no IntelliSense.
+- SourceLink metadata, so the published `.snupkg` supports step-into debugging.
+
+### Changed
+
+- **Only four settings are required** — `TenantId`, `ClientId`, `ClientSecret`, `Company`.
+  `BaseUrl`, `TokenEndpoint`, `Environment` and `Scope` have working defaults, and
+  `{tenant}`/`{environment}` are substituted.
+- **`Exception.Message` is a single line.** It previously embedded the status, URL and the
+  entire response body, flooding structured logs. Those are properties, and `ToString()`
+  renders everything.
+- **Writes send `Prefer: return=representation`**, so Business Central returns the affected
+  entity where it can.
+- **`POST` is not replayed on ambiguous transient failures.** A `429` is rejected before
+  processing so replay is safe, but `408`/`502`/`503`/`504` may mean the write landed —
+  replaying would duplicate it. `GET`/`PUT`/`DELETE` are retried normally. Opt back in with
+  `Retry.RetryPostOnTransientFailures`.
+- **Options validation names each missing setting** instead of collapsing everything into
+  one boolean, and rejects unsubstituted `{…}` placeholders.
+- `ConfigureAwait(false)` throughout, so sync-over-async callers cannot deadlock.
+- Package dependencies are declared per target framework rather than pinning every target
+  to the 8.0.0 floor.
+- `ExcludeFromCodeCoverage` removed from `ServiceCollectionExtensions`, now that the DI
+  wiring carries real logic and is covered by tests.
+
+### Notes
+
+- `429` is now `BusinessCentralThrottledException`, a **sibling** of
+  `BusinessCentralServerException` rather than a subclass. `catch (BusinessCentralServerException)`
+  no longer sees it. (The same was already true of `400`/`401`/`403`/`404` — see
+  [MIGRATION.md](MIGRATION.md).)
+- Test suite grew from 80 to 141, green on net8.0/net9.0/net10.0 with zero warnings.
+- No Native AOT or trimming support yet; `System.Text.Json` reflection and the reflection
+  used for typed selectors both block it.
+
+## [1.0.0] - 2026-01-20
+
+First stable release.
+
+### Added
+
+- `POST`, `PUT` and `DELETE` support alongside querying and `PATCH`.
+- Diagnostics observer (`IBusinessCentralObserver`) for request and token lifecycle events.
+- OData-aware exception factory mapping status codes to typed exceptions and extracting the
+  Business Central correlation ID.
+
+### Changed
+
+- Simplified dependency-injection registration.
+- Improved token caching and concurrency handling.
+- Reworked URL building.
+
+## [0.1.5] - [0.1.10] - 2026-01-16 - 2026-01-19
+
+Initial pre-release line: OData querying with fluent filters, client-credentials
+authentication, DI integration, multi-targeting and NuGet packaging.
+
+[Unreleased]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v1.0.0...v2.0.0
+[1.0.0]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v0.1.10...v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ are silent.
   `TResponse` was constrained to reference types, so the documented example never built for
   consumers. The constraint is removed, matching the unconstrained result type on the
   two-generic write overloads.
+- **Failed responses are released before the backoff sleep** rather than after, so a
+  throttling window no longer holds buffered responses open across concurrent callers.
 - **Retry backoff cannot overflow.** A large `BaseDelay` combined with a high `MaxAttempts`
   produced a value `TimeSpan` cannot represent, and `TimeSpan.FromMilliseconds` throws on
   that — turning a transient failure into an unrelated crash. Delays are now clamped, and
@@ -112,8 +114,9 @@ are silent.
   entity where it can.
 - **`POST` is not replayed on ambiguous transient failures.** A `429` is rejected before
   processing so replay is safe, but `408`/`502`/`503`/`504` may mean the write landed —
-  replaying would duplicate it. `GET`/`PUT`/`DELETE` are retried normally. Opt back in with
-  `Retry.RetryPostOnTransientFailures`.
+  replaying would duplicate it. `GET`/`PUT`/`DELETE` are retried normally, and `PATCH` is
+  too, because this client only sends absolute field values so a replay converges. Opt
+  `POST` back in with `Retry.RetryPostOnTransientFailures`.
 - **Options validation names each missing setting** instead of collapsing everything into
   one boolean, and rejects unsubstituted `{…}` placeholders.
 - `ConfigureAwait(false)` throughout, so sync-over-async callers cannot deadlock.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ are silent.
   use the new `ThenByAsc`/`ThenByDesc` to append.
 - **`Filter.In` with an empty collection** yields `false` instead of the invalid OData
   expression `field in ()`.
+- **Non-positive paging values no longer hang.** A page size of zero made the "short page"
+  termination check unreachable, so streaming and `QueryAllAsync` requested the same empty
+  page forever. `PageSize` now requires a positive value, `Top`/`Skip` reject negatives, and
+  a zero-row request returns immediately.
+- **Short-lived tokens are cached.** Subtracting the fixed 60-second safety margin from an
+  `expires_in` below 60 put the expiry in the past, so the token counted as expired on
+  arrival and every call re-authenticated.
+- **The `User-Agent` reports the real version**, derived from the assembly rather than a
+  hard-coded `1.0`.
 - `BusinessCentralErrorInfo.ResponseBody` was declared but never populated.
 - The constructor no longer mutates the injected `HttpClient`, which may be pooled.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ are silent.
   arrival and every call re-authenticated.
 - **The `User-Agent` reports the real version**, derived from the assembly rather than a
   hard-coded `1.0`.
+- **Retrying a write no longer throws `ObjectDisposedException`.** Retries reused the
+  original request, but `HttpClient` disposes request content once a send completes, so any
+  replayed `POST`/`PATCH`/`PUT` — including the automatic retry after a `401` — failed on
+  the second attempt. Each attempt now builds a fresh request.
+- **A caller-supplied `$skip` is honoured** by `QueryAllAsync`/`QueryStreamAsync`, which
+  previously always restarted from the first page.
+- **Abandoned responses are disposed** on the retry paths, and responses consumed internally
+  are scoped with `using`.
 - `BusinessCentralErrorInfo.ResponseBody` was declared but never populated.
 - The constructor no longer mutates the injected `HttpClient`, which may be pooled.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+`Dynamics365.BusinessCentral` — a NuGet library: a lightweight, strongly-typed client for the Dynamics 365 Business Central OData v4 API. Only two runtime dependencies (`Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Http`); everything else is `HttpClient` + `System.Text.Json`. Keeping it dependency-free is a deliberate design goal — don't add packages casually.
+
+## Commands
+
+The solution uses the newer `.slnx` format, so a recent SDK is required (CI uses 10.0.x).
+
+```bash
+dotnet build Dynamics365.BusinessCentral.slnx
+dotnet test  Dynamics365.BusinessCentral.slnx
+
+# Both projects multi-target net8.0/net9.0/net10.0 — a bare `dotnet test` runs
+# the suite once per TFM. Pin one while iterating. CI uses net8.0, but running
+# that locally needs the .NET 8 runtime installed; with only the .NET 10 SDK
+# present, `-f net8.0` fails at test-host launch. Use net10.0 locally:
+dotnet test Dynamics365.BusinessCentral.slnx -f net10.0
+
+# Single test / class (xUnit v2 filter syntax):
+dotnet test -f net10.0 --filter "FullyQualifiedName~ClientTests.QueryAll_Pages_Until_Short_Page"
+dotnet test -f net10.0 --filter "FullyQualifiedName~ObserverTests"
+
+dotnet pack -c Release          # produces .nupkg + .snupkg
+```
+
+CI: `.github/workflows/sonar.yml` builds + tests on net8.0 and runs SonarCloud on every push/PR to `master`. `.github/workflows/nuget.yml` packs and pushes to NuGet on published GitHub releases — bump `<Version>` in the csproj before tagging.
+
+## Architecture
+
+`src/Dynamics365.BusinessCentral/` — one assembly, folders by concern:
+
+- **`Client/`** — `BusinessCentralClient` (sealed, the only implementation of `IBusinessCentralClient`) plus the internal `BusinessCentralTokenProvider`, `BusinessCentralUrlBuilder` and `HttpRequestExtensions`.
+- **`OData/`** — `Filter` (factory) → `ODataFilter` (immutable expression) → `FilterExtensions` (`And`/`Or`/`Not`), and `QueryOptions` (`$top`/`$skip`/`$orderby`).
+- **`Options/`** — `BusinessCentralOptions` (credentials, base URL, company), `BusinessCentralOptionsValidator`, and `BusinessCentralJson.Options`, the single shared `JsonSerializerOptions` (camelCase policy, case-insensitive read) used by both the client and the exception factory.
+- **`Errors/`** — `BusinessCentralException` base + four sealed subtypes; `BusinessCentralExceptionFactory` maps status codes to them.
+- **`Diagnostics/`** — `IBusinessCentralObserver` and its info DTOs.
+- **`ServiceCollectionExtensions.cs`** — `AddBusinessCentral` / `AddObserver<T>`.
+
+### Request pipeline
+
+Everything funnels through `BusinessCentralClient.SendWithAuthRetryAsync`. It runs a 2-attempt loop: acquire token → clone the request (`HttpRequestExtensions.Clone`, because a sent `HttpRequestMessage` can't be reused) → send. A `401` on attempt 0 invalidates the cached token and retries once; any other non-success status throws via `BusinessCentralExceptionFactory.CreateAsync`. A failure is reported to the observer exactly once — the throw site sets `failureReported` so the catch-all doesn't double-report.
+
+The client never mutates the injected `HttpClient` (it may be pooled). Accept/User-Agent are set per request in `AddJsonHeaders`.
+
+### Token acquisition
+
+`BusinessCentralTokenProvider` owns the token cache: lock-free fast path, then a `SemaphoreSlim` with double-check before the client-credentials POST. Tokens are cached with a 60-second safety margin subtracted from `expires_in`. `{TenantId}` in `TokenEndpoint` is substituted at request time.
+
+**It is registered as a singleton on purpose.** Typed HTTP clients are transient, so a cache living on `BusinessCentralClient` would re-authenticate on every injection. It gets its own named `HttpClient` (`TokenHttpClientName`) via `IHttpClientFactory`. If you ever move token state back onto the client, you reintroduce that bug — `Token_Cache_Is_Shared_Across_Resolved_Clients` guards it.
+
+### URL construction
+
+All entity URLs go through `BusinessCentralUrlBuilder`, which always injects the company segment: `{BaseUrl}/Company('{company}')/{path}`. Three encoding rules, each deliberately different:
+
+- `EncodePath` encodes **per segment**, so `/` keeps its meaning (navigation properties) while spaces are escaped.
+- `EncodeKey` preserves OData key syntax (`'`, `=`, `,`, `(`, `)`) so alternate keys like `No='1000'` survive; `Uri.EscapeDataString` would mangle them into `No%3D%271000%27`.
+- `BuildRawUrl` (used only by `QueryRawAsync`) passes everything after the first `?` through verbatim, so caller-supplied query strings like `salesOrders?$top=5` work.
+
+Note the quirk in `BuildQueryUrl`: a filter string of `"true"` is treated as "no filter" and omitted.
+
+### Filters
+
+`ODataFilter`'s constructor is `internal` — expressions can only be produced by `Filter` or `FilterExtensions`. New operators belong in those two files, not at call sites. `Filter.Format` handles the type→OData literal conversion (invariant culture); extend it there when adding value types.
+
+### Paging
+
+`QueryAllAsync` interprets `QueryOptions.Top` as *page size* (default 1000) rather than a total cap. Termination is two-tier: follow `@odata.nextLink` whenever the server sends one (server-driven paging means a short page is **not** the end), otherwise stop on the first page shorter than the requested size. It preserves `OrderBy` across pages but overwrites `Top`/`Skip`.
+
+### Writes
+
+POST/PATCH/PUT send `Prefer: return=representation` and go through `ReadEntityOrEchoAsync`: a `204 NoContent` or empty body is a **success** that returns the payload that was sent, not an error. `DeleteAsync` accepts 200 or 204.
+
+### Observability
+
+There is no `ILogger` dependency. Instead the client takes an optional `IBusinessCentralObserver` and falls back to `NullBusinessCentralObserver` when none is registered. Consumers opt in with `services.AddObserver<MyObserver>()` (registered via `TryAddSingleton`). `OnTokenRefreshed` fires only on a real refresh; cache hits fire `OnTokenServedFromCache`, which is a **default interface method** so adding it didn't break existing implementers — use the same trick for future events. When adding one, update the interface, `NullBusinessCentralObserver`, `TestObserver`, and `ObserverTests`.
+
+### DI registration
+
+`AddBusinessCentral` wires four things: options + `BusinessCentralOptionsValidator` (an `IValidateOptions<>` that names *each* missing setting rather than collapsing to one boolean), a named token `HttpClient`, the singleton `BusinessCentralTokenProvider`, and the typed client. Both HTTP clients are registered under explicit names (`TokenHttpClientName`, `ClientHttpClientName`) so tests can swap primary handlers without replacing the registration.
+
+The typed client uses the explicit-factory overload of `AddHttpClient`, not `ActivatorUtilities` — the constructor taking `BusinessCentralTokenProvider` is `internal` and would otherwise never be selected.
+
+## Tests
+
+`test/Dynamics365.BusinessCentral.Tests/` — 80 xUnit facts, no mocking library. The csproj has `InternalsVisibleTo`, so internal types are directly testable.
+
+Pattern: `TestBase.CreateClient(handler, observer?)` builds a real `BusinessCentralClient` over `FakeHttpHandler`, a `HttpMessageHandler` driven by a `Func<HttpRequestMessage, HttpResponseMessage>`. **Every handler must answer the token request first** — check `req.RequestUri.AbsoluteUri.Contains("auth")` and return `{"access_token":"abc","expires_in":3600}`, otherwise the request never reaches the assertion. Test entity types live in `Utils/`.
+
+`ClientTests` is a `partial` class split by `#region` per operation; keep new tests grouped the same way.
+
+## Docs
+
+`README.md` and `src/Dynamics365.BusinessCentral/README.md` are byte-identical — the latter is the packed NuGet readme. Update both together when public API changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,4 +124,10 @@ Pattern: `TestBase.CreateClient(handler, observer?, configure?)` builds a real `
 
 `README.md` and `src/Dynamics365.BusinessCentral/README.md` are identical except for one line: the root file links `MIGRATION.md` relatively, the packed copy uses an absolute GitHub URL because relative links don't resolve on nuget.org. Update both together when public API changes.
 
-`MIGRATION.md` documents the 1.0 → 2.0 move. Add to it whenever a change alters behaviour silently — that file is the only place a silent change is discoverable.
+Three release docs, each with a distinct job — don't merge them:
+
+- `CHANGELOG.md` — **what** changed, every version, Keep a Changelog format. Add an entry under `## [Unreleased]` as part of the change itself, not at release time.
+- `MIGRATION.md` — **how** to upgrade across a breaking version. Add to it whenever a change alters behaviour *silently*; that file is the only place such a change is discoverable.
+- `<PackageReleaseNotes>` in the csproj — the nuget.org summary. Keep it to a few lines that link the other two; nuget.org renders it as plain text, so never duplicate content there.
+
+Releasing: bump `<Version>`, move `[Unreleased]` to the new version with a date, refresh `<PackageReleaseNotes>`, then tag. `.github/workflows/nuget.yml` packs and pushes on published GitHub releases.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-`Dynamics365.BusinessCentral` — a NuGet library: a lightweight, strongly-typed client for the Dynamics 365 Business Central OData v4 API. Only two runtime dependencies (`Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Http`); everything else is `HttpClient` + `System.Text.Json`. Keeping it dependency-free is a deliberate design goal — don't add packages casually.
+`Dynamics365.BusinessCentral` — a NuGet library: a lightweight, strongly-typed client for the Dynamics 365 Business Central OData v4 API. Three runtime dependencies (`Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Http`, `Microsoft.Extensions.Options.ConfigurationExtensions`); everything else is `HttpClient` + `System.Text.Json`. Staying near-dependency-free is a deliberate design goal — don't add packages casually.
+
+Package references are declared **per TFM** (8.0.x / 9.0.x / 10.0.x) in both csproj files. Adding a package to one project means adding all three conditional entries to both, or restore fails with NU1605 downgrade errors.
 
 ## Commands
 
@@ -34,27 +36,38 @@ CI: `.github/workflows/sonar.yml` builds + tests on net8.0 and runs SonarCloud o
 `src/Dynamics365.BusinessCentral/` — one assembly, folders by concern:
 
 - **`Client/`** — `BusinessCentralClient` (sealed, the only implementation of `IBusinessCentralClient`) plus the internal `BusinessCentralTokenProvider`, `BusinessCentralUrlBuilder` and `HttpRequestExtensions`.
-- **`OData/`** — `Filter` (factory) → `ODataFilter` (immutable expression) → `FilterExtensions` (`And`/`Or`/`Not`), and `QueryOptions` (`$top`/`$skip`/`$orderby`).
+- **`OData/`** — the typed query surface: `IBusinessCentralQuery<T>`/`BusinessCentralQuery<T>` (fluent builder), `PropertyPath` (selector → field name), `EntityPath` + `BusinessCentralEntityAttribute` (type → entity set), `Filter`/`ODataFilter`/`FilterExtensions`, `QueryOptions`, `ODataResponse<T>`, `BusinessCentralPage<T>`, `BusinessCentralCompany`.
 - **`Options/`** — `BusinessCentralOptions` (credentials, base URL, company), `BusinessCentralOptionsValidator`, and `BusinessCentralJson.Options`, the single shared `JsonSerializerOptions` (camelCase policy, case-insensitive read) used by both the client and the exception factory.
-- **`Errors/`** — `BusinessCentralException` base + four sealed subtypes; `BusinessCentralExceptionFactory` maps status codes to them.
+- **`Errors/`** — `BusinessCentralException` base + five sealed subtypes (incl. `BusinessCentralThrottledException`); `BusinessCentralExceptionFactory` maps status codes and parses `Retry-After`.
 - **`Diagnostics/`** — `IBusinessCentralObserver` and its info DTOs.
 - **`ServiceCollectionExtensions.cs`** — `AddBusinessCentral` / `AddObserver<T>`.
 
 ### Request pipeline
 
-Everything funnels through `BusinessCentralClient.SendWithAuthRetryAsync`. It runs a 2-attempt loop: acquire token → clone the request (`HttpRequestExtensions.Clone`, because a sent `HttpRequestMessage` can't be reused) → send. A `401` on attempt 0 invalidates the cached token and retries once; any other non-success status throws via `BusinessCentralExceptionFactory.CreateAsync`. A failure is reported to the observer exactly once — the throw site sets `failureReported` so the catch-all doesn't double-report.
+Everything funnels through `BusinessCentralClient.SendWithAuthRetryAsync`, a single loop with **two independent retry budgets**:
+
+- **auth** — one retry, tracked by `authRetried`. A `401` invalidates the token and retries once.
+- **transient** — `BusinessCentralRetryOptions.MaxAttempts`, tracked by `transientAttempt`. Fires when `exception.IsTransient` (429/408/502/503/504). `ComputeDelay` prefers the server's `Retry-After`, else doubles `BaseDelay`; both capped by `MaxDelay`.
+
+Each attempt clones the request (`HttpRequestExtensions.Clone`, because a sent `HttpRequestMessage` can't be reused). A failure is reported to the observer exactly once — the throw site sets `failureReported` so the catch-all doesn't double-report.
+
+Tests must set `Retry.BaseDelay`/`MaxDelay` to zero or they sleep; `TestBase.CreateClient` already does.
 
 The client never mutates the injected `HttpClient` (it may be pooled). Accept/User-Agent are set per request in `AddJsonHeaders`.
 
 ### Token acquisition
 
-`BusinessCentralTokenProvider` owns the token cache: lock-free fast path, then a `SemaphoreSlim` with double-check before the client-credentials POST. Tokens are cached with a 60-second safety margin subtracted from `expires_in`. `{TenantId}` in `TokenEndpoint` is substituted at request time.
+`BusinessCentralTokenProvider` owns the token cache: lock-free fast path, then a `SemaphoreSlim` with double-check before the client-credentials POST. Tokens are cached with a 60-second safety margin subtracted from `expires_in`. It uses `options.ResolvedTokenEndpoint` — never re-implement placeholder substitution locally.
 
 **It is registered as a singleton on purpose.** Typed HTTP clients are transient, so a cache living on `BusinessCentralClient` would re-authenticate on every injection. It gets its own named `HttpClient` (`TokenHttpClientName`) via `IHttpClientFactory`. If you ever move token state back onto the client, you reintroduce that bug — `Token_Cache_Is_Shared_Across_Resolved_Clients` guards it.
 
+### Options and placeholders
+
+`BusinessCentralOptions` requires only four settings (TenantId, ClientId, ClientSecret, Company); `BaseUrl`, `TokenEndpoint`, `Environment` and `Scope` have working defaults. `{tenant}`, `{TenantId}` and `{environment}` are substituted by `ResolvedBaseUrl`/`ResolvedTokenEndpoint` — **always consume those, not the raw properties**. The validator checks the *resolved* URLs and rejects leftover `{...}`, which is what made the old README's `{tenant}` example fail silently.
+
 ### URL construction
 
-All entity URLs go through `BusinessCentralUrlBuilder`, which always injects the company segment: `{BaseUrl}/Company('{company}')/{path}`. Three encoding rules, each deliberately different:
+All entity URLs go through `BusinessCentralUrlBuilder`, which injects the company segment: `{BaseUrl}/Company('{company}')/{path}`. `BuildServiceRootUrl` deliberately skips it — the company list is tenant-level. Three encoding rules, each deliberately different:
 
 - `EncodePath` encodes **per segment**, so `/` keeps its meaning (navigation properties) while spaces are escaped.
 - `EncodeKey` preserves OData key syntax (`'`, `=`, `,`, `(`, `)`) so alternate keys like `No='1000'` survive; `Uri.EscapeDataString` would mangle them into `No%3D%271000%27`.
@@ -62,13 +75,21 @@ All entity URLs go through `BusinessCentralUrlBuilder`, which always injects the
 
 Note the quirk in `BuildQueryUrl`: a filter string of `"true"` is treated as "no filter" and omitted.
 
-### Filters
+### Filters and typed field names
 
-`ODataFilter`'s constructor is `internal` — expressions can only be produced by `Filter` or `FilterExtensions`. New operators belong in those two files, not at call sites. `Filter.Format` handles the type→OData literal conversion (invariant culture); extend it there when adding value types.
+`ODataFilter`'s constructor is `internal` — expressions can only be produced by `Filter` or `FilterExtensions`. New operators belong in those two files, and each needs **both** a string and an `Expression<Func<TEntity, object?>>` overload. `Filter.Format` handles type→OData literal conversion (invariant culture); extend it there when adding value types.
+
+`PropertyPath.Resolve` turns a selector into a field name using `JsonPropertyNameAttribute` first, then `BusinessCentralJson.Options.PropertyNamingPolicy`. That coupling is the point: `$filter`/`$select`/`$orderby` names always match deserialization. It strips the compiler's boxing `Convert` and walks nested members into `a/b` navigation paths.
 
 ### Paging
 
-`QueryAllAsync` interprets `QueryOptions.Top` as *page size* (default 1000) rather than a total cap. Termination is two-tier: follow `@odata.nextLink` whenever the server sends one (server-driven paging means a short page is **not** the end), otherwise stop on the first page shorter than the requested size. It preserves `OrderBy` across pages but overwrites `Top`/`Skip`.
+Two paging implementations exist and must stay in agreement: `BusinessCentralClient.QueryStreamAsync` (path-based) and `BusinessCentralQuery<T>.StreamAsync` (fluent). Both use the same three-tier termination:
+
+1. Follow `@odata.nextLink` whenever present, and set `serverDriven`.
+2. Once `serverDriven`, a missing nextLink means the collection is exhausted — the `$top` short-page rule no longer applies.
+3. Otherwise stop on the first page shorter than the requested size.
+
+`QueryOptions.PageSize` is rows-per-round-trip; `Top` is a result cap. `PageSize ?? Top ?? 1000` keeps the old `WithTop`-as-page-size behaviour working.
 
 ### Writes
 
@@ -76,19 +97,19 @@ POST/PATCH/PUT send `Prefer: return=representation` and go through `ReadEntityOr
 
 ### Observability
 
-There is no `ILogger` dependency. Instead the client takes an optional `IBusinessCentralObserver` and falls back to `NullBusinessCentralObserver` when none is registered. Consumers opt in with `services.AddObserver<MyObserver>()` (registered via `TryAddSingleton`). `OnTokenRefreshed` fires only on a real refresh; cache hits fire `OnTokenServedFromCache`, which is a **default interface method** so adding it didn't break existing implementers — use the same trick for future events. When adding one, update the interface, `NullBusinessCentralObserver`, `TestObserver`, and `ObserverTests`.
+There is no `ILogger` dependency. Instead the client takes an optional `IBusinessCentralObserver` and falls back to `NullBusinessCentralObserver` when none is registered. Consumers opt in with `services.AddObserver<MyObserver>()` (registered via `TryAddSingleton`). `OnTokenRefreshed` fires only on a real refresh; cache hits fire `OnTokenServedFromCache`, and retries fire `OnRequestRetrying`. Both are **default interface methods** so adding them didn't break existing implementers — use the same trick for future events. When adding one, update the interface, `NullBusinessCentralObserver`, `TestObserver`, and the observer tests.
 
 ### DI registration
 
-`AddBusinessCentral` wires four things: options + `BusinessCentralOptionsValidator` (an `IValidateOptions<>` that names *each* missing setting rather than collapsing to one boolean), a named token `HttpClient`, the singleton `BusinessCentralTokenProvider`, and the typed client. Both HTTP clients are registered under explicit names (`TokenHttpClientName`, `ClientHttpClientName`) so tests can swap primary handlers without replacing the registration.
+Two `AddBusinessCentral` overloads (lambda and `IConfiguration`) share `AddBusinessCentralCore`, which wires options + `BusinessCentralOptionsValidator` (an `IValidateOptions<>` that names *each* missing setting rather than collapsing to one boolean), a named token `HttpClient`, the singleton `BusinessCentralTokenProvider`, and the typed client. Both HTTP clients are registered under explicit names (`TokenHttpClientName`, `ClientHttpClientName`) so tests can swap primary handlers without replacing the registration.
 
 The typed client uses the explicit-factory overload of `AddHttpClient`, not `ActivatorUtilities` — the constructor taking `BusinessCentralTokenProvider` is `internal` and would otherwise never be selected.
 
 ## Tests
 
-`test/Dynamics365.BusinessCentral.Tests/` — 80 xUnit facts, no mocking library. The csproj has `InternalsVisibleTo`, so internal types are directly testable.
+`test/Dynamics365.BusinessCentral.Tests/` — 121 xUnit facts, no mocking library. The csproj has `InternalsVisibleTo`, so internal types are directly testable. Suites: `ClientTests` (path-based API), `QueryBuilderTests` (fluent/typed), `RetryTests`, `OptionsTests`, `ObserverTests`, `ServiceCollectionExtensionsTests`.
 
-Pattern: `TestBase.CreateClient(handler, observer?)` builds a real `BusinessCentralClient` over `FakeHttpHandler`, a `HttpMessageHandler` driven by a `Func<HttpRequestMessage, HttpResponseMessage>`. **Every handler must answer the token request first** — check `req.RequestUri.AbsoluteUri.Contains("auth")` and return `{"access_token":"abc","expires_in":3600}`, otherwise the request never reaches the assertion. Test entity types live in `Utils/`.
+Pattern: `TestBase.CreateClient(handler, observer?, configure?)` builds a real `BusinessCentralClient` over `FakeHttpHandler`, a `HttpMessageHandler` driven by a `Func<HttpRequestMessage, HttpResponseMessage>`. **Every handler must answer the token request first** — wrap it in `TestBase.WithToken(...)`, which does that for you, rather than repeating the `Contains("auth")` branch. `TestBase.Json(body)` is the 200-response shorthand. Test entity types live in `Utils/`; `SalesOrder` is the annotated one used for typed-query tests.
 
 `ClientTests` is a `partial` class split by `#region` per operation; keep new tests grouped the same way.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,12 @@ Two paging implementations exist and must stay in agreement: `BusinessCentralCli
 
 ### Writes
 
-POST/PATCH/PUT send `Prefer: return=representation` and go through `ReadEntityOrEchoAsync`: a `204 NoContent` or empty body is a **success** that returns the payload that was sent, not an error. `DeleteAsync` accepts 200 or 204.
+Each of POST/PATCH/PUT has two overloads, distinguished purely by **generic arity**:
+
+- one-generic (`PostAsync<T>`) — payload and result share a type; `ReadEntityOrEchoAsync` returns the sent payload on `204`/empty body.
+- two-generic (`PostAsync<TPayload, TResult>`) — `ReadEntityOrDefaultAsync` returns `default` on `204`/empty body, since the payload cannot stand in for the result. `TResult` is deliberately unconstrained so `JsonElement` works.
+
+Arity is what keeps `PostAsync<dynamic>(path, payload)` binding to the one-generic form. `WriteOverloadTests` pins that; don't add an overload that changes arity resolution. Both forms send `Prefer: return=representation`, and `204` is a success in both. `DeleteAsync` accepts 200 or 204.
 
 ### Observability
 
@@ -117,4 +122,6 @@ Pattern: `TestBase.CreateClient(handler, observer?, configure?)` builds a real `
 
 ## Docs
 
-`README.md` and `src/Dynamics365.BusinessCentral/README.md` are byte-identical — the latter is the packed NuGet readme. Update both together when public API changes.
+`README.md` and `src/Dynamics365.BusinessCentral/README.md` are identical except for one line: the root file links `MIGRATION.md` relatively, the packed copy uses an absolute GitHub URL because relative links don't resolve on nuget.org. Update both together when public API changes.
+
+`MIGRATION.md` documents the 1.0 → 2.0 move. Add to it whenever a change alters behaviour silently — that file is the only place a silent change is discoverable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,9 @@ CI: `.github/workflows/sonar.yml` builds + tests on net8.0 and runs SonarCloud o
 Everything funnels through `BusinessCentralClient.SendWithAuthRetryAsync`, a single loop with **two independent retry budgets**:
 
 - **auth** — one retry, tracked by `authRetried`. A `401` invalidates the token and retries once.
-- **transient** — `BusinessCentralRetryOptions.MaxAttempts`, tracked by `transientAttempt`. Fires when `exception.IsTransient` (429/408/502/503/504). `ComputeDelay` prefers the server's `Retry-After`, else doubles `BaseDelay`; both capped by `MaxDelay`.
+- **transient** — `BusinessCentralRetryOptions.MaxAttempts`, tracked by `transientAttempt`. Gated by `IsSafeToReplay`, not by `IsTransient` alone. `ComputeDelay` prefers the server's `Retry-After`, else doubles `BaseDelay`; both capped by `MaxDelay`.
+
+`IsSafeToReplay` encodes a deliberate asymmetry: a `429` is rejected *before* processing so it is always replayable, but `408/502/503/504` are ambiguous — the write may already have landed. A `POST` is therefore not replayed on those unless `Retry.RetryPostOnTransientFailures` is set, because a duplicate row is worse than a surfaced error. `GET`/`PUT`/`DELETE` are idempotent and always retried. Don't "simplify" this back to a plain `IsTransient` check.
 
 Each attempt clones the request (`HttpRequestExtensions.Clone`, because a sent `HttpRequestMessage` can't be reused). A failure is reported to the observer exactly once — the throw site sets `failureReported` so the catch-all doesn't double-report.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,234 @@
+# Migrating from 1.0 to 2.0
+
+2.0 fixes several defects and reworks the consumer-facing API. Most existing code keeps
+compiling — the changes that need your attention are mostly **silent behavioural** ones,
+so read that section even if the build is green.
+
+---
+
+## 1. Changes that can break the build
+
+### `IBusinessCentralClient` gained members
+
+New members: `Company`, `ForCompany`, `Query<T>()` (two overloads), `QueryStreamAsync<T>`,
+`GetCompaniesAsync`, and two-generic `PostAsync`/`PatchAsync`/`PutAsync`.
+
+Mocking libraries (Moq, NSubstitute, FakeItEasy) absorb this automatically. **A
+hand-written test fake implementing the interface will not compile** until the new members
+are added.
+
+### Nothing else, in practice
+
+`QueryAsync`, `QueryAllAsync`, `QueryRawAsync`, `PostAsync<T>`, `PatchAsync<T>`,
+`PutAsync<T>`, `DeleteAsync`, `Filter.*` and `.And/.Or/.Not` all keep their signatures.
+Existing single-generic write calls — including `PostAsync<dynamic>(path, payload, ct)` —
+still resolve to the same overload; generic arity disambiguates.
+
+---
+
+## 2. Silent behavioural changes — read this section
+
+### `204 No Content` on a write is now success
+
+| | 1.0 | 2.0 |
+| --- | --- | --- |
+| `POST`/`PATCH`/`PUT` returning 204 | threw `BusinessCentralServerException` | returns successfully |
+
+Writes now send `Prefer: return=representation`, so 204 is less likely. When it does
+happen, the single-generic overloads return **the payload you sent**; the new two-generic
+overloads return **`default`**.
+
+**If you have a `catch` that relied on 204 failing, it will no longer fire.** Conversely,
+code that inspects the returned object may now receive the echoed payload rather than a
+deserialized response:
+
+```csharp
+// This now yields the anonymous payload on 204, not a JsonElement:
+object? raw = await client.PostAsync<dynamic>(path, new { … });
+if (raw is not JsonElement element) { /* now reachable on 204 */ }
+```
+
+The fix is the new overload — see §4.
+
+### `429` is no longer a `BusinessCentralServerException`
+
+Throttling now raises `BusinessCentralThrottledException`. It is a **sibling** of
+`BusinessCentralServerException`, not a subclass, so:
+
+```csharp
+catch (BusinessCentralServerException ex) { … }   // no longer sees 429
+catch (BusinessCentralException ex) { … }          // sees everything
+```
+
+> **Worth auditing while you are here.** This applies to the other subtypes too, and always
+> did: `BusinessCentralServerException` never caught `400`, `401`, `403` or `404` either —
+> those are `Validation`, `Auth`, `Auth` and `NotFound`, all sealed siblings. A guard like
+> `catch (BusinessCentralServerException ex) when (ex.StatusCode == HttpStatusCode.NotFound)`
+> can never match. Catch `BusinessCentralNotFoundException`, or the base type.
+
+### Transient failures are retried automatically
+
+`429`, `408`, `502`, `503` and `504` are now retried (3 attempts by default), honouring
+`Retry-After`. Calls therefore take longer before surfacing a failure, and fewer transient
+errors reach your code.
+
+**Writes are not blindly replayed.** A `429` is rejected before processing so replay is
+always safe; the others are ambiguous, so a `POST` is *not* retried on them:
+
+| Method | `429` | `408`/`502`/`503`/`504` |
+| --- | --- | --- |
+| `GET`, `PUT`, `DELETE` | retried | retried |
+| `POST` | retried | **not** retried |
+
+If you already have an outer retry policy (Polly, Wolverine, a message broker), the two now
+compose multiplicatively. Consider lowering `Retry.MaxAttempts`, or disabling it:
+
+```csharp
+options.Retry.Enabled = false;   // 1.0 behaviour
+```
+
+### `QueryAllAsync` may return more rows than before
+
+It now follows `@odata.nextLink`. Where Business Central applied a server-side page cap
+below the requested `$top`, 1.0 stopped early and silently truncated. Reconciliation logic
+that assumed the old result size should be re-checked.
+
+### `Exception.Message` is now a single line
+
+1.0 baked the status, URL and **entire response body** into `Message`. 2.0 keeps it to one
+line; `ResponseBody`, `RequestUrl`, `ODataErrorCode`, `CorrelationId` and `RetryAfter` are
+properties, and `ToString()` renders everything.
+
+Logging `ex` is unaffected. Code that stores or displays `ex.Message` will see shorter,
+cleaner text.
+
+### Access tokens are shared across injections
+
+1.0 kept the token cache on the client instance, but typed `HttpClient`s are transient — so
+every resolution of `IBusinessCentralClient` triggered a fresh token request. 2.0 moves the
+cache to a singleton. Expect a large drop in calls to your identity provider. No code
+change required.
+
+### Two bugs whose fixes change URLs
+
+- `QueryRawAsync("salesOrders?$top=5")` previously percent-encoded the query string into the
+  path (`salesOrders%3F%24top%3D5`). It now works as documented.
+- Alternate keys such as `No='1000'` were mangled to `No%3D%271000%27`. They now survive.
+
+If you built workarounds for either, remove them.
+
+---
+
+## 3. Renames and deprecated shapes
+
+### `WithTop` vs `WithPageSize`
+
+In `QueryAllAsync`, `WithTop(n)` meant *page size*, not a result limit. `WithPageSize(n)`
+now says that explicitly. `WithTop` still works there (`PageSize ?? Top ?? 1000`), but
+prefer the clearer name.
+
+### Chained ordering
+
+`OrderByAsc(a).OrderByAsc(b)` silently discarded `a` in 1.0. `OrderByAsc`/`OrderByDesc`
+still *replace* the ordering; use `ThenByAsc`/`ThenByDesc` to append:
+
+```csharp
+o.OrderByDesc("amount").ThenByAsc("no")   // $orderby=amount desc,no asc
+```
+
+### Observer
+
+`OnTokenRefreshed` now fires only on a real refresh. Cache hits raise
+`OnTokenServedFromCache`, and retries raise `OnRequestRetrying`. Both are default interface
+methods, so existing observers keep compiling.
+
+---
+
+## 4. Recommended clean-ups
+
+### Replace `dynamic` writes with the two-generic overloads
+
+`PostAsync<T>` forced the request and response to be the same type, which pushed callers
+into `dynamic` plus a runtime type check. Before:
+
+```csharp
+object? raw = await client.PostAsync<dynamic>(path, payload, ct);
+if (raw is not JsonElement element) throw new …;
+if (!TryGetSystemId(element, out var systemId)) throw new …;
+```
+
+After:
+
+```csharp
+var created = await client.PostAsync<object, CreatedRow>(path, payload, ct);
+
+// null means Business Central applied the write but returned no representation.
+if (created is null) throw new …;
+
+var systemId = created.SystemId;
+```
+
+`TResult` is unconstrained, so `JsonElement` still works if you have no model:
+
+```csharp
+var element = await client.PostAsync<object, JsonElement>(path, payload, ct);
+
+// Value types cannot be null — a 204 yields default(JsonElement).
+if (element.ValueKind == JsonValueKind.Undefined) { /* created, not echoed */ }
+```
+
+Failures still throw; an empty result only ever means "created, not echoed".
+
+### Simplify configuration
+
+Only `TenantId`, `ClientId`, `ClientSecret` and `Company` are required. `BaseUrl` and
+`TokenEndpoint` default to the SaaS endpoints and resolve `{tenant}` and `{environment}`:
+
+```csharp
+services.AddBusinessCentral(options =>
+{
+    options.TenantId     = …;
+    options.ClientId     = …;
+    options.ClientSecret = …;
+    options.Company      = "CRONUS AG";
+    options.Environment  = "UAT3";     // instead of a hand-built BaseUrl
+});
+```
+
+Or bind a section directly:
+
+```csharp
+services.AddBusinessCentral(builder.Configuration.GetSection("BusinessCentral"));
+```
+
+> In 1.0 the `{tenant}` placeholder shown in the README was **never substituted in
+> `BaseUrl`** — only `{TenantId}` in `TokenEndpoint` was. If you worked around this by
+> hard-coding the URL, you can now use the placeholder form. Validation rejects any
+> unsubstituted `{…}` that remains.
+
+### Adopt typed queries incrementally
+
+Field-name strings still work. The typed form resolves names through the same
+`JsonSerializerOptions` used for deserialization, so filters cannot drift from the model:
+
+```csharp
+var orders = await client.Query<SalesOrder>()          // path from [BusinessCentralEntity]
+    .Where(Filter.Equals<SalesOrder>(o => o.Status, "Open"))
+    .OrderByDescending(o => o.Amount)
+    .ThenBy(o => o.No)
+    .ToListAsync();
+```
+
+There is no deprecation on the path-based API; migrate at your own pace, or not at all.
+
+---
+
+## 5. Checklist
+
+- [ ] Update hand-written `IBusinessCentralClient` fakes, if any
+- [ ] Audit `catch (BusinessCentralServerException)` — it does not see `400`/`401`/`403`/`404`/`429`
+- [ ] Decide on retry: keep it, tune `MaxAttempts`, or `Retry.Enabled = false`
+- [ ] Re-check any logic that assumed a `204` write failed
+- [ ] Re-check result-size assumptions around `QueryAllAsync`
+- [ ] Replace `dynamic` writes with the two-generic overloads
+- [ ] Optionally simplify configuration and drop hand-built `BaseUrl`

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -78,6 +78,7 @@ always safe; the others are ambiguous, so a `POST` is *not* retried on them:
 | Method | `429` | `408`/`502`/`503`/`504` |
 | --- | --- | --- |
 | `GET`, `PUT`, `DELETE` | retried | retried |
+| `PATCH` | retried | retried — this client sends absolute values, so replay converges |
 | `POST` | retried | **not** retried |
 
 If you already have an outer retry policy (Polly, Wolverine, a message broker), the two now

--- a/README.md
+++ b/README.md
@@ -253,7 +253,13 @@ already have been applied — so:
 | Method | `429` | `408` / `502` / `503` / `504` |
 | ------ | ----- | ----------------------------- |
 | `GET`, `PUT`, `DELETE` | retried | retried (idempotent — replay converges) |
+| `PATCH` | retried | retried (see below) |
 | `POST` | retried | **not** retried; the exception is raised |
+
+`PATCH` is replayed too. RFC 9110 does not guarantee PATCH is idempotent, but this client
+only ever sends a JSON merge of absolute field values, so applying it twice converges on the
+same state. If your payload carries relative operations, disable retries or pass a real
+`If-Match` ETag instead of `*`.
 
 Without this, a `504` on a `POST` could duplicate a record that Business Central had already
 created. If your endpoint deduplicates server-side, or duplicates are acceptable, opt back

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - Clean DI integration
 - No runtime dependencies beyond `HttpClient` and `System.Text.Json`
 
-Upgrading from 1.x? See [MIGRATION.md](MIGRATION.md).
+Upgrading from 1.x? See [MIGRATION.md](MIGRATION.md). Full history in [CHANGELOG.md](CHANGELOG.md).
 
 # 📦 Installation
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,19 @@ services.AddBusinessCentral(options =>
 });
 ```
 
+**Writes are not blindly replayed.** A `429` is rejected before Business Central processes
+it, so replaying is always safe. The other transient statuses are ambiguous — the write may
+already have been applied — so:
+
+| Method | `429` | `408` / `502` / `503` / `504` |
+| ------ | ----- | ----------------------------- |
+| `GET`, `PUT`, `DELETE` | retried | retried (idempotent — replay converges) |
+| `POST` | retried | **not** retried; the exception is raised |
+
+Without this, a `504` on a `POST` could duplicate a record that Business Central had already
+created. If your endpoint deduplicates server-side, or duplicates are acceptable, opt back
+in with `options.Retry.RetryPostOnTransientFailures = true`.
+
 # ⚠️ Errors
 
 All failures derive from `BusinessCentralException`. `Message` is a single line suitable

--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 
 # ✨ Features
 
-- Typed OData querying with fluent filter composition
-- Built-in OAuth2 client credentials authentication
-- Automatic token caching and refresh
-- Fluent paging, ordering and selection helpers
+- Strongly-typed queries — field names come from your entity, not from strings
+- Built-in OAuth2 client credentials authentication, with a shared token cache
+- Automatic retry of throttled (`429`) and transient failures, honouring `Retry-After`
+- Streaming and automatic paging, including server-driven `@odata.nextLink`
+- Filtering, ordering, projection, expansion and counting
+- Multi-company support from a single registration
 - Clean DI integration
-- No runtime dependencies beyond HttpClient and System.Text.Json
+- No runtime dependencies beyond `HttpClient` and `System.Text.Json`
 
 # 📦 Installation
 
@@ -16,111 +18,245 @@
 dotnet add package Dynamics365.BusinessCentral
 ```
 
-# 🧩 Dependency Injection
+# 🧩 Setup
+
+Only four settings are required. `BaseUrl` and `TokenEndpoint` default to the Business
+Central SaaS endpoints and understand the `{tenant}` and `{environment}` placeholders.
 
 ```csharp
 services.AddBusinessCentral(options =>
 {
-    options.TenantId = "your-tenant-id";
-    options.ClientId = "your-client-id";
+    options.TenantId     = "your-tenant-id";
+    options.ClientId     = "your-client-id";
     options.ClientSecret = "your-client-secret";
-    options.Company = "CRONUS AG";
-    options.BaseUrl = "https://api.businesscentral.dynamics.com/v2.0/{tenant}/Production/ODataV4";
-    options.TokenEndpoint = "https://login.microsoftonline.com/{TenantId}/oauth2/v2.0/token";
-    options.Scope = "https://api.businesscentral.dynamics.com/.default";
+    options.Company      = "CRONUS AG";
+
+    // Optional — defaults to "Production"
+    options.Environment  = "Sandbox";
 });
+```
 
-public class MyService
+Or bind from configuration:
+
+```csharp
+services.AddBusinessCentral(builder.Configuration.GetSection("BusinessCentral"));
+```
+
+```json
 {
-    private readonly IBusinessCentralClient _client;
+  "BusinessCentral": {
+    "TenantId": "...",
+    "ClientId": "...",
+    "ClientSecret": "...",
+    "Company": "CRONUS AG",
+    "Environment": "Production",
+    "Retry": { "MaxAttempts": 3 }
+  }
+}
+```
 
-    public MyService(IBusinessCentralClient client)
-    {
-        _client = client;
-    }
+Then inject `IBusinessCentralClient`:
+
+```csharp
+public class MyService(IBusinessCentralClient client)
+{
+    public Task<List<SalesOrder>> GetOpenOrders() =>
+        client.Query<SalesOrder>()
+              .Where(Filter.Equals<SalesOrder>(o => o.Status, "Open"))
+              .ToListAsync();
+}
+```
+
+Point an entity at its OData entity set once, and stop repeating the path:
+
+```csharp
+[BusinessCentralEntity("salesOrders")]
+public sealed class SalesOrder
+{
+    public string No { get; set; } = "";
+    public string Status { get; set; } = "";
+    public decimal Amount { get; set; }
 }
 ```
 
 # 🔍 Querying
 
-Simple Query
+`Query<T>()` is the recommended entry point. Field names come from property selectors, so
+they survive renames and always match how the entity is deserialized.
+
 ```csharp
-var orders = await client.QueryAsync<Order>("salesOrders");
+var orders = await client.Query<SalesOrder>()
+    .Where(Filter.Equals<SalesOrder>(o => o.Status, "Open"))
+    .Where(Filter.GreaterThan<SalesOrder>(o => o.Amount, 100))
+    .OrderByDescending(o => o.Amount)
+    .ThenBy(o => o.No)
+    .Select(o => o.No, o => o.Amount)
+    .Top(50)
+    .ToListAsync();
 ```
 
-With Filters
-```csharp
-var filter =
-    Filter.Equals("Status", "Open")
-          .And(Filter.GreaterThan("Amount", 100));
+| Operation | Method |
+| --------- | ------ |
+| One page | `ToListAsync()` |
+| Everything, auto-paged | `ToAllAsync()` |
+| Everything, lazily | `StreamAsync()` |
+| Page plus total | `ToPageAsync()` |
+| Single row | `FirstOrDefaultAsync()` |
+| Count only | `CountAsync()` |
 
-var orders = await client.QueryAsync<Order>("salesOrders", filter);
+## Streaming
+
+`StreamAsync` fetches pages as you consume them and stops fetching when you stop reading —
+prefer it over `ToAllAsync` for large sets.
+
+```csharp
+await foreach (var order in client.Query<SalesOrder>().PageSize(500).StreamAsync())
+{
+    if (Process(order) is Done) break;   // no further pages are requested
+}
 ```
 
-Paging and Ordering
+## Counting and paging
+
 ```csharp
-var orders = await client.QueryAsync<Order>(
-    "salesOrders",
-    Filter.Equals("Status", "Open"),
-    o => o.WithTop(100).OrderByAsc("No"));
+var page = await client.Query<SalesOrder>().Top(50).ToPageAsync();
+
+Console.WriteLine($"{page.Items.Count} of {page.TotalCount}");
+
+var total = await client.Query<SalesOrder>()
+    .Where(Filter.Equals<SalesOrder>(o => o.Status, "Open"))
+    .CountAsync();
 ```
 
-Query All
+## Expanding
+
 ```csharp
-var allOrders = await client.QueryAllAsync<Order>("salesOrders");
+var orders = await client.Query<SalesOrder>()
+    .Expand(o => o.Lines)
+    .ToListAsync();
+
+// Raw OData expand syntax also works
+var withNested = await client.Query<SalesOrder>()
+    .Expand("salesOrderLines($select=lineNo,amount)")
+    .ToListAsync();
 ```
 
-Raw Query
+## Path-based access
+
+The lower-level API remains available when you do not want an annotated type.
+
 ```csharp
-var raw = await client.QueryRawAsync<JsonElement>("salesOrders?$top=5");
+var orders = await client.QueryAsync<SalesOrder>("salesOrders", Filter.Equals("status", "Open"));
+var all    = await client.QueryAllAsync<SalesOrder>("salesOrders");
+var raw    = await client.QueryRawAsync<JsonElement>("salesOrders?$top=5");
+
+await foreach (var o in client.QueryStreamAsync<SalesOrder>("salesOrders")) { }
 ```
 
-Patch
+# ✏️ Writing
+
 ```csharp
-await client.PatchAsync(
-    "salesOrders",
-    "No='1000'",
-    new { Status = "Released" });
+await client.PostAsync("salesOrders", new SalesOrder { No = "1000" });
+
+await client.PatchAsync("salesOrders", "No='1000'", new { Status = "Released" });
+
+await client.PutAsync("salesOrders", systemId, order, ifMatch: etag);
+
+await client.DeleteAsync("salesOrders", systemId);
+```
+
+Writes send `Prefer: return=representation`. If the server answers `204 No Content`, the
+payload you sent is returned instead of throwing. Keys may be a `systemId` or an alternate
+key such as `No='1000'`.
+
+# 🏢 Multiple companies
+
+One registration serves every company in the tenant. `ForCompany` shares the underlying
+HTTP client and token cache, so it costs nothing.
+
+```csharp
+foreach (var company in await client.GetCompaniesAsync())
+{
+    var scoped = client.ForCompany(company.Name);
+    var orders = await scoped.Query<SalesOrder>().ToAllAsync();
+}
 ```
 
 # 🧪 Filters
 
-| Method                  | Expression                |
-| ----------------------- | ------------------------- |
-| `Filter.Equals`         | `field eq value`          |
-| `Filter.NotEquals`      | `field ne value`          |
-| `Filter.GreaterThan`    | `field gt value`          |
-| `Filter.GreaterOrEqual` | `field ge value`          |
-| `Filter.LessThan`       | `field lt value`          |
-| `Filter.LessOrEqual`    | `field le value`          |
-| `Filter.Contains`       | `contains(field,value)`   |
-| `Filter.StartsWith`     | `startswith(field,value)` |
-| `Filter.EndsWith`       | `endswith(field,value)`   |
-| `Filter.In`             | `field in (...)`          |
-| `Filter.IsNull`         | `field eq null`           |
-| `Filter.IsNotNull`      | `field ne null`           |
+Every method has a string overload and a typed overload.
 
-# Example
+| Method | Expression |
+| ------ | ---------- |
+| `Filter.Equals` | `field eq value` |
+| `Filter.NotEquals` | `field ne value` |
+| `Filter.GreaterThan` | `field gt value` |
+| `Filter.GreaterOrEqual` | `field ge value` |
+| `Filter.LessThan` | `field lt value` |
+| `Filter.LessOrEqual` | `field le value` |
+| `Filter.Contains` | `contains(field,value)` |
+| `Filter.StartsWith` | `startswith(field,value)` |
+| `Filter.EndsWith` | `endswith(field,value)` |
+| `Filter.In` | `field in (...)` |
+| `Filter.IsNull` | `field eq null` |
+| `Filter.IsNotNull` | `field ne null` |
+
+Combine with `.And(...)`, `.Or(...)` and `.Not()`:
+
 ```csharp
-public static class SmokeTestEndpoints
+var filter = Filter.Equals<SalesOrder>(o => o.Status, "Open")
+                   .And(Filter.GreaterThan<SalesOrder>(o => o.Amount, 100));
+```
+
+`Filter.In` with an empty collection yields a filter matching nothing, rather than the
+invalid OData expression `field in ()`.
+
+# ♻️ Throttling and retries
+
+Business Central throttles aggressively. Throttled (`429`) and transient (`408`, `502`,
+`503`, `504`) responses are retried automatically, honouring `Retry-After` when present.
+
+```csharp
+services.AddBusinessCentral(options =>
 {
-    public static void MapSmokeTests(this WebApplication app)
-    {
-        app.MapGet("/bc/orders", async (IBusinessCentralClient client) =>
-        {
-            var orders = await client.QueryAsync<dynamic>(
-                "LDATProductionOrd1er",
-                Filter.Equals("Status", "Released"),
-                o => o.WithTop(5));
+    options.Retry.MaxAttempts = 5;
+    options.Retry.BaseDelay   = TimeSpan.FromSeconds(2);
+    options.Retry.MaxDelay    = TimeSpan.FromSeconds(30);
+    // options.Retry.Enabled  = false;   // surface transient failures immediately
+});
+```
 
-            return Results.Ok(orders);
-        });
+# ⚠️ Errors
 
-        app.MapGet("/bc/orders/all", async (IBusinessCentralClient client) =>
-        {
-            var orders = await client.QueryAllAsync<dynamic>("salesOrders");
-            return Results.Ok(orders.Count);
-        });
-    }
+All failures derive from `BusinessCentralException`. `Message` is a single line suitable
+for logging; the detail lives on properties, and `ToString()` renders everything.
+
+| Type | When |
+| ---- | ---- |
+| `BusinessCentralValidationException` | `400` |
+| `BusinessCentralAuthException` | `401`, `403` |
+| `BusinessCentralNotFoundException` | `404` |
+| `BusinessCentralThrottledException` | `429` |
+| `BusinessCentralServerException` | everything else, and deserialization failures |
+
+```csharp
+catch (BusinessCentralException ex)
+{
+    logger.LogError(ex, "BC call failed: {Code} {CorrelationId}",
+        ex.ODataErrorCode, ex.CorrelationId);
+
+    if (ex.IsTransient) { /* safe to try again */ }
 }
 ```
+
+# 📊 Diagnostics
+
+There is no logging dependency. Implement `IBusinessCentralObserver` to hook requests,
+retries and the token lifecycle:
+
+```csharp
+services.AddObserver<MyObserver>();
+```
+
+Every member except the core request callbacks has a default implementation, so you only
+override what you care about.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 - Clean DI integration
 - No runtime dependencies beyond `HttpClient` and `System.Text.Json`
 
+Upgrading from 1.x? See [MIGRATION.md](MIGRATION.md).
+
 # 📦 Installation
 
 ```bash
@@ -168,6 +170,24 @@ await client.DeleteAsync("salesOrders", systemId);
 Writes send `Prefer: return=representation`. If the server answers `204 No Content`, the
 payload you sent is returned instead of throwing. Keys may be a `systemId` or an alternate
 key such as `No='1000'`.
+
+When the response type differs from the payload — posting an anonymous object and reading
+back an entity — use the two-generic overloads instead of `dynamic`:
+
+```csharp
+var created = await client.PostAsync<object, CreatedRow>(
+    "ldatSummary",
+    new { serialNo = "S1", productionOrderNo = "PO1" });
+
+// null means BC applied the write but returned no representation. Failures throw.
+if (created is null) { /* handle "created but not echoed" */ }
+```
+
+`TResult` is unconstrained, so `JsonElement` works when you have no model:
+
+```csharp
+var element = await client.PostAsync<object, JsonElement>("ldatSummary", payload);
+```
 
 # 🏢 Multiple companies
 

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -6,25 +6,34 @@ using Microsoft.Extensions.Options;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace Dynamics365.BusinessCentral.Client;
 
-public sealed class BusinessCentralClient : IBusinessCentralClient
+/// <summary>
+/// Default <see cref="IBusinessCentralClient"/> implementation.
+/// </summary>
+public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCentralQueryExecutor
 {
     private readonly HttpClient _http;
+    private readonly BusinessCentralOptions _options;
     private readonly BusinessCentralUrlBuilder _urlBuilder;
     private readonly BusinessCentralTokenProvider _tokenProvider;
     private readonly IBusinessCentralObserver _observer;
+    private readonly string _company;
 
     private const string BearerScheme = "Bearer";
 
-    /// <summary>Default page size used by <see cref="QueryAllAsync{TEntity}"/>.</summary>
+    /// <summary>Default page size used when auto-paging.</summary>
     private const int DefaultPageSize = 1000;
 
     private static readonly JsonSerializerOptions _jsonOptions = BusinessCentralJson.Options;
 
+    /// <summary>Creates a client for the company configured in <paramref name="options"/>.</summary>
+    /// <param name="http">HTTP client used for data requests.</param>
+    /// <param name="options">Connection settings.</param>
+    /// <param name="observer">Optional diagnostics observer.</param>
     public BusinessCentralClient(
         HttpClient http,
         IOptions<BusinessCentralOptions> options,
@@ -40,22 +49,77 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         IBusinessCentralObserver? observer)
     {
         _http = http;
-
-        var resolvedOptions = options.Value;
-
+        _options = options.Value;
         _observer = observer ?? new NullBusinessCentralObserver();
+        _company = _options.Company;
 
-        // No mutation of the supplied HttpClient: it may be pooled or shared, and
-        // setting Timeout/DefaultRequestHeaders after first use throws. Per-request
-        // headers are applied in HttpRequestExtensions.AddJsonHeaders instead.
+        // No mutation of the supplied HttpClient: it may be pooled or shared, and setting
+        // Timeout/DefaultRequestHeaders after first use throws. Per-request headers are
+        // applied in HttpRequestExtensions.AddJsonHeaders instead.
         _tokenProvider = tokenProvider ?? new BusinessCentralTokenProvider(http, options, _observer);
 
-        _urlBuilder = new BusinessCentralUrlBuilder(
-            resolvedOptions.BaseUrl,
-            resolvedOptions.Company);
+        _urlBuilder = new BusinessCentralUrlBuilder(_options.ResolvedBaseUrl, _company);
     }
 
+    /// <summary>Copy constructor used by <see cref="ForCompany"/>.</summary>
+    private BusinessCentralClient(BusinessCentralClient source, string company)
+    {
+        _http = source._http;
+        _options = source._options;
+        _observer = source._observer;
+        _tokenProvider = source._tokenProvider;
+        _company = company;
 
+        _urlBuilder = new BusinessCentralUrlBuilder(source._options.ResolvedBaseUrl, company);
+    }
+
+    /// <inheritdoc />
+    public string Company => _company;
+
+    /// <inheritdoc />
+    public IBusinessCentralClient ForCompany(string company)
+    {
+        if (string.IsNullOrWhiteSpace(company))
+            throw new ArgumentException("Company must not be empty.", nameof(company));
+
+        return string.Equals(company, _company, StringComparison.Ordinal)
+            ? this
+            : new BusinessCentralClient(this, company);
+    }
+
+    /// <inheritdoc />
+    public IBusinessCentralQuery<TEntity> Query<TEntity>() =>
+        new BusinessCentralQuery<TEntity>(this, EntityPath.For<TEntity>());
+
+    /// <inheritdoc />
+    public IBusinessCentralQuery<TEntity> Query<TEntity>(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("Path must not be empty.", nameof(path));
+
+        return new BusinessCentralQuery<TEntity>(this, path);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<BusinessCentralCompany>> GetCompaniesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        // The company list lives at the service root, not under Company('...').
+        var url = _urlBuilder.BuildServiceRootUrl("Company");
+
+        var req = CreateJsonRequest(HttpMethod.Get, url);
+
+        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+
+        var wrapper = await DeserializeAsync<ODataResponse<BusinessCentralCompany>>(
+            res,
+            "Failed to deserialize the Business Central company list.",
+            cancellationToken).ConfigureAwait(false);
+
+        return wrapper.Value;
+    }
+
+    /// <inheritdoc />
     public Task<List<TEntity>> QueryAsync<TEntity>(
         string path,
         ODataFilter? filter = null,
@@ -64,6 +128,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         CancellationToken cancellationToken = default)
         => QueryAsync<TEntity>(path, filter?.Value ?? string.Empty, options, select, cancellationToken);
 
+    /// <inheritdoc />
     public async Task<List<TEntity>> QueryAsync<TEntity>(
         string path,
         string filter,
@@ -74,11 +139,13 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         var queryOptions = new QueryOptions();
         options?.Invoke(queryOptions);
 
-        var page = await QueryPageAsync<TEntity>(path, filter, queryOptions, select, cancellationToken);
+        var page = await FetchPageAsync<TEntity>(path, filter, queryOptions, select, cancellationToken)
+            .ConfigureAwait(false);
 
         return page.Value;
     }
 
+    /// <inheritdoc />
     public async Task<TResponse> QueryRawAsync<TResponse>(
         string path,
         CancellationToken cancellationToken = default)
@@ -90,14 +157,15 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
 
         var req = CreateJsonRequest(HttpMethod.Get, url);
 
-        var res = await SendWithAuthRetryAsync(req, cancellationToken);
+        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
 
         return await DeserializeAsync<TResponse>(
             res,
             "Failed to deserialize Business Central response.",
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
     public async Task<List<TEntity>> QueryAllAsync<TEntity>(
         string path,
         ODataFilter? filter = null,
@@ -107,54 +175,107 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
     {
         var all = new List<TEntity>();
 
-        var baseOptions = new QueryOptions();
-        options?.Invoke(baseOptions);
-
-        var pageSize = baseOptions.Top ?? DefaultPageSize;
-        var filterValue = filter?.Value ?? string.Empty;
-        var skip = 0;
-
-        var page = await QueryPageAsync<TEntity>(
-            path, filterValue, BuildPageOptions(baseOptions, pageSize, skip), select, cancellationToken);
-
-        while (true)
+        await foreach (var entity in QueryStreamAsync<TEntity>(path, filter, options, select, cancellationToken)
+                           .ConfigureAwait(false))
         {
-            all.AddRange(page.Value);
-
-            // Server-driven paging wins: when Business Central returns @odata.nextLink
-            // it decides the page size, so a short page is not the end of the collection.
-            if (!string.IsNullOrWhiteSpace(page.NextLink))
-            {
-                page = await QueryNextPageAsync<TEntity>(page.NextLink!, cancellationToken);
-                continue;
-            }
-
-            // No nextLink and a short page means the collection is exhausted.
-            if (page.Value.Count < pageSize)
-                break;
-
-            skip += page.Value.Count;
-
-            page = await QueryPageAsync<TEntity>(
-                path, filterValue, BuildPageOptions(baseOptions, pageSize, skip), select, cancellationToken);
+            all.Add(entity);
         }
 
         return all;
     }
 
-    private static QueryOptions BuildPageOptions(QueryOptions baseOptions, int pageSize, int skip)
+    /// <inheritdoc />
+    public async IAsyncEnumerable<TEntity> QueryStreamAsync<TEntity>(
+        string path,
+        ODataFilter? filter = null,
+        Action<QueryOptions>? options = null,
+        IEnumerable<string>? select = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var options = new QueryOptions()
-            .WithTop(pageSize)
-            .WithSkip(skip);
+        var baseOptions = new QueryOptions();
+        options?.Invoke(baseOptions);
+
+        // Top has historically doubled as the page size here; PageSize now says it plainly
+        // and wins when both are set.
+        var pageSize = baseOptions.PageSize ?? baseOptions.Top ?? DefaultPageSize;
+        var filterValue = filter?.Value ?? string.Empty;
+        var skip = 0;
+
+        var page = await FetchPageAsync<TEntity>(
+                path, filterValue, PageOptions(baseOptions, pageSize, skip), select, cancellationToken)
+            .ConfigureAwait(false);
+
+        var serverDriven = false;
+
+        while (true)
+        {
+            var inPage = 0;
+
+            foreach (var entity in page.Value)
+            {
+                yield return entity;
+                inPage++;
+            }
+
+            // Server-driven paging wins: when Business Central sends @odata.nextLink it
+            // decides the page size, so a short page is not the end of the collection.
+            if (!string.IsNullOrWhiteSpace(page.NextLink))
+            {
+                serverDriven = true;
+
+                page = await FetchNextPageAsync<TEntity>(page.NextLink!, cancellationToken)
+                    .ConfigureAwait(false);
+
+                continue;
+            }
+
+            if (serverDriven)
+                yield break;
+
+            // No nextLink and a short page means the collection is exhausted.
+            if (inPage < pageSize)
+                yield break;
+
+            skip += inPage;
+
+            page = await FetchPageAsync<TEntity>(
+                    path, filterValue, PageOptions(baseOptions, pageSize, skip), select, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static QueryOptions PageOptions(QueryOptions baseOptions, int pageSize, int skip)
+    {
+        var options = new QueryOptions
+        {
+            Top = pageSize,
+            Skip = skip,
+            IncludeCount = baseOptions.IncludeCount
+        };
 
         if (baseOptions.OrderBy != null)
             options.OrderBy = baseOptions.OrderBy;
 
+        if (baseOptions.Expand.Count > 0)
+            options.WithExpand([.. baseOptions.Expand]);
+
         return options;
     }
 
-    private async Task<ODataWrapper<TEntity>> QueryPageAsync<TEntity>(
+    async Task<ODataResponse<TEntity>> IBusinessCentralQueryExecutor.FetchPageAsync<TEntity>(
+        string path,
+        string filter,
+        QueryOptions options,
+        IEnumerable<string>? select,
+        CancellationToken cancellationToken)
+        => await FetchPageAsync<TEntity>(path, filter, options, select, cancellationToken).ConfigureAwait(false);
+
+    async Task<ODataResponse<TEntity>> IBusinessCentralQueryExecutor.FetchNextPageAsync<TEntity>(
+        string absoluteUrl,
+        CancellationToken cancellationToken)
+        => await FetchNextPageAsync<TEntity>(absoluteUrl, cancellationToken).ConfigureAwait(false);
+
+    private async Task<ODataResponse<TEntity>> FetchPageAsync<TEntity>(
         string path,
         string filter,
         QueryOptions options,
@@ -165,26 +286,26 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
 
         var req = CreateJsonRequest(HttpMethod.Get, url);
 
-        var res = await SendWithAuthRetryAsync(req, cancellationToken);
+        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
 
-        return await DeserializeAsync<ODataWrapper<TEntity>>(
+        return await DeserializeAsync<ODataResponse<TEntity>>(
             res,
             "Failed to deserialize Business Central response.",
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<ODataWrapper<TEntity>> QueryNextPageAsync<TEntity>(
+    private async Task<ODataResponse<TEntity>> FetchNextPageAsync<TEntity>(
         string absoluteUrl,
         CancellationToken cancellationToken)
     {
         var req = CreateJsonRequest(HttpMethod.Get, absoluteUrl);
 
-        var res = await SendWithAuthRetryAsync(req, cancellationToken);
+        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
 
-        return await DeserializeAsync<ODataWrapper<TEntity>>(
+        return await DeserializeAsync<ODataResponse<TEntity>>(
             res,
             "Failed to deserialize Business Central response.",
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
     }
 
     private static HttpRequestMessage CreateJsonRequest(HttpMethod method, string url, object? payload = null)
@@ -203,6 +324,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         return req;
     }
 
+    /// <inheritdoc />
     public async Task<T> PatchAsync<T>(
         string path,
         string systemId,
@@ -218,15 +340,13 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
         req.AddReturnRepresentationPreference();
 
-        var res = await SendWithAuthRetryAsync(req, cancellationToken);
+        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
 
         return await ReadEntityOrEchoAsync(
-            res,
-            payload,
-            "Failed to deserialize PATCH response.",
-            cancellationToken);
+            res, payload, "Failed to deserialize PATCH response.", cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
     public async Task<T> PostAsync<T>(
         string path,
         T payload,
@@ -239,15 +359,13 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
 
         req.AddReturnRepresentationPreference();
 
-        var res = await SendWithAuthRetryAsync(req, cancellationToken);
+        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
 
         return await ReadEntityOrEchoAsync(
-            res,
-            payload,
-            "Failed to deserialize POST response.",
-            cancellationToken);
+            res, payload, "Failed to deserialize POST response.", cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
     public async Task<T> PutAsync<T>(
         string path,
         string systemId,
@@ -263,15 +381,13 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
         req.AddReturnRepresentationPreference();
 
-        var res = await SendWithAuthRetryAsync(req, cancellationToken);
+        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
 
         return await ReadEntityOrEchoAsync(
-            res,
-            payload,
-            "Failed to deserialize PUT response.",
-            cancellationToken);
+            res, payload, "Failed to deserialize PUT response.", cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
     public async Task DeleteAsync(
         string path,
         string systemId,
@@ -284,7 +400,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
 
         req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
 
-        var res = await SendWithAuthRetryAsync(req, cancellationToken);
+        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
 
         if (res.StatusCode != HttpStatusCode.NoContent &&
             res.StatusCode != HttpStatusCode.OK)
@@ -316,7 +432,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         if (res.StatusCode == HttpStatusCode.NoContent)
             return payload;
 
-        var json = await res.Content.ReadAsStringAsync(cancellationToken);
+        var json = await res.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(json))
             return payload;
@@ -328,54 +444,60 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         HttpRequestMessage originalRequest,
         CancellationToken cancellationToken)
     {
-        var requestInfo = new BusinessCentralRequestInfo
+        _observer.OnRequestStarting(new BusinessCentralRequestInfo
         {
             Method = originalRequest.Method.Method,
             Url = originalRequest.RequestUri!.ToString()
-        };
+        });
 
-        _observer.OnRequestStarting(requestInfo);
+        var retry = _options.Retry ?? new BusinessCentralRetryOptions();
+        var maxAttempts = retry.Enabled ? Math.Max(1, retry.MaxAttempts) : 1;
 
         // Guards against reporting the same failure twice: once at the throw site and
         // again in the catch-all below.
         var failureReported = false;
 
+        var authRetried = false;
+        var transientAttempt = 0;
+
         try
         {
-            for (var attempt = 0; attempt < 2; attempt++)
+            while (true)
             {
-                var token = await _tokenProvider.GetTokenAsync(cancellationToken);
+                var token = await _tokenProvider.GetTokenAsync(cancellationToken).ConfigureAwait(false);
 
                 var req = originalRequest.Clone();
-                req.Headers.Authorization =
-                    new AuthenticationHeaderValue(BearerScheme, token);
+                req.Headers.Authorization = new AuthenticationHeaderValue(BearerScheme, token);
 
                 var stopwatch = Stopwatch.StartNew();
 
-                var res = await _http.SendAsync(req, cancellationToken);
+                var res = await _http.SendAsync(req, cancellationToken).ConfigureAwait(false);
                 res.RequestMessage ??= req;
 
                 stopwatch.Stop();
 
-                if (res.StatusCode == HttpStatusCode.Unauthorized && attempt == 0)
+                if (res.StatusCode == HttpStatusCode.Unauthorized && !authRetried)
                 {
+                    authRetried = true;
+
                     _observer.OnRequestFailed(new BusinessCentralErrorInfo
                     {
                         Method = req.Method.Method,
                         Url = req.RequestUri!.ToString(),
                         Duration = stopwatch.Elapsed,
                         StatusCode = (int)res.StatusCode,
-                        ResponseBody = await ReadBodySafeAsync(res, cancellationToken),
+                        ResponseBody = await ReadBodySafeAsync(res, cancellationToken).ConfigureAwait(false),
                         Exception = new UnauthorizedAccessException("Unauthorized – retrying with refreshed token")
                     });
 
-                    await _tokenProvider.InvalidateAsync(cancellationToken);
+                    await _tokenProvider.InvalidateAsync(cancellationToken).ConfigureAwait(false);
                     continue;
                 }
 
                 if (!res.IsSuccessStatusCode)
                 {
-                    var failure = await BusinessCentralExceptionFactory.CreateAsync(res, cancellationToken);
+                    var failure = await BusinessCentralExceptionFactory
+                        .CreateAsync(res, cancellationToken).ConfigureAwait(false);
 
                     _observer.OnRequestFailed(new BusinessCentralErrorInfo
                     {
@@ -386,6 +508,29 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
                         ResponseBody = failure.ResponseBody,
                         Exception = failure
                     });
+
+                    if (failure.IsTransient && transientAttempt + 1 < maxAttempts)
+                    {
+                        transientAttempt++;
+
+                        var fromRetryAfter = retry.HonorRetryAfter && failure.RetryAfter != null;
+                        var delay = ComputeDelay(retry, failure.RetryAfter, transientAttempt);
+
+                        _observer.OnRequestRetrying(new BusinessCentralRetryInfo
+                        {
+                            Method = req.Method.Method,
+                            Url = req.RequestUri!.ToString(),
+                            StatusCode = (int)res.StatusCode,
+                            Attempt = transientAttempt,
+                            Delay = delay,
+                            FromRetryAfter = fromRetryAfter
+                        });
+
+                        if (delay > TimeSpan.Zero)
+                            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+
+                        continue;
+                    }
 
                     failureReported = true;
                     throw failure;
@@ -401,8 +546,6 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
 
                 return res;
             }
-
-            throw new InvalidOperationException("Unexpected state in SendWithAuthRetryAsync");
         }
         catch (Exception ex)
         {
@@ -420,13 +563,31 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         }
     }
 
+    /// <summary>
+    /// A server-supplied <c>Retry-After</c> wins over computed backoff; otherwise the delay
+    /// doubles per attempt. Both are capped by <see cref="BusinessCentralRetryOptions.MaxDelay"/>.
+    /// </summary>
+    private static TimeSpan ComputeDelay(
+        BusinessCentralRetryOptions retry,
+        TimeSpan? retryAfter,
+        int attempt)
+    {
+        if (retry.HonorRetryAfter && retryAfter is { } requested)
+            return requested > retry.MaxDelay ? retry.MaxDelay : requested;
+
+        var backoff = TimeSpan.FromMilliseconds(
+            retry.BaseDelay.TotalMilliseconds * Math.Pow(2, attempt - 1));
+
+        return backoff > retry.MaxDelay ? retry.MaxDelay : backoff;
+    }
+
     private static async Task<string?> ReadBodySafeAsync(
         HttpResponseMessage res,
         CancellationToken cancellationToken)
     {
         try
         {
-            return await res.Content.ReadAsStringAsync(cancellationToken);
+            return await res.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         }
         catch
         {
@@ -440,7 +601,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         string errorMessage,
         CancellationToken cancellationToken)
     {
-        var json = await res.Content.ReadAsStringAsync(cancellationToken);
+        var json = await res.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
         return Deserialize<T>(json, res, errorMessage);
     }
@@ -473,14 +634,5 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
                 null,
                 ex);
         }
-    }
-
-    private sealed class ODataWrapper<T>
-    {
-        [JsonPropertyName("value")]
-        public List<T> Value { get; set; } = [];
-
-        [JsonPropertyName("@odata.nextLink")]
-        public string? NextLink { get; set; }
     }
 }

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -195,9 +195,20 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
         var baseOptions = new QueryOptions();
         options?.Invoke(baseOptions);
 
+        // $top=0 is a request for no rows at all.
+        if (baseOptions.Top == 0)
+            yield break;
+
         // Top has historically doubled as the page size here; PageSize now says it plainly
         // and wins when both are set.
         var pageSize = baseOptions.PageSize ?? baseOptions.Top ?? DefaultPageSize;
+
+        // Guards the loop below: with a non-positive page size the "short page" termination
+        // check can never fire, so it would request the same empty page forever. The public
+        // setters reject these values; this covers the internal ones.
+        if (pageSize <= 0)
+            yield break;
+
         var filterValue = filter?.Value ?? string.Empty;
         var skip = 0;
 

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -148,7 +148,6 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     public async Task<TResponse> QueryRawAsync<TResponse>(
         string path,
         CancellationToken cancellationToken = default)
-        where TResponse : class
     {
         // BuildRawUrl (not BuildEntityUrl) so a caller-supplied query string such as
         // "salesOrders?$top=5" survives instead of being percent-encoded into the path.
@@ -753,14 +752,27 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
         TimeSpan? retryAfter,
         int attempt)
     {
+        var max = Floor(retry.MaxDelay);
+
         if (retry.HonorRetryAfter && retryAfter is { } requested)
-            return requested > retry.MaxDelay ? retry.MaxDelay : requested;
+            return Clamp(requested, max);
 
-        var backoff = TimeSpan.FromMilliseconds(
-            retry.BaseDelay.TotalMilliseconds * Math.Pow(2, attempt - 1));
+        var milliseconds = Floor(retry.BaseDelay).TotalMilliseconds * Math.Pow(2, attempt - 1);
 
-        return backoff > retry.MaxDelay ? retry.MaxDelay : backoff;
+        // A large BaseDelay or a high attempt count overflows to a value TimeSpan cannot
+        // represent — or to Infinity — and TimeSpan.FromMilliseconds throws on both. Compare
+        // in double space first so a transient failure never becomes a crash.
+        if (double.IsNaN(milliseconds) || milliseconds >= max.TotalMilliseconds)
+            return max;
+
+        return Clamp(TimeSpan.FromMilliseconds(milliseconds), max);
     }
+
+    private static TimeSpan Floor(TimeSpan value) =>
+        value < TimeSpan.Zero ? TimeSpan.Zero : value;
+
+    private static TimeSpan Clamp(TimeSpan value, TimeSpan max) =>
+        value < TimeSpan.Zero ? TimeSpan.Zero : value > max ? max : value;
 
     private static async Task<string?> ReadBodySafeAsync(
         HttpResponseMessage res,

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -1,8 +1,9 @@
-﻿using Dynamics365.BusinessCentral.Diagnostics;
+using Dynamics365.BusinessCentral.Diagnostics;
 using Dynamics365.BusinessCentral.Errors;
 using Dynamics365.BusinessCentral.OData;
 using Dynamics365.BusinessCentral.Options;
 using Microsoft.Extensions.Options;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -13,14 +14,14 @@ namespace Dynamics365.BusinessCentral.Client;
 public sealed class BusinessCentralClient : IBusinessCentralClient
 {
     private readonly HttpClient _http;
-    private readonly BusinessCentralOptions _options;
     private readonly BusinessCentralUrlBuilder _urlBuilder;
+    private readonly BusinessCentralTokenProvider _tokenProvider;
     private readonly IBusinessCentralObserver _observer;
 
-    private readonly SemaphoreSlim _tokenLock = new(1, 1);
-    private CachedAccessToken? _token;
-
     private const string BearerScheme = "Bearer";
+
+    /// <summary>Default page size used by <see cref="QueryAllAsync{TEntity}"/>.</summary>
+    private const int DefaultPageSize = 1000;
 
     private static readonly JsonSerializerOptions _jsonOptions = BusinessCentralJson.Options;
 
@@ -28,24 +29,30 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         HttpClient http,
         IOptions<BusinessCentralOptions> options,
         IBusinessCentralObserver? observer = null)
+        : this(http, options, null, observer)
+    {
+    }
+
+    internal BusinessCentralClient(
+        HttpClient http,
+        IOptions<BusinessCentralOptions> options,
+        BusinessCentralTokenProvider? tokenProvider,
+        IBusinessCentralObserver? observer)
     {
         _http = http;
-        _options = options.Value;
+
+        var resolvedOptions = options.Value;
 
         _observer = observer ?? new NullBusinessCentralObserver();
 
-        _http.Timeout = TimeSpan.FromSeconds(100);
-
-        _http.DefaultRequestHeaders.Accept.Clear();
-        _http.DefaultRequestHeaders.Accept.Add(
-            new MediaTypeWithQualityHeaderValue("application/json"));
-
-        _http.DefaultRequestHeaders.UserAgent.ParseAdd(
-            "Dynamics365.BusinessCentral.Client/1.0");
+        // No mutation of the supplied HttpClient: it may be pooled or shared, and
+        // setting Timeout/DefaultRequestHeaders after first use throws. Per-request
+        // headers are applied in HttpRequestExtensions.AddJsonHeaders instead.
+        _tokenProvider = tokenProvider ?? new BusinessCentralTokenProvider(http, options, _observer);
 
         _urlBuilder = new BusinessCentralUrlBuilder(
-            _options.BaseUrl,
-            _options.Company);
+            resolvedOptions.BaseUrl,
+            resolvedOptions.Company);
     }
 
 
@@ -67,13 +74,9 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         var queryOptions = new QueryOptions();
         options?.Invoke(queryOptions);
 
-        var res = await SendAsync(path, filter, queryOptions, select, cancellationToken);
-        var wrapper = await DeserializeAsync<ODataWrapper<TEntity>>(
-            res,
-            "Failed to deserialize Business Central response.",
-            cancellationToken);
+        var page = await QueryPageAsync<TEntity>(path, filter, queryOptions, select, cancellationToken);
 
-        return wrapper.Value;
+        return page.Value;
     }
 
     public async Task<TResponse> QueryRawAsync<TResponse>(
@@ -81,11 +84,18 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         CancellationToken cancellationToken = default)
         where TResponse : class
     {
-        var url = _urlBuilder.BuildEntityUrl(path);
+        // BuildRawUrl (not BuildEntityUrl) so a caller-supplied query string such as
+        // "salesOrders?$top=5" survives instead of being percent-encoded into the path.
+        var url = _urlBuilder.BuildRawUrl(path);
 
         var req = CreateJsonRequest(HttpMethod.Get, url);
 
-        return await SendWithRetryAndDeserializeAsync<TResponse>(req, cancellationToken);
+        var res = await SendWithAuthRetryAsync(req, cancellationToken);
+
+        return await DeserializeAsync<TResponse>(
+            res,
+            "Failed to deserialize Business Central response.",
+            cancellationToken);
     }
 
     public async Task<List<TEntity>> QueryAllAsync<TEntity>(
@@ -96,36 +106,85 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         CancellationToken cancellationToken = default)
     {
         var all = new List<TEntity>();
-        var skip = 0;
 
         var baseOptions = new QueryOptions();
         options?.Invoke(baseOptions);
 
-        var pageSize = baseOptions.Top ?? 1000;
+        var pageSize = baseOptions.Top ?? DefaultPageSize;
+        var filterValue = filter?.Value ?? string.Empty;
+        var skip = 0;
+
+        var page = await QueryPageAsync<TEntity>(
+            path, filterValue, BuildPageOptions(baseOptions, pageSize, skip), select, cancellationToken);
 
         while (true)
         {
-            var page = await QueryAsync<TEntity>(
-                path,
-                filter,
-                o =>
-                {
-                    o.WithTop(pageSize).WithSkip(skip);
-                    if (baseOptions.OrderBy != null)
-                        o.OrderBy = baseOptions.OrderBy;
-                },
-                select,
-                cancellationToken);
+            all.AddRange(page.Value);
 
-            all.AddRange(page);
+            // Server-driven paging wins: when Business Central returns @odata.nextLink
+            // it decides the page size, so a short page is not the end of the collection.
+            if (!string.IsNullOrWhiteSpace(page.NextLink))
+            {
+                page = await QueryNextPageAsync<TEntity>(page.NextLink!, cancellationToken);
+                continue;
+            }
 
-            if (page.Count < pageSize)
+            // No nextLink and a short page means the collection is exhausted.
+            if (page.Value.Count < pageSize)
                 break;
 
-            skip += page.Count;
+            skip += page.Value.Count;
+
+            page = await QueryPageAsync<TEntity>(
+                path, filterValue, BuildPageOptions(baseOptions, pageSize, skip), select, cancellationToken);
         }
 
         return all;
+    }
+
+    private static QueryOptions BuildPageOptions(QueryOptions baseOptions, int pageSize, int skip)
+    {
+        var options = new QueryOptions()
+            .WithTop(pageSize)
+            .WithSkip(skip);
+
+        if (baseOptions.OrderBy != null)
+            options.OrderBy = baseOptions.OrderBy;
+
+        return options;
+    }
+
+    private async Task<ODataWrapper<TEntity>> QueryPageAsync<TEntity>(
+        string path,
+        string filter,
+        QueryOptions options,
+        IEnumerable<string>? select,
+        CancellationToken cancellationToken)
+    {
+        var url = _urlBuilder.BuildQueryUrl(path, filter, options, select);
+
+        var req = CreateJsonRequest(HttpMethod.Get, url);
+
+        var res = await SendWithAuthRetryAsync(req, cancellationToken);
+
+        return await DeserializeAsync<ODataWrapper<TEntity>>(
+            res,
+            "Failed to deserialize Business Central response.",
+            cancellationToken);
+    }
+
+    private async Task<ODataWrapper<TEntity>> QueryNextPageAsync<TEntity>(
+        string absoluteUrl,
+        CancellationToken cancellationToken)
+    {
+        var req = CreateJsonRequest(HttpMethod.Get, absoluteUrl);
+
+        var res = await SendWithAuthRetryAsync(req, cancellationToken);
+
+        return await DeserializeAsync<ODataWrapper<TEntity>>(
+            res,
+            "Failed to deserialize Business Central response.",
+            cancellationToken);
     }
 
     private static HttpRequestMessage CreateJsonRequest(HttpMethod method, string url, object? payload = null)
@@ -157,23 +216,13 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         var req = CreateJsonRequest(HttpMethod.Patch, url, payload);
 
         req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+        req.AddReturnRepresentationPreference();
 
         var res = await SendWithAuthRetryAsync(req, cancellationToken);
 
-        if (res.StatusCode == HttpStatusCode.NoContent)
-        {
-            throw new BusinessCentralServerException(
-                "PATCH returned 204 NoContent – no entity was returned.",
-                res.StatusCode,
-                req.Method.Method,
-                req.RequestUri!.ToString(),
-                null,
-                null,
-                null);
-        }
-
-        return await DeserializeAsync<T>(
+        return await ReadEntityOrEchoAsync(
             res,
+            payload,
             "Failed to deserialize PATCH response.",
             cancellationToken);
     }
@@ -188,22 +237,13 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
 
         var req = CreateJsonRequest(HttpMethod.Post, url, payload);
 
+        req.AddReturnRepresentationPreference();
+
         var res = await SendWithAuthRetryAsync(req, cancellationToken);
 
-        if (res.StatusCode == HttpStatusCode.NoContent)
-        {
-            throw new BusinessCentralServerException(
-                "POST returned 204 NoContent – expected created entity.",
-                res.StatusCode,
-                req.Method.Method,
-                req.RequestUri!.ToString(),
-                null,
-                null,
-                null);
-        }
-
-        return await DeserializeAsync<T>(
+        return await ReadEntityOrEchoAsync(
             res,
+            payload,
             "Failed to deserialize POST response.",
             cancellationToken);
     }
@@ -221,23 +261,13 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         var req = CreateJsonRequest(HttpMethod.Put, url, payload);
 
         req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+        req.AddReturnRepresentationPreference();
 
         var res = await SendWithAuthRetryAsync(req, cancellationToken);
 
-        if (res.StatusCode == HttpStatusCode.NoContent)
-        {
-            throw new BusinessCentralServerException(
-                "PUT returned 204 NoContent – expected updated entity.",
-                res.StatusCode,
-                req.Method.Method,
-                req.RequestUri!.ToString(),
-                null,
-                null,
-                null);
-        }
-
-        return await DeserializeAsync<T>(
+        return await ReadEntityOrEchoAsync(
             res,
+            payload,
             "Failed to deserialize PUT response.",
             cancellationToken);
     }
@@ -270,17 +300,28 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         }
     }
 
-    private async Task<T> SendWithRetryAndDeserializeAsync<T>(
-        HttpRequestMessage req,
+    /// <summary>
+    /// Returns the entity Business Central echoed back, or the payload that was sent when
+    /// the server answered 204 NoContent / an empty body. A write that succeeded without a
+    /// representation is still a success — the request asked for one via Prefer, but the
+    /// server is free to decline.
+    /// </summary>
+    private async Task<T> ReadEntityOrEchoAsync<T>(
+        HttpResponseMessage res,
+        T payload,
+        string errorMessage,
         CancellationToken cancellationToken)
         where T : class
     {
-        var res = await SendWithAuthRetryAsync(req, cancellationToken);
+        if (res.StatusCode == HttpStatusCode.NoContent)
+            return payload;
 
-        return await DeserializeAsync<T>(
-            res,
-            "Failed to deserialize Business Central response.",
-            cancellationToken);
+        var json = await res.Content.ReadAsStringAsync(cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(json))
+            return payload;
+
+        return Deserialize<T>(json, res, errorMessage);
     }
 
     private async Task<HttpResponseMessage> SendWithAuthRetryAsync(
@@ -295,17 +336,21 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
 
         _observer.OnRequestStarting(requestInfo);
 
+        // Guards against reporting the same failure twice: once at the throw site and
+        // again in the catch-all below.
+        var failureReported = false;
+
         try
         {
             for (var attempt = 0; attempt < 2; attempt++)
             {
-                var token = await GetTokenAsync(cancellationToken);
+                var token = await _tokenProvider.GetTokenAsync(cancellationToken);
 
                 var req = originalRequest.Clone();
                 req.Headers.Authorization =
                     new AuthenticationHeaderValue(BearerScheme, token);
 
-                var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+                var stopwatch = Stopwatch.StartNew();
 
                 var res = await _http.SendAsync(req, cancellationToken);
                 res.RequestMessage ??= req;
@@ -320,25 +365,30 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
                         Url = req.RequestUri!.ToString(),
                         Duration = stopwatch.Elapsed,
                         StatusCode = (int)res.StatusCode,
+                        ResponseBody = await ReadBodySafeAsync(res, cancellationToken),
                         Exception = new UnauthorizedAccessException("Unauthorized – retrying with refreshed token")
                     });
 
-                    await InvalidateTokenAsync(cancellationToken);
+                    await _tokenProvider.InvalidateAsync(cancellationToken);
                     continue;
                 }
 
                 if (!res.IsSuccessStatusCode)
                 {
+                    var failure = await BusinessCentralExceptionFactory.CreateAsync(res, cancellationToken);
+
                     _observer.OnRequestFailed(new BusinessCentralErrorInfo
                     {
                         Method = req.Method.Method,
                         Url = req.RequestUri!.ToString(),
                         Duration = stopwatch.Elapsed,
                         StatusCode = (int)res.StatusCode,
-                        Exception = new HttpRequestException($"HTTP {(int)res.StatusCode}")
+                        ResponseBody = failure.ResponseBody,
+                        Exception = failure
                     });
 
-                    throw await BusinessCentralExceptionFactory.CreateAsync(res, cancellationToken);
+                    failureReported = true;
+                    throw failure;
                 }
 
                 _observer.OnRequestSucceeded(new BusinessCentralRequestInfo
@@ -356,103 +406,32 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         }
         catch (Exception ex)
         {
-            _observer.OnRequestFailed(new BusinessCentralErrorInfo
+            if (!failureReported)
             {
-                Method = originalRequest.Method.Method,
-                Url = originalRequest.RequestUri!.ToString(),
-                Exception = ex
-            });
+                _observer.OnRequestFailed(new BusinessCentralErrorInfo
+                {
+                    Method = originalRequest.Method.Method,
+                    Url = originalRequest.RequestUri!.ToString(),
+                    Exception = ex
+                });
+            }
 
             throw;
         }
     }
 
-    private async Task<HttpResponseMessage> SendAsync(
-        string path,
-        string filter,
-        QueryOptions options,
-        IEnumerable<string>? select,
+    private static async Task<string?> ReadBodySafeAsync(
+        HttpResponseMessage res,
         CancellationToken cancellationToken)
     {
-        var url = _urlBuilder.BuildQueryUrl(path, filter, options, select);
-
-        var req = CreateJsonRequest(HttpMethod.Get, url);
-
-        return await SendWithAuthRetryAsync(req, cancellationToken);
-    }
-
-    private async Task InvalidateTokenAsync(CancellationToken cancellationToken)
-    {
-        await _tokenLock.WaitAsync(cancellationToken);
-        try { _token = null; }
-        finally { _tokenLock.Release(); }
-    }
-
-    private async Task<string> GetTokenAsync(CancellationToken cancellationToken)
-    {
-        var current = _token;
-        if (current != null && !current.IsExpired)
-        {
-            NotifyTokenRefreshed(current.ExpiresAt, true);
-
-            return current.Token;
-        }
-
-        await _tokenLock.WaitAsync(cancellationToken);
-
         try
         {
-            current = _token;
-            if (current != null && !current.IsExpired)
-            {
-                NotifyTokenRefreshed(current.ExpiresAt, true);
-
-                return current.Token;
-            }
-
-            var endpoint = _options.TokenEndpoint.Replace("{TenantId}", _options.TenantId);
-
-            var form = new Dictionary<string, string>
-            {
-                ["client_id"] = _options.ClientId,
-                ["client_secret"] = _options.ClientSecret,
-                ["scope"] = _options.Scope,
-                ["grant_type"] = "client_credentials"
-            };
-
-            var body = new FormUrlEncodedContent(form);
-
-            _observer.OnTokenRequested();
-
-            var req = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = body };
-            req.AddJsonHeaders();
-
-            var res = await _http.SendAsync(req, cancellationToken);
-            res.RequestMessage ??= req;
-
-            if (!res.IsSuccessStatusCode)
-                throw await BusinessCentralExceptionFactory.CreateAsync(res, cancellationToken);
-
-            var json = await res.Content.ReadAsStringAsync(cancellationToken);
-
-            var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(json, _jsonOptions)
-                                ?? throw new JsonException("Token response was null.");
-
-            var expiresAt = DateTime.UtcNow.AddSeconds(tokenResponse.ExpiresIn - 60);
-
-            _token = new CachedAccessToken
-            {
-                Token = tokenResponse.AccessToken,
-                ExpiresAt = expiresAt
-            };
-
-            NotifyTokenRefreshed(expiresAt, false);
-
-            return _token.Token;
+            return await res.Content.ReadAsStringAsync(cancellationToken);
         }
-        finally
+        catch
         {
-            _tokenLock.Release();
+            // Diagnostics must never mask the original failure.
+            return null;
         }
     }
 
@@ -463,6 +442,11 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
     {
         var json = await res.Content.ReadAsStringAsync(cancellationToken);
 
+        return Deserialize<T>(json, res, errorMessage);
+    }
+
+    private T Deserialize<T>(string json, HttpResponseMessage res, string errorMessage)
+    {
         try
         {
             return JsonSerializer.Deserialize<T>(json, _jsonOptions)
@@ -475,6 +459,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
                 Method = res.RequestMessage!.Method.Method,
                 Url = res.RequestMessage!.RequestUri!.ToString(),
                 StatusCode = (int)res.StatusCode,
+                ResponseBody = json,
                 Exception = ex
             });
 
@@ -490,34 +475,12 @@ public sealed class BusinessCentralClient : IBusinessCentralClient
         }
     }
 
-    private void NotifyTokenRefreshed(DateTime expiresAt, bool fromCache)
-    {
-        _observer.OnTokenRefreshed(new BusinessCentralTokenInfo
-        {
-            ExpiresAt = expiresAt,
-            FromCache = fromCache
-        });
-    }
-
     private sealed class ODataWrapper<T>
     {
         [JsonPropertyName("value")]
         public List<T> Value { get; set; } = [];
-    }
 
-    private sealed class TokenResponse
-    {
-        [JsonPropertyName("access_token")]
-        public string AccessToken { get; set; } = string.Empty;
-
-        [JsonPropertyName("expires_in")]
-        public int ExpiresIn { get; set; }
-    }
-
-    private sealed class CachedAccessToken
-    {
-        public string Token { get; set; } = string.Empty;
-        public DateTime ExpiresAt { get; set; }
-        public bool IsExpired => DateTime.UtcNow >= ExpiresAt;
+        [JsonPropertyName("@odata.nextLink")]
+        public string? NextLink { get; set; }
     }
 }

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -509,7 +509,8 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
                         Exception = failure
                     });
 
-                    if (failure.IsTransient && transientAttempt + 1 < maxAttempts)
+                    if (transientAttempt + 1 < maxAttempts &&
+                        IsSafeToReplay(failure, originalRequest.Method, retry))
                     {
                         transientAttempt++;
 
@@ -561,6 +562,32 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
 
             throw;
         }
+    }
+
+    /// <summary>
+    /// Whether this failure may be retried by replaying the same request.
+    /// </summary>
+    /// <remarks>
+    /// A <c>429</c> was rejected before processing, so replaying is always safe. The other
+    /// transient statuses are ambiguous — the write may already have been applied — so a
+    /// non-idempotent <c>POST</c> is not replayed unless the caller opts in. Idempotent
+    /// methods converge on the same state and are always retried.
+    /// </remarks>
+    private static bool IsSafeToReplay(
+        BusinessCentralException failure,
+        HttpMethod method,
+        BusinessCentralRetryOptions retry)
+    {
+        if (!failure.IsTransient)
+            return false;
+
+        if (failure.StatusCode == HttpStatusCode.TooManyRequests)
+            return true;
+
+        if (method == HttpMethod.Post && !retry.RetryPostOnTransientFailures)
+            return false;
+
+        return true;
     }
 
     /// <summary>

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -107,9 +107,8 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
         // The company list lives at the service root, not under Company('...').
         var url = _urlBuilder.BuildServiceRootUrl("Company");
 
-        var req = CreateJsonRequest(HttpMethod.Get, url);
-
-        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+        using var res = await SendWithAuthRetryAsync(
+            () => CreateJsonRequest(HttpMethod.Get, url), cancellationToken).ConfigureAwait(false);
 
         var wrapper = await DeserializeAsync<ODataResponse<BusinessCentralCompany>>(
             res,
@@ -155,9 +154,8 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
         // "salesOrders?$top=5" survives instead of being percent-encoded into the path.
         var url = _urlBuilder.BuildRawUrl(path);
 
-        var req = CreateJsonRequest(HttpMethod.Get, url);
-
-        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+        using var res = await SendWithAuthRetryAsync(
+            () => CreateJsonRequest(HttpMethod.Get, url), cancellationToken).ConfigureAwait(false);
 
         return await DeserializeAsync<TResponse>(
             res,
@@ -210,7 +208,10 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             yield break;
 
         var filterValue = filter?.Value ?? string.Empty;
-        var skip = 0;
+
+        // Honour a caller-supplied $skip as the starting offset instead of silently
+        // restarting from the first page.
+        var skip = baseOptions.Skip ?? 0;
 
         var page = await FetchPageAsync<TEntity>(
                 path, filterValue, PageOptions(baseOptions, pageSize, skip), select, cancellationToken)
@@ -295,9 +296,8 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     {
         var url = _urlBuilder.BuildQueryUrl(path, filter, options, select);
 
-        var req = CreateJsonRequest(HttpMethod.Get, url);
-
-        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+        using var res = await SendWithAuthRetryAsync(
+            () => CreateJsonRequest(HttpMethod.Get, url), cancellationToken).ConfigureAwait(false);
 
         return await DeserializeAsync<ODataResponse<TEntity>>(
             res,
@@ -309,9 +309,8 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
         string absoluteUrl,
         CancellationToken cancellationToken)
     {
-        var req = CreateJsonRequest(HttpMethod.Get, absoluteUrl);
-
-        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+        using var res = await SendWithAuthRetryAsync(
+            () => CreateJsonRequest(HttpMethod.Get, absoluteUrl), cancellationToken).ConfigureAwait(false);
 
         return await DeserializeAsync<ODataResponse<TEntity>>(
             res,
@@ -346,12 +345,15 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     {
         var url = _urlBuilder.BuildEntityUrl(path, systemId);
 
-        var req = CreateJsonRequest(HttpMethod.Patch, url, payload);
-
-        req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
-        req.AddReturnRepresentationPreference();
-
-        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+        using var res = await SendWithAuthRetryAsync(
+            () =>
+            {
+                var req = CreateJsonRequest(HttpMethod.Patch, url, payload);
+                req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+                req.AddReturnRepresentationPreference();
+                return req;
+            },
+            cancellationToken).ConfigureAwait(false);
 
         return await ReadEntityOrEchoAsync(
             res, payload, "Failed to deserialize PATCH response.", cancellationToken).ConfigureAwait(false);
@@ -366,11 +368,14 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     {
         var url = _urlBuilder.BuildEntityUrl(path);
 
-        var req = CreateJsonRequest(HttpMethod.Post, url, payload);
-
-        req.AddReturnRepresentationPreference();
-
-        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+        using var res = await SendWithAuthRetryAsync(
+            () =>
+            {
+                var req = CreateJsonRequest(HttpMethod.Post, url, payload);
+                req.AddReturnRepresentationPreference();
+                return req;
+            },
+            cancellationToken).ConfigureAwait(false);
 
         return await ReadEntityOrEchoAsync(
             res, payload, "Failed to deserialize POST response.", cancellationToken).ConfigureAwait(false);
@@ -385,11 +390,14 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     {
         var url = _urlBuilder.BuildEntityUrl(path);
 
-        var req = CreateJsonRequest(HttpMethod.Post, url, payload);
-
-        req.AddReturnRepresentationPreference();
-
-        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+        using var res = await SendWithAuthRetryAsync(
+            () =>
+            {
+                var req = CreateJsonRequest(HttpMethod.Post, url, payload);
+                req.AddReturnRepresentationPreference();
+                return req;
+            },
+            cancellationToken).ConfigureAwait(false);
 
         return await ReadEntityOrDefaultAsync<TResult>(
             res, "Failed to deserialize POST response.", cancellationToken).ConfigureAwait(false);
@@ -406,12 +414,15 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     {
         var url = _urlBuilder.BuildEntityUrl(path, systemId);
 
-        var req = CreateJsonRequest(HttpMethod.Patch, url, payload);
-
-        req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
-        req.AddReturnRepresentationPreference();
-
-        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+        using var res = await SendWithAuthRetryAsync(
+            () =>
+            {
+                var req = CreateJsonRequest(HttpMethod.Patch, url, payload);
+                req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+                req.AddReturnRepresentationPreference();
+                return req;
+            },
+            cancellationToken).ConfigureAwait(false);
 
         return await ReadEntityOrDefaultAsync<TResult>(
             res, "Failed to deserialize PATCH response.", cancellationToken).ConfigureAwait(false);
@@ -428,12 +439,15 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     {
         var url = _urlBuilder.BuildEntityUrl(path, systemId);
 
-        var req = CreateJsonRequest(HttpMethod.Put, url, payload);
-
-        req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
-        req.AddReturnRepresentationPreference();
-
-        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+        using var res = await SendWithAuthRetryAsync(
+            () =>
+            {
+                var req = CreateJsonRequest(HttpMethod.Put, url, payload);
+                req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+                req.AddReturnRepresentationPreference();
+                return req;
+            },
+            cancellationToken).ConfigureAwait(false);
 
         return await ReadEntityOrDefaultAsync<TResult>(
             res, "Failed to deserialize PUT response.", cancellationToken).ConfigureAwait(false);
@@ -450,12 +464,15 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     {
         var url = _urlBuilder.BuildEntityUrl(path, systemId);
 
-        var req = CreateJsonRequest(HttpMethod.Put, url, payload);
-
-        req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
-        req.AddReturnRepresentationPreference();
-
-        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+        using var res = await SendWithAuthRetryAsync(
+            () =>
+            {
+                var req = CreateJsonRequest(HttpMethod.Put, url, payload);
+                req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+                req.AddReturnRepresentationPreference();
+                return req;
+            },
+            cancellationToken).ConfigureAwait(false);
 
         return await ReadEntityOrEchoAsync(
             res, payload, "Failed to deserialize PUT response.", cancellationToken).ConfigureAwait(false);
@@ -470,11 +487,14 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     {
         var url = _urlBuilder.BuildEntityUrl(path, systemId);
 
-        var req = CreateJsonRequest(HttpMethod.Delete, url);
-
-        req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
-
-        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+        using var res = await SendWithAuthRetryAsync(
+            () =>
+            {
+                var req = CreateJsonRequest(HttpMethod.Delete, url);
+                req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+                return req;
+            },
+            cancellationToken).ConfigureAwait(false);
 
         if (res.StatusCode != HttpStatusCode.NoContent &&
             res.StatusCode != HttpStatusCode.OK)
@@ -482,8 +502,8 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             throw new BusinessCentralServerException(
                 $"DELETE expected 204 NoContent but got {(int)res.StatusCode}.",
                 res.StatusCode,
-                req.Method.Method,
-                req.RequestUri!.ToString(),
+                HttpMethod.Delete.Method,
+                url,
                 null,
                 null,
                 null);
@@ -536,14 +556,30 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
         return Deserialize<TResult>(json, res, errorMessage);
     }
 
+    /// <summary>
+    /// Sends a request, refreshing the token once on <c>401</c> and replaying transient
+    /// failures according to <see cref="BusinessCentralRetryOptions"/>.
+    /// </summary>
+    /// <param name="createRequest">
+    /// Builds the request. Called once per attempt — <b>not</b> reused — because
+    /// <see cref="HttpClient"/> disposes request content once a send completes, so replaying
+    /// a previously sent instance throws <see cref="ObjectDisposedException"/> for anything
+    /// with a body.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     private async Task<HttpResponseMessage> SendWithAuthRetryAsync(
-        HttpRequestMessage originalRequest,
+        Func<HttpRequestMessage> createRequest,
         CancellationToken cancellationToken)
     {
+        var request = createRequest();
+
+        var method = request.Method;
+        var url = request.RequestUri!.ToString();
+
         _observer.OnRequestStarting(new BusinessCentralRequestInfo
         {
-            Method = originalRequest.Method.Method,
-            Url = originalRequest.RequestUri!.ToString()
+            Method = method.Method,
+            Url = url
         });
 
         var retry = _options.Retry ?? new BusinessCentralRetryOptions();
@@ -562,13 +598,12 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             {
                 var token = await _tokenProvider.GetTokenAsync(cancellationToken).ConfigureAwait(false);
 
-                var req = originalRequest.Clone();
-                req.Headers.Authorization = new AuthenticationHeaderValue(BearerScheme, token);
+                request.Headers.Authorization = new AuthenticationHeaderValue(BearerScheme, token);
 
                 var stopwatch = Stopwatch.StartNew();
 
-                var res = await _http.SendAsync(req, cancellationToken).ConfigureAwait(false);
-                res.RequestMessage ??= req;
+                var res = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                res.RequestMessage ??= request;
 
                 stopwatch.Stop();
 
@@ -578,8 +613,8 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
 
                     _observer.OnRequestFailed(new BusinessCentralErrorInfo
                     {
-                        Method = req.Method.Method,
-                        Url = req.RequestUri!.ToString(),
+                        Method = method.Method,
+                        Url = url,
                         Duration = stopwatch.Elapsed,
                         StatusCode = (int)res.StatusCode,
                         ResponseBody = await ReadBodySafeAsync(res, cancellationToken).ConfigureAwait(false),
@@ -587,6 +622,8 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
                     });
 
                     await _tokenProvider.InvalidateAsync(cancellationToken).ConfigureAwait(false);
+
+                    request = Replace(res, request, createRequest);
                     continue;
                 }
 
@@ -597,8 +634,8 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
 
                     _observer.OnRequestFailed(new BusinessCentralErrorInfo
                     {
-                        Method = req.Method.Method,
-                        Url = req.RequestUri!.ToString(),
+                        Method = method.Method,
+                        Url = url,
                         Duration = stopwatch.Elapsed,
                         StatusCode = (int)res.StatusCode,
                         ResponseBody = failure.ResponseBody,
@@ -606,7 +643,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
                     });
 
                     if (transientAttempt + 1 < maxAttempts &&
-                        IsSafeToReplay(failure, originalRequest.Method, retry))
+                        IsSafeToReplay(failure, method, retry))
                     {
                         transientAttempt++;
 
@@ -615,8 +652,8 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
 
                         _observer.OnRequestRetrying(new BusinessCentralRetryInfo
                         {
-                            Method = req.Method.Method,
-                            Url = req.RequestUri!.ToString(),
+                            Method = method.Method,
+                            Url = url,
                             StatusCode = (int)res.StatusCode,
                             Attempt = transientAttempt,
                             Delay = delay,
@@ -626,21 +663,27 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
                         if (delay > TimeSpan.Zero)
                             await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
 
+                        request = Replace(res, request, createRequest);
                         continue;
                     }
 
                     failureReported = true;
+
+                    res.Dispose();
+                    request.Dispose();
+
                     throw failure;
                 }
 
                 _observer.OnRequestSucceeded(new BusinessCentralRequestInfo
                 {
-                    Method = req.Method.Method,
-                    Url = req.RequestUri!.ToString(),
+                    Method = method.Method,
+                    Url = url,
                     Duration = stopwatch.Elapsed,
                     StatusCode = (int)res.StatusCode
                 });
 
+                // Ownership of the response passes to the caller, which disposes it.
                 return res;
             }
         }
@@ -650,14 +693,29 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             {
                 _observer.OnRequestFailed(new BusinessCentralErrorInfo
                 {
-                    Method = originalRequest.Method.Method,
-                    Url = originalRequest.RequestUri!.ToString(),
+                    Method = method.Method,
+                    Url = url,
                     Exception = ex
                 });
             }
 
             throw;
         }
+    }
+
+    /// <summary>
+    /// Releases an abandoned attempt and builds a fresh request for the next one, so retries
+    /// neither leak responses nor re-send content that has already been disposed.
+    /// </summary>
+    private static HttpRequestMessage Replace(
+        HttpResponseMessage response,
+        HttpRequestMessage request,
+        Func<HttpRequestMessage> createRequest)
+    {
+        response.Dispose();
+        request.Dispose();
+
+        return createRequest();
     }
 
     /// <summary>

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -366,6 +366,69 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     }
 
     /// <inheritdoc />
+    public async Task<TResult?> PostAsync<TPayload, TResult>(
+        string path,
+        TPayload payload,
+        CancellationToken cancellationToken = default)
+        where TPayload : class
+    {
+        var url = _urlBuilder.BuildEntityUrl(path);
+
+        var req = CreateJsonRequest(HttpMethod.Post, url, payload);
+
+        req.AddReturnRepresentationPreference();
+
+        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+
+        return await ReadEntityOrDefaultAsync<TResult>(
+            res, "Failed to deserialize POST response.", cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<TResult?> PatchAsync<TPayload, TResult>(
+        string path,
+        string systemId,
+        TPayload payload,
+        string ifMatch = "*",
+        CancellationToken cancellationToken = default)
+        where TPayload : class
+    {
+        var url = _urlBuilder.BuildEntityUrl(path, systemId);
+
+        var req = CreateJsonRequest(HttpMethod.Patch, url, payload);
+
+        req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+        req.AddReturnRepresentationPreference();
+
+        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+
+        return await ReadEntityOrDefaultAsync<TResult>(
+            res, "Failed to deserialize PATCH response.", cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<TResult?> PutAsync<TPayload, TResult>(
+        string path,
+        string systemId,
+        TPayload payload,
+        string ifMatch = "*",
+        CancellationToken cancellationToken = default)
+        where TPayload : class
+    {
+        var url = _urlBuilder.BuildEntityUrl(path, systemId);
+
+        var req = CreateJsonRequest(HttpMethod.Put, url, payload);
+
+        req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+        req.AddReturnRepresentationPreference();
+
+        var res = await SendWithAuthRetryAsync(req, cancellationToken).ConfigureAwait(false);
+
+        return await ReadEntityOrDefaultAsync<TResult>(
+            res, "Failed to deserialize PUT response.", cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
     public async Task<T> PutAsync<T>(
         string path,
         string systemId,
@@ -438,6 +501,28 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             return payload;
 
         return Deserialize<T>(json, res, errorMessage);
+    }
+
+    /// <summary>
+    /// Response reader for the two-generic write overloads, where the payload cannot stand
+    /// in for the result. A 204 NoContent or empty body yields <see langword="default"/>,
+    /// which is how the caller learns the server applied the write without returning a
+    /// representation.
+    /// </summary>
+    private async Task<TResult?> ReadEntityOrDefaultAsync<TResult>(
+        HttpResponseMessage res,
+        string errorMessage,
+        CancellationToken cancellationToken)
+    {
+        if (res.StatusCode == HttpStatusCode.NoContent)
+            return default;
+
+        var json = await res.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(json))
+            return default;
+
+        return Deserialize<TResult>(json, res, errorMessage);
     }
 
     private async Task<HttpResponseMessage> SendWithAuthRetryAsync(

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -659,10 +659,16 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
                             FromRetryAfter = fromRetryAfter
                         });
 
+                        // Release the failed attempt before sleeping. Under throttling the
+                        // backoff window is exactly when buffered responses would otherwise
+                        // pile up across concurrent callers.
+                        res.Dispose();
+                        request.Dispose();
+
                         if (delay > TimeSpan.Zero)
                             await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
 
-                        request = Replace(res, request, createRequest);
+                        request = createRequest();
                         continue;
                     }
 
@@ -721,10 +727,25 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     /// Whether this failure may be retried by replaying the same request.
     /// </summary>
     /// <remarks>
-    /// A <c>429</c> was rejected before processing, so replaying is always safe. The other
-    /// transient statuses are ambiguous — the write may already have been applied — so a
-    /// non-idempotent <c>POST</c> is not replayed unless the caller opts in. Idempotent
-    /// methods converge on the same state and are always retried.
+    /// <para>
+    /// A <c>429</c> was rejected before processing, so replaying is always safe regardless
+    /// of method. The other transient statuses are ambiguous — the write may already have
+    /// been applied — so the method decides.
+    /// </para>
+    /// <para>
+    /// <c>GET</c>, <c>PUT</c> and <c>DELETE</c> are idempotent by HTTP semantics and always
+    /// replayed. <c>POST</c> is not, and creates a duplicate record if replayed after a write
+    /// that actually landed, so it is held back unless
+    /// <see cref="BusinessCentralRetryOptions.RetryPostOnTransientFailures"/> is set.
+    /// </para>
+    /// <para>
+    /// <c>PATCH</c> is <b>replayed</b>, which is a deliberate deviation from RFC 9110 — that
+    /// spec does not guarantee PATCH is idempotent. It is safe here because this client only
+    /// ever sends a JSON merge of absolute field values, so applying it twice converges on
+    /// the same state rather than compounding. A <c>PATCH</c> body containing relative
+    /// operations would break that assumption; disable retries or pass a real
+    /// <c>If-Match</c> ETag instead of <c>*</c> if you need one.
+    /// </para>
     /// </remarks>
     private static bool IsSafeToReplay(
         BusinessCentralException failure,

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -499,7 +499,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             res.StatusCode != HttpStatusCode.OK)
         {
             throw new BusinessCentralServerException(
-                $"DELETE expected 204 NoContent but got {(int)res.StatusCode}.",
+                $"DELETE expected 200 OK or 204 NoContent but got {(int)res.StatusCode}.",
                 res.StatusCode,
                 HttpMethod.Delete.Method,
                 url,

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
@@ -88,8 +88,7 @@ internal sealed class BusinessCentralTokenProvider : IDisposable
             var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(json, _jsonOptions)
                                 ?? throw new JsonException("Token response was null.");
 
-            var expiresAt = DateTime.UtcNow.AddSeconds(
-                tokenResponse.ExpiresIn - ExpirySafetyMarginSeconds);
+            var expiresAt = DateTime.UtcNow + CacheLifetime(tokenResponse.ExpiresIn);
 
             _token = new CachedAccessToken
             {
@@ -116,6 +115,29 @@ internal sealed class BusinessCentralTokenProvider : IDisposable
         await _tokenLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try { _token = null; }
         finally { _tokenLock.Release(); }
+    }
+
+    /// <summary>
+    /// How long a freshly issued token may be cached: its advertised lifetime less a safety
+    /// margin, so it is never used right at the edge of expiry.
+    /// </summary>
+    /// <remarks>
+    /// Subtracting a fixed margin would put the expiry in the past for any token whose
+    /// lifetime is shorter than the margin, marking it expired on arrival and forcing a
+    /// fresh request on every single call. For those, half the lifetime is used instead.
+    /// </remarks>
+    internal static TimeSpan CacheLifetime(int expiresInSeconds)
+    {
+        if (expiresInSeconds <= 0)
+            return TimeSpan.Zero;
+
+        var lifetime = TimeSpan.FromSeconds(expiresInSeconds);
+        var margin = TimeSpan.FromSeconds(ExpirySafetyMarginSeconds);
+
+        if (margin >= lifetime)
+            margin = TimeSpan.FromTicks(lifetime.Ticks / 2);
+
+        return lifetime - margin;
     }
 
     private void NotifyServedFromCache(DateTime expiresAt)

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
@@ -1,0 +1,147 @@
+using Dynamics365.BusinessCentral.Diagnostics;
+using Dynamics365.BusinessCentral.Errors;
+using Dynamics365.BusinessCentral.Options;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Dynamics365.BusinessCentral.Client;
+
+/// <summary>
+/// Acquires and caches the OAuth2 client-credentials access token.
+/// <para>
+/// This is registered as a <b>singleton</b> so the cache is shared by every
+/// <see cref="BusinessCentralClient"/> instance. Typed HTTP clients are transient,
+/// so keeping the cache on the client itself would mean a fresh token request for
+/// every injection.
+/// </para>
+/// </summary>
+internal sealed class BusinessCentralTokenProvider : IDisposable
+{
+    private readonly HttpClient _http;
+    private readonly BusinessCentralOptions _options;
+    private readonly IBusinessCentralObserver _observer;
+
+    private readonly SemaphoreSlim _tokenLock = new(1, 1);
+    private CachedAccessToken? _token;
+
+    /// <summary>Subtracted from the advertised lifetime so a token is never used at the edge of expiry.</summary>
+    private const int ExpirySafetyMarginSeconds = 60;
+
+    private static readonly JsonSerializerOptions _jsonOptions = BusinessCentralJson.Options;
+
+    public BusinessCentralTokenProvider(
+        HttpClient http,
+        IOptions<BusinessCentralOptions> options,
+        IBusinessCentralObserver? observer = null)
+    {
+        _http = http;
+        _options = options.Value;
+        _observer = observer ?? new NullBusinessCentralObserver();
+    }
+
+    public async Task<string> GetTokenAsync(CancellationToken cancellationToken)
+    {
+        var current = _token;
+        if (current is { IsExpired: false })
+        {
+            NotifyServedFromCache(current.ExpiresAt);
+            return current.Token;
+        }
+
+        await _tokenLock.WaitAsync(cancellationToken);
+
+        try
+        {
+            current = _token;
+            if (current is { IsExpired: false })
+            {
+                NotifyServedFromCache(current.ExpiresAt);
+                return current.Token;
+            }
+
+            var endpoint = _options.TokenEndpoint.Replace("{TenantId}", _options.TenantId);
+
+            var form = new Dictionary<string, string>
+            {
+                ["client_id"] = _options.ClientId,
+                ["client_secret"] = _options.ClientSecret,
+                ["scope"] = _options.Scope,
+                ["grant_type"] = "client_credentials"
+            };
+
+            var body = new FormUrlEncodedContent(form);
+
+            _observer.OnTokenRequested();
+
+            var req = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = body };
+            req.AddJsonHeaders();
+
+            var res = await _http.SendAsync(req, cancellationToken);
+            res.RequestMessage ??= req;
+
+            if (!res.IsSuccessStatusCode)
+                throw await BusinessCentralExceptionFactory.CreateAsync(res, cancellationToken);
+
+            var json = await res.Content.ReadAsStringAsync(cancellationToken);
+
+            var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(json, _jsonOptions)
+                                ?? throw new JsonException("Token response was null.");
+
+            var expiresAt = DateTime.UtcNow.AddSeconds(
+                tokenResponse.ExpiresIn - ExpirySafetyMarginSeconds);
+
+            _token = new CachedAccessToken
+            {
+                Token = tokenResponse.AccessToken,
+                ExpiresAt = expiresAt
+            };
+
+            _observer.OnTokenRefreshed(new BusinessCentralTokenInfo
+            {
+                ExpiresAt = expiresAt,
+                FromCache = false
+            });
+
+            return _token.Token;
+        }
+        finally
+        {
+            _tokenLock.Release();
+        }
+    }
+
+    public async Task InvalidateAsync(CancellationToken cancellationToken)
+    {
+        await _tokenLock.WaitAsync(cancellationToken);
+        try { _token = null; }
+        finally { _tokenLock.Release(); }
+    }
+
+    private void NotifyServedFromCache(DateTime expiresAt)
+    {
+        _observer.OnTokenServedFromCache(new BusinessCentralTokenInfo
+        {
+            ExpiresAt = expiresAt,
+            FromCache = true
+        });
+    }
+
+    public void Dispose() => _tokenLock.Dispose();
+
+    private sealed class TokenResponse
+    {
+        [JsonPropertyName("access_token")]
+        public string AccessToken { get; set; } = string.Empty;
+
+        [JsonPropertyName("expires_in")]
+        public int ExpiresIn { get; set; }
+    }
+
+    private sealed class CachedAccessToken
+    {
+        public string Token { get; set; } = string.Empty;
+        public DateTime ExpiresAt { get; set; }
+        public bool IsExpired => DateTime.UtcNow >= ExpiresAt;
+    }
+}

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
@@ -49,7 +49,7 @@ internal sealed class BusinessCentralTokenProvider : IDisposable
             return current.Token;
         }
 
-        await _tokenLock.WaitAsync(cancellationToken);
+        await _tokenLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {
@@ -60,7 +60,7 @@ internal sealed class BusinessCentralTokenProvider : IDisposable
                 return current.Token;
             }
 
-            var endpoint = _options.TokenEndpoint.Replace("{TenantId}", _options.TenantId);
+            var endpoint = _options.ResolvedTokenEndpoint;
 
             var form = new Dictionary<string, string>
             {
@@ -77,13 +77,13 @@ internal sealed class BusinessCentralTokenProvider : IDisposable
             var req = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = body };
             req.AddJsonHeaders();
 
-            var res = await _http.SendAsync(req, cancellationToken);
+            var res = await _http.SendAsync(req, cancellationToken).ConfigureAwait(false);
             res.RequestMessage ??= req;
 
             if (!res.IsSuccessStatusCode)
-                throw await BusinessCentralExceptionFactory.CreateAsync(res, cancellationToken);
+                throw await BusinessCentralExceptionFactory.CreateAsync(res, cancellationToken).ConfigureAwait(false);
 
-            var json = await res.Content.ReadAsStringAsync(cancellationToken);
+            var json = await res.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
             var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(json, _jsonOptions)
                                 ?? throw new JsonException("Token response was null.");
@@ -113,7 +113,7 @@ internal sealed class BusinessCentralTokenProvider : IDisposable
 
     public async Task InvalidateAsync(CancellationToken cancellationToken)
     {
-        await _tokenLock.WaitAsync(cancellationToken);
+        await _tokenLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try { _token = null; }
         finally { _tokenLock.Release(); }
     }

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
@@ -74,10 +74,13 @@ internal sealed class BusinessCentralTokenProvider : IDisposable
 
             _observer.OnTokenRequested();
 
-            var req = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = body };
+            // Both are fully consumed here — nothing escapes this method — so they can be
+            // scoped. Disposing the request also releases the FormUrlEncodedContent, which
+            // carries the client secret.
+            using var req = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = body };
             req.AddJsonHeaders();
 
-            var res = await _http.SendAsync(req, cancellationToken).ConfigureAwait(false);
+            using var res = await _http.SendAsync(req, cancellationToken).ConfigureAwait(false);
             res.RequestMessage ??= req;
 
             if (!res.IsSuccessStatusCode)

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralUrlBuilder.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralUrlBuilder.cs
@@ -1,4 +1,5 @@
-﻿using Dynamics365.BusinessCentral.OData;
+using Dynamics365.BusinessCentral.OData;
+using System.Text;
 
 namespace Dynamics365.BusinessCentral.Client;
 
@@ -15,12 +16,30 @@ internal sealed class BusinessCentralUrlBuilder
 
     public string BuildEntityUrl(string path)
     {
-        return $"{BuildCompanyBase()}/{Encode(path)}";
+        return $"{BuildCompanyBase()}/{EncodePath(path)}";
     }
 
     public string BuildEntityUrl(string path, string key)
     {
-        return $"{BuildCompanyBase()}/{Encode(path)}({Encode(key)})";
+        return $"{BuildCompanyBase()}/{EncodePath(path)}({EncodeKey(key)})";
+    }
+
+    /// <summary>
+    /// Builds a URL from a caller-supplied relative OData URL that may already carry
+    /// its own query string. Path segments are encoded individually; everything after
+    /// the first '?' is passed through verbatim because the caller owns it.
+    /// </summary>
+    public string BuildRawUrl(string path)
+    {
+        var split = path.IndexOf('?');
+
+        if (split < 0)
+            return BuildEntityUrl(path);
+
+        var pathPart = path[..split];
+        var queryPart = path[(split + 1)..];
+
+        return $"{BuildCompanyBase()}/{EncodePath(pathPart)}?{queryPart}";
     }
 
     public string BuildQueryUrl(
@@ -84,8 +103,63 @@ internal sealed class BusinessCentralUrlBuilder
         return $"{_baseUrl}/Company('{encodedCompany}')";
     }
 
-    private static string Encode(string value)
+    /// <summary>
+    /// Encodes each path segment separately so '/' keeps its meaning as a segment
+    /// separator (navigation properties, nested paths) while spaces and other unsafe
+    /// characters are still escaped.
+    /// </summary>
+    private static string EncodePath(string path)
     {
-        return Uri.EscapeDataString(value);
+        if (string.IsNullOrEmpty(path))
+            return path;
+
+        var segments = path.Split('/');
+
+        for (var i = 0; i < segments.Length; i++)
+            segments[i] = Uri.EscapeDataString(segments[i]);
+
+        return string.Join("/", segments);
     }
+
+    /// <summary>
+    /// Encodes an OData entity key. Unlike <see cref="Uri.EscapeDataString"/> this keeps
+    /// the characters that make up OData key syntax — quotes, '=', ',' and parentheses —
+    /// so alternate keys such as <c>No='1000'</c> survive intact, while spaces and other
+    /// unsafe characters are still percent-encoded.
+    /// </summary>
+    private static string EncodeKey(string key)
+    {
+        if (string.IsNullOrEmpty(key))
+            return key;
+
+        var result = new StringBuilder(key.Length);
+        var i = 0;
+
+        while (i < key.Length)
+        {
+            if (IsKeySafe(key[i]))
+            {
+                result.Append(key[i]);
+                i++;
+                continue;
+            }
+
+            // Escape a whole run at once so surrogate pairs are never split
+            // across two EscapeDataString calls.
+            var start = i;
+            while (i < key.Length && !IsKeySafe(key[i]))
+                i++;
+
+            result.Append(Uri.EscapeDataString(key[start..i]));
+        }
+
+        return result.ToString();
+    }
+
+    private static bool IsKeySafe(char c) =>
+        c is >= 'A' and <= 'Z' ||
+        c is >= 'a' and <= 'z' ||
+        c is >= '0' and <= '9' ||
+        c is '-' or '.' or '_' or '~' ||
+        c is '\'' or '=' or ',' or '(' or ')';
 }

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralUrlBuilder.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralUrlBuilder.cs
@@ -25,6 +25,15 @@ internal sealed class BusinessCentralUrlBuilder
     }
 
     /// <summary>
+    /// Builds a URL against the service root, i.e. without the <c>Company('...')</c>
+    /// segment. Used for tenant-level entity sets such as the company list itself.
+    /// </summary>
+    public string BuildServiceRootUrl(string path)
+    {
+        return $"{_baseUrl}/{EncodePath(path)}";
+    }
+
+    /// <summary>
     /// Builds a URL from a caller-supplied relative OData URL that may already carry
     /// its own query string. Path segments are encoded individually; everything after
     /// the first '?' is passed through verbatim because the caller owns it.
@@ -89,6 +98,19 @@ internal sealed class BusinessCentralUrlBuilder
             query.Add("$orderby=" + Uri.EscapeDataString(options.OrderBy));
         }
 
+        // Expand — joined verbatim so nested syntax such as
+        // "salesOrderLines($select=lineNo)" survives.
+        if (options.Expand.Count > 0)
+        {
+            query.Add("$expand=" + string.Join(",", options.Expand).Replace(" ", "%20"));
+        }
+
+        // Count
+        if (options.IncludeCount)
+        {
+            query.Add("$count=true");
+        }
+
         if (query.Count > 0)
         {
             url += "?" + string.Join("&", query);
@@ -122,7 +144,7 @@ internal sealed class BusinessCentralUrlBuilder
     }
 
     /// <summary>
-    /// Encodes an OData entity key. Unlike <see cref="Uri.EscapeDataString"/> this keeps
+    /// Encodes an OData entity key. Unlike <see cref="Uri.EscapeDataString(string)"/> this keeps
     /// the characters that make up OData key syntax — quotes, '=', ',' and parentheses —
     /// so alternate keys such as <c>No='1000'</c> survive intact, while spaces and other
     /// unsafe characters are still percent-encoded.

--- a/src/Dynamics365.BusinessCentral/Client/HttpRequestExtensions.cs
+++ b/src/Dynamics365.BusinessCentral/Client/HttpRequestExtensions.cs
@@ -14,24 +14,6 @@ internal static class HttpRequestExtensions
     private static string ClientVersion() =>
         typeof(HttpRequestExtensions).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
 
-    public static HttpRequestMessage Clone(this HttpRequestMessage original)
-    {
-        var clone = new HttpRequestMessage(original.Method, original.RequestUri)
-        {
-            Version = original.Version
-        };
-
-        foreach (var header in original.Headers)
-            clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
-
-        // Shared by reference: every payload this client sends is a buffered
-        // ByteArrayContent/StringContent, which can be re-sent on the 401 retry.
-        if (original.Content != null)
-            clone.Content = original.Content;
-
-        return clone;
-    }
-
     public static void AddJsonHeaders(this HttpRequestMessage request)
     {
         request.Headers.Accept.Clear();

--- a/src/Dynamics365.BusinessCentral/Client/HttpRequestExtensions.cs
+++ b/src/Dynamics365.BusinessCentral/Client/HttpRequestExtensions.cs
@@ -1,16 +1,23 @@
-﻿using System.Net.Http.Headers;
+using System.Net.Http.Headers;
 
 namespace Dynamics365.BusinessCentral.Client;
 
 internal static class HttpRequestExtensions
 {
+    private const string UserAgent = "Dynamics365.BusinessCentral.Client/1.0";
+
     public static HttpRequestMessage Clone(this HttpRequestMessage original)
     {
-        var clone = new HttpRequestMessage(original.Method, original.RequestUri);
+        var clone = new HttpRequestMessage(original.Method, original.RequestUri)
+        {
+            Version = original.Version
+        };
 
         foreach (var header in original.Headers)
             clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
 
+        // Shared by reference: every payload this client sends is a buffered
+        // ByteArrayContent/StringContent, which can be re-sent on the 401 retry.
         if (original.Content != null)
             clone.Content = original.Content;
 
@@ -22,5 +29,17 @@ internal static class HttpRequestExtensions
         request.Headers.Accept.Clear();
         request.Headers.Accept.Add(
             new MediaTypeWithQualityHeaderValue("application/json"));
+
+        if (!request.Headers.UserAgent.Any())
+            request.Headers.UserAgent.ParseAdd(UserAgent);
+    }
+
+    /// <summary>
+    /// Asks Business Central to return the affected entity in the response body so a
+    /// write does not come back as a bare 204 NoContent.
+    /// </summary>
+    public static void AddReturnRepresentationPreference(this HttpRequestMessage request)
+    {
+        request.Headers.TryAddWithoutValidation("Prefer", "return=representation");
     }
 }

--- a/src/Dynamics365.BusinessCentral/Client/HttpRequestExtensions.cs
+++ b/src/Dynamics365.BusinessCentral/Client/HttpRequestExtensions.cs
@@ -4,7 +4,15 @@ namespace Dynamics365.BusinessCentral.Client;
 
 internal static class HttpRequestExtensions
 {
-    private const string UserAgent = "Dynamics365.BusinessCentral.Client/1.0";
+    /// <summary>
+    /// Derived from the assembly version rather than hard-coded, so outbound requests always
+    /// identify the library version actually in use.
+    /// </summary>
+    private static readonly string UserAgent =
+        $"Dynamics365.BusinessCentral.Client/{ClientVersion()}";
+
+    private static string ClientVersion() =>
+        typeof(HttpRequestExtensions).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
 
     public static HttpRequestMessage Clone(this HttpRequestMessage original)
     {

--- a/src/Dynamics365.BusinessCentral/Client/IBusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/IBusinessCentralClient.cs
@@ -158,6 +158,79 @@ public interface IBusinessCentralClient
         where T : class;
 
     /// <summary>
+    /// Creates an entity, deserializing the response into a type different from the payload.
+    /// </summary>
+    /// <remarks>
+    /// Use this when you post an anonymous object or DTO but want a typed response back —
+    /// the single-generic <see cref="PostAsync{T}"/> forces both to be the same type.
+    /// </remarks>
+    /// <typeparam name="TPayload">Type sent in the request body.</typeparam>
+    /// <typeparam name="TResult">Type to deserialize the response into.</typeparam>
+    /// <param name="path">Relative OData entity path where the entity should be created.</param>
+    /// <param name="payload">Object to serialize and send as the POST body.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The created entity, or <see langword="default"/> when Business Central applied the
+    /// write but returned no representation (<c>204 No Content</c> or an empty body). That
+    /// means "created, but not echoed back" — not "failed"; failures throw.
+    /// <para>
+    /// For a reference <typeparamref name="TResult"/> this is <see langword="null"/>. For a
+    /// value type it is <c>default</c> — notably <c>default(JsonElement)</c>, whose
+    /// <c>ValueKind</c> is <c>Undefined</c>; check that rather than comparing to null.
+    /// </para>
+    /// </returns>
+    Task<TResult?> PostAsync<TPayload, TResult>(
+        string path,
+        TPayload payload,
+        CancellationToken cancellationToken = default)
+        where TPayload : class;
+
+    /// <summary>
+    /// Partially updates an entity, deserializing the response into a type different from
+    /// the payload.
+    /// </summary>
+    /// <typeparam name="TPayload">Type sent in the request body.</typeparam>
+    /// <typeparam name="TResult">Type to deserialize the response into.</typeparam>
+    /// <param name="path">Relative OData entity path.</param>
+    /// <param name="systemId">Entity key: a systemId, or an alternate key such as <c>No='1000'</c>.</param>
+    /// <param name="payload">Object to serialize and send as the PATCH body.</param>
+    /// <param name="ifMatch">ETag value for optimistic concurrency control (default "*").</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The updated entity, or <see langword="default"/> when the server returned no
+    /// representation. Failures throw.
+    /// </returns>
+    Task<TResult?> PatchAsync<TPayload, TResult>(
+        string path,
+        string systemId,
+        TPayload payload,
+        string ifMatch = "*",
+        CancellationToken cancellationToken = default)
+        where TPayload : class;
+
+    /// <summary>
+    /// Replaces an entity, deserializing the response into a type different from the payload.
+    /// </summary>
+    /// <typeparam name="TPayload">Type sent in the request body.</typeparam>
+    /// <typeparam name="TResult">Type to deserialize the response into.</typeparam>
+    /// <param name="path">Relative OData entity path.</param>
+    /// <param name="systemId">Entity key: a systemId, or an alternate key such as <c>No='1000'</c>.</param>
+    /// <param name="payload">Object to serialize and send as the PUT body.</param>
+    /// <param name="ifMatch">ETag value for optimistic concurrency control (default "*").</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The updated entity, or <see langword="default"/> when the server returned no
+    /// representation. Failures throw.
+    /// </returns>
+    Task<TResult?> PutAsync<TPayload, TResult>(
+        string path,
+        string systemId,
+        TPayload payload,
+        string ifMatch = "*",
+        CancellationToken cancellationToken = default)
+        where TPayload : class;
+
+    /// <summary>
     /// Executes a PUT request to fully replace an existing Business Central entity.
     /// </summary>
     /// <typeparam name="T">The entity type to serialize and deserialize.</typeparam>

--- a/src/Dynamics365.BusinessCentral/Client/IBusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/IBusinessCentralClient.cs
@@ -1,12 +1,46 @@
-﻿using Dynamics365.BusinessCentral.OData;
+using Dynamics365.BusinessCentral.OData;
 
 namespace Dynamics365.BusinessCentral.Client;
 
 /// <summary>
 /// Client abstraction for querying and modifying data in Microsoft Dynamics 365 Business Central via OData.
 /// </summary>
+/// <remarks>
+/// <see cref="Query{TEntity}()"/> is the recommended entry point — it is strongly typed and
+/// covers filtering, ordering, projection, expansion, paging and counting. The
+/// <c>QueryAsync</c>/<c>PostAsync</c> family remains for direct, path-based access.
+/// </remarks>
 public interface IBusinessCentralClient
 {
+    /// <summary>Company this client is scoped to.</summary>
+    string Company { get; }
+
+    /// <summary>
+    /// Returns a client scoped to a different company, sharing the same HTTP client and
+    /// access-token cache. Returns <see langword="this"/> when the company is unchanged.
+    /// </summary>
+    /// <param name="company">Company name, as returned by <see cref="GetCompaniesAsync"/>.</param>
+    IBusinessCentralClient ForCompany(string company);
+
+    /// <summary>
+    /// Starts a strongly-typed query. The entity set path comes from
+    /// <see cref="BusinessCentralEntityAttribute"/> on <typeparamref name="TEntity"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">Entity type to query.</typeparam>
+    /// <exception cref="InvalidOperationException">
+    /// <typeparamref name="TEntity"/> is not annotated; use <see cref="Query{TEntity}(string)"/>.
+    /// </exception>
+    IBusinessCentralQuery<TEntity> Query<TEntity>();
+
+    /// <summary>Starts a strongly-typed query against an explicit entity set path.</summary>
+    /// <typeparam name="TEntity">Entity type to query.</typeparam>
+    /// <param name="path">Relative OData entity path, e.g. <c>salesOrders</c>.</param>
+    IBusinessCentralQuery<TEntity> Query<TEntity>(string path);
+
+    /// <summary>Lists the companies available in the tenant.</summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<List<BusinessCentralCompany>> GetCompaniesAsync(CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Executes an OData query against a Business Central entity and returns the matching entities.
     /// </summary>
@@ -40,12 +74,13 @@ public interface IBusinessCentralClient
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Executes an OData query and retrieves all matching entities by automatically paging through the result set.
+    /// Executes an OData query and retrieves all matching entities by automatically paging
+    /// through the result set. Prefer <see cref="QueryStreamAsync{TEntity}"/> for large sets.
     /// </summary>
     /// <typeparam name="TEntity">The entity type to deserialize the OData result into.</typeparam>
     /// <param name="path">Relative OData entity path.</param>
     /// <param name="filter">Optional strongly-typed OData filter expression.</param>
-    /// <param name="options">Optional query options such as page size or ordering.</param>
+    /// <param name="options">Optional query options; use <c>WithPageSize</c> to size each round trip.</param>
     /// <param name="select">Optional list of fields to select.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<List<TEntity>> QueryAllAsync<TEntity>(
@@ -56,8 +91,25 @@ public interface IBusinessCentralClient
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Streams every matching entity, fetching pages lazily so the whole result set is
+    /// never held in memory. Stopping the enumeration stops fetching.
+    /// </summary>
+    /// <typeparam name="TEntity">The entity type to deserialize the OData result into.</typeparam>
+    /// <param name="path">Relative OData entity path.</param>
+    /// <param name="filter">Optional strongly-typed OData filter expression.</param>
+    /// <param name="options">Optional query options; use <c>WithPageSize</c> to size each round trip.</param>
+    /// <param name="select">Optional list of fields to select.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    IAsyncEnumerable<TEntity> QueryStreamAsync<TEntity>(
+        string path,
+        ODataFilter? filter = null,
+        Action<QueryOptions>? options = null,
+        IEnumerable<string>? select = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Executes a raw GET request against the given relative OData URL and deserializes the full response body.
-    /// This method bypasses the standard query helpers and can be used for custom endpoints or complex responses.
+    /// The path may include its own query string, which is sent verbatim.
     /// </summary>
     /// <typeparam name="TResponse">The type to deserialize the response body into.</typeparam>
     /// <param name="path">Relative OData URL including any query parameters.</param>
@@ -69,15 +121,17 @@ public interface IBusinessCentralClient
 
     /// <summary>
     /// Executes a PATCH request to partially update an existing Business Central entity.
-    /// The request requires an If-Match header for optimistic concurrency control.
     /// </summary>
     /// <typeparam name="T">The entity type to serialize and deserialize.</typeparam>
     /// <param name="path">Relative OData entity path.</param>
-    /// <param name="systemId">The Business Central systemId of the entity to update.</param>
+    /// <param name="systemId">Entity key: a systemId, or an alternate key such as <c>No='1000'</c>.</param>
     /// <param name="payload">Object to serialize and send as the PATCH body.</param>
     /// <param name="ifMatch">ETag value for optimistic concurrency control (default "*").</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The updated entity returned by Business Central.</returns>
+    /// <returns>
+    /// The updated entity returned by Business Central, or <paramref name="payload"/> when
+    /// the server answered 204 NoContent.
+    /// </returns>
     Task<T> PatchAsync<T>(
         string path,
         string systemId,
@@ -93,7 +147,10 @@ public interface IBusinessCentralClient
     /// <param name="path">Relative OData entity path where the entity should be created.</param>
     /// <param name="payload">Object to serialize and send as the POST body.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The created entity returned by Business Central.</returns>
+    /// <returns>
+    /// The created entity returned by Business Central, or <paramref name="payload"/> when
+    /// the server answered 204 NoContent.
+    /// </returns>
     Task<T> PostAsync<T>(
         string path,
         T payload,
@@ -102,15 +159,17 @@ public interface IBusinessCentralClient
 
     /// <summary>
     /// Executes a PUT request to fully replace an existing Business Central entity.
-    /// The request requires an If-Match header for optimistic concurrency control.
     /// </summary>
     /// <typeparam name="T">The entity type to serialize and deserialize.</typeparam>
     /// <param name="path">Relative OData entity path.</param>
-    /// <param name="systemId">The Business Central systemId of the entity to replace.</param>
+    /// <param name="systemId">Entity key: a systemId, or an alternate key such as <c>No='1000'</c>.</param>
     /// <param name="payload">Object to serialize and send as the PUT body.</param>
     /// <param name="ifMatch">ETag value for optimistic concurrency control (default "*").</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The updated entity returned by Business Central.</returns>
+    /// <returns>
+    /// The updated entity returned by Business Central, or <paramref name="payload"/> when
+    /// the server answered 204 NoContent.
+    /// </returns>
     Task<T> PutAsync<T>(
         string path,
         string systemId,
@@ -121,10 +180,9 @@ public interface IBusinessCentralClient
 
     /// <summary>
     /// Executes a DELETE request to remove an existing Business Central entity.
-    /// The request requires an If-Match header for optimistic concurrency control.
     /// </summary>
     /// <param name="path">Relative OData entity path.</param>
-    /// <param name="systemId">The Business Central systemId of the entity to delete.</param>
+    /// <param name="systemId">Entity key: a systemId, or an alternate key such as <c>No='1000'</c>.</param>
     /// <param name="ifMatch">ETag value for optimistic concurrency control (default "*").</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task DeleteAsync(

--- a/src/Dynamics365.BusinessCentral/Client/IBusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/IBusinessCentralClient.cs
@@ -111,13 +111,15 @@ public interface IBusinessCentralClient
     /// Executes a raw GET request against the given relative OData URL and deserializes the full response body.
     /// The path may include its own query string, which is sent verbatim.
     /// </summary>
-    /// <typeparam name="TResponse">The type to deserialize the response body into.</typeparam>
+    /// <typeparam name="TResponse">
+    /// The type to deserialize the response body into. Unconstrained, so value types such as
+    /// <see cref="System.Text.Json.JsonElement"/> work for responses you have no model for.
+    /// </typeparam>
     /// <param name="path">Relative OData URL including any query parameters.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<TResponse> QueryRawAsync<TResponse>(
         string path,
-        CancellationToken cancellationToken = default)
-        where TResponse : class;
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Executes a PATCH request to partially update an existing Business Central entity.

--- a/src/Dynamics365.BusinessCentral/Diagnostics/BusinessCentralErrorInfo.cs
+++ b/src/Dynamics365.BusinessCentral/Diagnostics/BusinessCentralErrorInfo.cs
@@ -1,16 +1,23 @@
 ﻿namespace Dynamics365.BusinessCentral.Diagnostics;
 
+/// <summary>Describes a failed request or a failed deserialization.</summary>
 public sealed class BusinessCentralErrorInfo
 {
+    /// <summary>HTTP method of the request.</summary>
     public string Method { get; init; } = string.Empty;
 
+    /// <summary>Full request URL.</summary>
     public string Url { get; init; } = string.Empty;
 
+    /// <summary>The failure.</summary>
     public Exception Exception { get; init; } = default!;
 
+    /// <summary>Elapsed time, when the failure happened after a response arrived.</summary>
     public TimeSpan? Duration { get; init; }
 
+    /// <summary>Response status code, when one was received.</summary>
     public int? StatusCode { get; init; }
+    /// <summary>Raw response body, when one was read.</summary>
     public string? ResponseBody { get; init; }
 
 }

--- a/src/Dynamics365.BusinessCentral/Diagnostics/BusinessCentralRequestInfo.cs
+++ b/src/Dynamics365.BusinessCentral/Diagnostics/BusinessCentralRequestInfo.cs
@@ -1,12 +1,17 @@
 ﻿namespace Dynamics365.BusinessCentral.Diagnostics;
 
+/// <summary>Describes a request that started, succeeded, or is being reported on.</summary>
 public sealed class BusinessCentralRequestInfo
 {
+    /// <summary>HTTP method of the request.</summary>
     public string Method { get; init; } = string.Empty;
 
+    /// <summary>Full request URL.</summary>
     public string Url { get; init; } = string.Empty;
 
+    /// <summary>Elapsed time, populated once the response arrived.</summary>
     public TimeSpan? Duration { get; init; }
 
+    /// <summary>Response status code, populated once the response arrived.</summary>
     public int? StatusCode { get; init; }
 }

--- a/src/Dynamics365.BusinessCentral/Diagnostics/BusinessCentralRetryInfo.cs
+++ b/src/Dynamics365.BusinessCentral/Diagnostics/BusinessCentralRetryInfo.cs
@@ -1,0 +1,28 @@
+namespace Dynamics365.BusinessCentral.Diagnostics;
+
+/// <summary>
+/// Describes a request that is about to be retried after a throttled or transient failure.
+/// </summary>
+public sealed class BusinessCentralRetryInfo
+{
+    /// <summary>HTTP method of the request being retried.</summary>
+    public string Method { get; init; } = string.Empty;
+
+    /// <summary>URL of the request being retried.</summary>
+    public string Url { get; init; } = string.Empty;
+
+    /// <summary>Status code that triggered the retry.</summary>
+    public int StatusCode { get; init; }
+
+    /// <summary>1-based retry number: <c>1</c> is the first retry after the original attempt.</summary>
+    public int Attempt { get; init; }
+
+    /// <summary>How long the client will wait before retrying.</summary>
+    public TimeSpan Delay { get; init; }
+
+    /// <summary>
+    /// Whether <see cref="Delay"/> came from the server's <c>Retry-After</c> header rather
+    /// than from computed backoff.
+    /// </summary>
+    public bool FromRetryAfter { get; init; }
+}

--- a/src/Dynamics365.BusinessCentral/Diagnostics/BusinessCentralTokenInfo.cs
+++ b/src/Dynamics365.BusinessCentral/Diagnostics/BusinessCentralTokenInfo.cs
@@ -1,8 +1,11 @@
 ﻿namespace Dynamics365.BusinessCentral.Diagnostics;
 
+/// <summary>Describes an access token that was acquired or served from cache.</summary>
 public sealed class BusinessCentralTokenInfo
 {
+    /// <summary>UTC expiry, already reduced by the safety margin.</summary>
     public DateTime ExpiresAt { get; init; }
 
+    /// <summary>Whether the token came from cache rather than a fresh request.</summary>
     public bool FromCache { get; init; }
 }

--- a/src/Dynamics365.BusinessCentral/Diagnostics/IBusinessCentralObserver.cs
+++ b/src/Dynamics365.BusinessCentral/Diagnostics/IBusinessCentralObserver.cs
@@ -1,4 +1,4 @@
-﻿namespace Dynamics365.BusinessCentral.Diagnostics;
+namespace Dynamics365.BusinessCentral.Diagnostics;
 
 public interface IBusinessCentralObserver
 {
@@ -6,11 +6,27 @@ public interface IBusinessCentralObserver
 
     void OnRequestSucceeded(BusinessCentralRequestInfo request);
 
+    /// <summary>
+    /// Raised once per failed attempt. A request that is retried after a 401 raises this
+    /// for the rejected attempt and then either <see cref="OnRequestSucceeded"/> or a
+    /// second failure — never twice for the same attempt.
+    /// </summary>
     void OnRequestFailed(BusinessCentralErrorInfo error);
 
+    /// <summary>Raised immediately before a token is requested from the identity provider.</summary>
     void OnTokenRequested();
 
+    /// <summary>
+    /// Raised only when a new token was actually obtained. Cache hits raise
+    /// <see cref="OnTokenServedFromCache"/> instead.
+    /// </summary>
     void OnTokenRefreshed(BusinessCentralTokenInfo token);
+
+    /// <summary>
+    /// Raised when an existing, unexpired token was reused. Has a default no-op
+    /// implementation so existing observers keep compiling.
+    /// </summary>
+    void OnTokenServedFromCache(BusinessCentralTokenInfo token) { }
 
     void OnDeserializationFailed(BusinessCentralErrorInfo error);
 }

--- a/src/Dynamics365.BusinessCentral/Diagnostics/IBusinessCentralObserver.cs
+++ b/src/Dynamics365.BusinessCentral/Diagnostics/IBusinessCentralObserver.cs
@@ -1,9 +1,19 @@
 namespace Dynamics365.BusinessCentral.Diagnostics;
 
+/// <summary>
+/// Diagnostics hook for request, retry and token lifecycle events.
+/// </summary>
+/// <remarks>
+/// Register an implementation with <c>services.AddObserver&lt;MyObserver&gt;()</c>. The
+/// client has no logging dependency; this interface is how you attach one. Methods with a
+/// default implementation can be ignored by existing observers.
+/// </remarks>
 public interface IBusinessCentralObserver
 {
+    /// <summary>Raised once when a request is about to be sent, before any retries.</summary>
     void OnRequestStarting(BusinessCentralRequestInfo request);
 
+    /// <summary>Raised when a request completed with a success status code.</summary>
     void OnRequestSucceeded(BusinessCentralRequestInfo request);
 
     /// <summary>
@@ -28,5 +38,12 @@ public interface IBusinessCentralObserver
     /// </summary>
     void OnTokenServedFromCache(BusinessCentralTokenInfo token) { }
 
+    /// <summary>
+    /// Raised before the client waits and retries a throttled or transient failure. Has a
+    /// default no-op implementation so existing observers keep compiling.
+    /// </summary>
+    void OnRequestRetrying(BusinessCentralRetryInfo retry) { }
+
+    /// <summary>Raised when a response could not be deserialized into the requested type.</summary>
     void OnDeserializationFailed(BusinessCentralErrorInfo error);
 }

--- a/src/Dynamics365.BusinessCentral/Diagnostics/NullBusinessCentralObserver.cs
+++ b/src/Dynamics365.BusinessCentral/Diagnostics/NullBusinessCentralObserver.cs
@@ -1,4 +1,4 @@
-﻿namespace Dynamics365.BusinessCentral.Diagnostics;
+namespace Dynamics365.BusinessCentral.Diagnostics;
 
 internal sealed class NullBusinessCentralObserver : IBusinessCentralObserver
 {
@@ -11,6 +11,8 @@ internal sealed class NullBusinessCentralObserver : IBusinessCentralObserver
     public void OnTokenRequested() { }
 
     public void OnTokenRefreshed(BusinessCentralTokenInfo token) { }
+
+    public void OnTokenServedFromCache(BusinessCentralTokenInfo token) { }
 
     public void OnDeserializationFailed(BusinessCentralErrorInfo error) { }
 }

--- a/src/Dynamics365.BusinessCentral/Diagnostics/NullBusinessCentralObserver.cs
+++ b/src/Dynamics365.BusinessCentral/Diagnostics/NullBusinessCentralObserver.cs
@@ -14,5 +14,7 @@ internal sealed class NullBusinessCentralObserver : IBusinessCentralObserver
 
     public void OnTokenServedFromCache(BusinessCentralTokenInfo token) { }
 
+    public void OnRequestRetrying(BusinessCentralRetryInfo retry) { }
+
     public void OnDeserializationFailed(BusinessCentralErrorInfo error) { }
 }

--- a/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
+++ b/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>Dynamics365.BusinessCentral</PackageId>
-        <Version>2.0.0</Version>
+        <Version>2.0.0-alpha</Version>
         <Authors>Daniel Rückenbach</Authors>
         <Company>KRAL GmbH</Company>
 
@@ -35,6 +35,9 @@
         <!-- Shown on the nuget.org package page. Kept short and pointed at CHANGELOG.md
              rather than duplicated, since nuget.org renders this as plain text. -->
         <PackageReleaseNotes>
+            PRERELEASE — 2.0.0-alpha is published for validation against real Business
+            Central environments. Not recommended for production until 2.0.0 stable.
+
             2.0.0 fixes six defects and reworks the API: typed queries via client.Query&lt;T&gt;(),
             Retry-After aware throttling handling, streaming, $expand/$count, multi-company
             support, and XML docs now shipped in the package.

--- a/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
+++ b/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
@@ -32,6 +32,20 @@
         <Title>Dynamics365 Business Central</Title>
         <PackageIcon>bcclient.png</PackageIcon>
 
+        <!-- Shown on the nuget.org package page. Kept short and pointed at CHANGELOG.md
+             rather than duplicated, since nuget.org renders this as plain text. -->
+        <PackageReleaseNotes>
+            2.0.0 fixes six defects and reworks the API: typed queries via client.Query&lt;T&gt;(),
+            Retry-After aware throttling handling, streaming, $expand/$count, multi-company
+            support, and XML docs now shipped in the package.
+
+            Breaking changes — see the migration guide before upgrading:
+            https://github.com/KralGmbh/Dynamics365-BusinessCentral/blob/master/MIGRATION.md
+
+            Full changelog:
+            https://github.com/KralGmbh/Dynamics365-BusinessCentral/blob/master/CHANGELOG.md
+        </PackageReleaseNotes>
+
         <!-- Ship XML docs so consumers get IntelliSense for the public API. -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 

--- a/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
+++ b/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
@@ -17,8 +17,8 @@
 
         <PackageTags>Dynamics365 BusinessCentral OData Client</PackageTags>
 
-        <PackageProjectUrl>https://github.com/kraldev/Dynamics365-BusinessCentral</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/kraldev/Dynamics365-BusinessCentral</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/KralGmbh/Dynamics365-BusinessCentral</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/KralGmbh/Dynamics365-BusinessCentral</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
 
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
+++ b/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-        
+
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
         <PackageId>Dynamics365.BusinessCentral</PackageId>
-        <Version>1.0.0</Version>
+        <Version>2.0.0</Version>
         <Authors>Daniel Rückenbach</Authors>
         <Company>KRAL GmbH</Company>
 
@@ -31,11 +31,35 @@
 
         <Title>Dynamics365 Business Central</Title>
         <PackageIcon>bcclient.png</PackageIcon>
+
+        <!-- Ship XML docs so consumers get IntelliSense for the public API. -->
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+        <!-- SourceLink is built into the .NET 8+ SDK; these make the snupkg actually
+             usable for step-into debugging. -->
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <!-- Match the dependency major to the target framework rather than pinning every
+         TFM to the 8.0.0 floor. -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Dynamics365.BusinessCentral/Errors/BusinessCentralException.cs
+++ b/src/Dynamics365.BusinessCentral/Errors/BusinessCentralException.cs
@@ -1,18 +1,58 @@
-﻿using System.Net;
+using System.Net;
 using System.Text;
 using System.Text.Json.Serialization;
 
 namespace Dynamics365.BusinessCentral.Errors;
 
+/// <summary>
+/// Base type for every error surfaced by the Business Central client.
+/// </summary>
+/// <remarks>
+/// <see cref="Exception.Message"/> is deliberately a single line so it stays usable as a
+/// log message. The response body, request URL, OData error code and correlation ID are
+/// available as properties, and <see cref="ToString"/> renders all of them.
+/// </remarks>
 public abstract class BusinessCentralException : Exception
 {
+    /// <summary>HTTP status code returned by Business Central.</summary>
     public HttpStatusCode StatusCode { get; }
+
+    /// <summary>HTTP method of the failed request.</summary>
     public string Method { get; }
+
+    /// <summary>URL of the failed request.</summary>
     public string? RequestUrl { get; }
+
+    /// <summary>Raw response body, when one was returned.</summary>
     public string? ResponseBody { get; }
+
+    /// <summary>OData error code, e.g. <c>BadRequest_ResourceNotFound</c>.</summary>
     public string? ODataErrorCode { get; }
+
+    /// <summary>Business Central correlation ID, useful when raising a support ticket.</summary>
     public string? CorrelationId { get; }
 
+    /// <summary>
+    /// Delay requested by the server via <c>Retry-After</c>, when present.
+    /// </summary>
+    public TimeSpan? RetryAfter { get; internal set; }
+
+    /// <summary>
+    /// Whether retrying the same request could plausibly succeed. <see langword="true"/> for
+    /// throttling and transient server failures, <see langword="false"/> for validation,
+    /// authentication and not-found errors.
+    /// </summary>
+    public virtual bool IsTransient => false;
+
+    /// <summary>Creates a new <see cref="BusinessCentralException"/>.</summary>
+    /// <param name="message">Short, single-line description of the failure.</param>
+    /// <param name="statusCode">HTTP status code returned by Business Central.</param>
+    /// <param name="method">HTTP method of the failed request.</param>
+    /// <param name="requestUrl">URL of the failed request.</param>
+    /// <param name="responseBody">Raw response body, when one was returned.</param>
+    /// <param name="odataErrorCode">OData error code parsed from the response.</param>
+    /// <param name="correlationId">Business Central correlation ID.</param>
+    /// <param name="inner">Underlying exception, when this wraps one.</param>
     protected BusinessCentralException(
         string message,
         HttpStatusCode statusCode,
@@ -22,7 +62,7 @@ public abstract class BusinessCentralException : Exception
         string? odataErrorCode = null,
         string? correlationId = null,
         Exception? inner = null)
-        : base(BuildMessage(message, statusCode, method, requestUrl, responseBody, odataErrorCode, correlationId), inner)
+        : base(BuildSummary(message, statusCode, method), inner)
     {
         StatusCode = statusCode;
         Method = method;
@@ -32,42 +72,56 @@ public abstract class BusinessCentralException : Exception
         CorrelationId = correlationId;
     }
 
-    private static string BuildMessage(
-        string message,
-        HttpStatusCode status,
-        string method,
-        string? url,
-        string? body,
-        string? odataErrorCode,
-        string? correlationId)
+    /// <summary>
+    /// One line: the server's message plus method and status. Everything else lives on
+    /// properties so structured logs are not flooded with response bodies.
+    /// </summary>
+    private static string BuildSummary(string message, HttpStatusCode status, string method)
     {
-        var sb = new StringBuilder();
+        var trimmed = string.IsNullOrWhiteSpace(message)
+            ? $"Business Central request failed."
+            : message.Trim().ReplaceLineEndings(" ");
 
-        sb.AppendLine(message);
-        sb.AppendLine($"Status: {(int)status} {status}");
-        sb.AppendLine($"Method: {method}");
-        sb.AppendLine($"URL: {url}");
+        return $"{trimmed} ({method} → HTTP {(int)status} {status})";
+    }
 
-        if (!string.IsNullOrWhiteSpace(odataErrorCode))
-            sb.AppendLine($"OData Code: {odataErrorCode}");
+    /// <summary>
+    /// Renders the full diagnostic picture: message, stack trace, request URL, OData code,
+    /// correlation ID and response body.
+    /// </summary>
+    public override string ToString()
+    {
+        var sb = new StringBuilder(base.ToString());
 
-        if (!string.IsNullOrWhiteSpace(correlationId))
-            sb.AppendLine($"CorrelationId: {correlationId}");
+        sb.AppendLine();
+        sb.AppendLine("--- Business Central details ---");
+        sb.AppendLine($"Status: {(int)StatusCode} {StatusCode}");
+        sb.AppendLine($"Method: {Method}");
+        sb.AppendLine($"URL: {RequestUrl}");
 
-        if (!string.IsNullOrWhiteSpace(body))
+        if (!string.IsNullOrWhiteSpace(ODataErrorCode))
+            sb.AppendLine($"OData Code: {ODataErrorCode}");
+
+        if (!string.IsNullOrWhiteSpace(CorrelationId))
+            sb.AppendLine($"CorrelationId: {CorrelationId}");
+
+        if (RetryAfter != null)
+            sb.AppendLine($"Retry-After: {RetryAfter}");
+
+        if (!string.IsNullOrWhiteSpace(ResponseBody))
         {
             sb.AppendLine("Response:");
-            sb.AppendLine(body);
+            sb.AppendLine(ResponseBody);
         }
 
         return sb.ToString();
     }
-
-    public override string ToString() => Message;
 }
 
+/// <summary>The requested entity or entity set does not exist (<c>404</c>).</summary>
 public sealed class BusinessCentralNotFoundException : BusinessCentralException
 {
+    /// <inheritdoc cref="BusinessCentralException(string, HttpStatusCode, string, string?, string?, string?, string?, Exception?)"/>
     public BusinessCentralNotFoundException(
         string message,
         HttpStatusCode code,
@@ -80,8 +134,10 @@ public sealed class BusinessCentralNotFoundException : BusinessCentralException
         : base(message, code, method, url, body, odataErrorCode, correlationId, inner) { }
 }
 
+/// <summary>Authentication or authorisation failed (<c>401</c> / <c>403</c>).</summary>
 public sealed class BusinessCentralAuthException : BusinessCentralException
 {
+    /// <inheritdoc cref="BusinessCentralException(string, HttpStatusCode, string, string?, string?, string?, string?, Exception?)"/>
     public BusinessCentralAuthException(
         string message,
         HttpStatusCode code,
@@ -94,8 +150,10 @@ public sealed class BusinessCentralAuthException : BusinessCentralException
         : base(message, code, method, url, body, odataErrorCode, correlationId, inner) { }
 }
 
+/// <summary>Business Central rejected the request as invalid (<c>400</c>).</summary>
 public sealed class BusinessCentralValidationException : BusinessCentralException
 {
+    /// <inheritdoc cref="BusinessCentralException(string, HttpStatusCode, string, string?, string?, string?, string?, Exception?)"/>
     public BusinessCentralValidationException(
         string message,
         HttpStatusCode code,
@@ -108,8 +166,36 @@ public sealed class BusinessCentralValidationException : BusinessCentralExceptio
         : base(message, code, method, url, body, odataErrorCode, correlationId, inner) { }
 }
 
+/// <summary>
+/// The request was throttled (<c>429</c>). Always transient; inspect
+/// <see cref="BusinessCentralException.RetryAfter"/> for the server's requested delay.
+/// </summary>
+public sealed class BusinessCentralThrottledException : BusinessCentralException
+{
+    /// <inheritdoc cref="BusinessCentralException(string, HttpStatusCode, string, string?, string?, string?, string?, Exception?)"/>
+    public BusinessCentralThrottledException(
+        string message,
+        HttpStatusCode code,
+        string method,
+        string? url,
+        string? body,
+        string? odataErrorCode = null,
+        string? correlationId = null,
+        Exception? inner = null)
+        : base(message, code, method, url, body, odataErrorCode, correlationId, inner) { }
+
+    /// <inheritdoc />
+    public override bool IsTransient => true;
+}
+
+/// <summary>
+/// Business Central returned a server-side failure, or a response that could not be
+/// deserialized. <see cref="BusinessCentralException.IsTransient"/> is <see langword="true"/>
+/// for <c>408</c>, <c>502</c>, <c>503</c> and <c>504</c>.
+/// </summary>
 public sealed class BusinessCentralServerException : BusinessCentralException
 {
+    /// <inheritdoc cref="BusinessCentralException(string, HttpStatusCode, string, string?, string?, string?, string?, Exception?)"/>
     public BusinessCentralServerException(
         string message,
         HttpStatusCode code,
@@ -120,6 +206,13 @@ public sealed class BusinessCentralServerException : BusinessCentralException
         string? correlationId = null,
         Exception? inner = null)
         : base(message, code, method, url, body, odataErrorCode, correlationId, inner) { }
+
+    /// <inheritdoc />
+    public override bool IsTransient => StatusCode is
+        HttpStatusCode.RequestTimeout or
+        HttpStatusCode.BadGateway or
+        HttpStatusCode.ServiceUnavailable or
+        HttpStatusCode.GatewayTimeout;
 }
 
 internal sealed class BusinessCentralODataError

--- a/src/Dynamics365.BusinessCentral/Errors/BusinessCentralExceptionFactory.cs
+++ b/src/Dynamics365.BusinessCentral/Errors/BusinessCentralExceptionFactory.cs
@@ -1,18 +1,29 @@
-﻿using Dynamics365.BusinessCentral.Options;
+using Dynamics365.BusinessCentral.Options;
 using System.Net;
 using System.Text.Json;
 
 namespace Dynamics365.BusinessCentral.Errors;
 
+/// <summary>
+/// Translates a failed <see cref="HttpResponseMessage"/> into the matching
+/// <see cref="BusinessCentralException"/> subtype, parsing Business Central's OData error
+/// envelope for the message, error code and correlation ID.
+/// </summary>
 public static class BusinessCentralExceptionFactory
 {
     private static readonly JsonSerializerOptions _jsonOptions = BusinessCentralJson.Options;
 
+    /// <summary>
+    /// Builds the exception describing <paramref name="res"/>. Never throws — an
+    /// unparseable body simply leaves the structured fields null.
+    /// </summary>
+    /// <param name="res">The failed response.</param>
+    /// <param name="ct">Cancellation token.</param>
     public static async Task<BusinessCentralException> CreateAsync(
         HttpResponseMessage res,
         CancellationToken ct)
     {
-        var body = await res.Content.ReadAsStringAsync(ct);
+        var body = await res.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
 
         var url = res.RequestMessage?.RequestUri?.ToString();
         var method = res.RequestMessage?.Method.Method ?? "UNKNOWN";
@@ -40,7 +51,7 @@ public static class BusinessCentralExceptionFactory
 
         var message = odataMessage ?? $"Business Central returned {(int)res.StatusCode} {res.StatusCode}.";
 
-        return res.StatusCode switch
+        BusinessCentralException exception = res.StatusCode switch
         {
             HttpStatusCode.NotFound => new BusinessCentralNotFoundException(
                 message, res.StatusCode, method, url, body, odataCode, correlationId),
@@ -51,9 +62,39 @@ public static class BusinessCentralExceptionFactory
             HttpStatusCode.BadRequest => new BusinessCentralValidationException(
                 message, res.StatusCode, method, url, body, odataCode, correlationId),
 
+            HttpStatusCode.TooManyRequests => new BusinessCentralThrottledException(
+                message, res.StatusCode, method, url, body, odataCode, correlationId),
+
             _ => new BusinessCentralServerException(
                 message, res.StatusCode, method, url, body, odataCode, correlationId)
         };
+
+        exception.RetryAfter = ReadRetryAfter(res);
+
+        return exception;
+    }
+
+    /// <summary>
+    /// Reads <c>Retry-After</c>, which Business Central may send either as a delay in
+    /// seconds or as an absolute HTTP date.
+    /// </summary>
+    internal static TimeSpan? ReadRetryAfter(HttpResponseMessage res)
+    {
+        var retryAfter = res.Headers.RetryAfter;
+
+        if (retryAfter == null)
+            return null;
+
+        if (retryAfter.Delta is { } delta)
+            return delta < TimeSpan.Zero ? TimeSpan.Zero : delta;
+
+        if (retryAfter.Date is { } date)
+        {
+            var remaining = date - DateTimeOffset.UtcNow;
+            return remaining < TimeSpan.Zero ? TimeSpan.Zero : remaining;
+        }
+
+        return null;
     }
 
     private static string? ExtractCorrelationId(string? message)

--- a/src/Dynamics365.BusinessCentral/OData/BusinessCentralCompany.cs
+++ b/src/Dynamics365.BusinessCentral/OData/BusinessCentralCompany.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace Dynamics365.BusinessCentral.OData;
+
+/// <summary>
+/// A company exposed by the Business Central tenant.
+/// </summary>
+/// <remarks>
+/// <see cref="Name"/> is the value to pass to <c>ForCompany</c> and is always populated.
+/// The remaining properties depend on which endpoint is configured and are
+/// <see langword="null"/> when the service does not return them.
+/// </remarks>
+public sealed class BusinessCentralCompany
+{
+    /// <summary>Company name, as used in the <c>Company('...')</c> URL segment.</summary>
+    [JsonPropertyName("Name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Human-readable company name, when the endpoint exposes one.</summary>
+    [JsonPropertyName("Display_Name")]
+    public string? DisplayName { get; set; }
+
+    /// <summary>Company system ID, when the endpoint exposes one.</summary>
+    [JsonPropertyName("Id")]
+    public Guid? Id { get; set; }
+
+    /// <summary>Whether this is an evaluation company, when the endpoint exposes it.</summary>
+    [JsonPropertyName("Evaluation_Company")]
+    public bool? IsEvaluationCompany { get; set; }
+
+    /// <inheritdoc />
+    public override string ToString() => DisplayName is null ? Name : $"{Name} ({DisplayName})";
+}

--- a/src/Dynamics365.BusinessCentral/OData/BusinessCentralEntityAttribute.cs
+++ b/src/Dynamics365.BusinessCentral/OData/BusinessCentralEntityAttribute.cs
@@ -1,0 +1,31 @@
+namespace Dynamics365.BusinessCentral.OData;
+
+/// <summary>
+/// Binds a CLR type to its Business Central OData entity set, so queries can be written
+/// without repeating the path string at every call site.
+/// </summary>
+/// <example>
+/// <code>
+/// [BusinessCentralEntity("salesOrders")]
+/// public sealed class SalesOrder { }
+///
+/// // path is inferred
+/// var orders = await client.Query&lt;SalesOrder&gt;().ToListAsync();
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface)]
+public sealed class BusinessCentralEntityAttribute : Attribute
+{
+    /// <summary>Relative OData entity set path, e.g. <c>salesOrders</c>.</summary>
+    public string Path { get; }
+
+    /// <summary>Binds the decorated type to <paramref name="path"/>.</summary>
+    /// <param name="path">Relative OData entity set path.</param>
+    public BusinessCentralEntityAttribute(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("Entity path must not be empty.", nameof(path));
+
+        Path = path;
+    }
+}

--- a/src/Dynamics365.BusinessCentral/OData/BusinessCentralPage.cs
+++ b/src/Dynamics365.BusinessCentral/OData/BusinessCentralPage.cs
@@ -1,0 +1,38 @@
+namespace Dynamics365.BusinessCentral.OData;
+
+/// <summary>
+/// A single page of results, together with the server-reported total when
+/// <c>$count</c> was requested.
+/// </summary>
+/// <typeparam name="TEntity">Entity type of the page contents.</typeparam>
+public sealed class BusinessCentralPage<TEntity>
+{
+    /// <summary>Entities in this page.</summary>
+    public IReadOnlyList<TEntity> Items { get; }
+
+    /// <summary>
+    /// Total number of entities matching the filter, ignoring paging. Populated only when
+    /// the query asked for a count.
+    /// </summary>
+    public long? TotalCount { get; }
+
+    /// <summary>
+    /// Absolute URL of the next page when the server is driving paging, otherwise
+    /// <see langword="null"/>.
+    /// </summary>
+    public string? NextLink { get; }
+
+    /// <summary>Whether the server indicated that more results are available.</summary>
+    public bool HasMore => !string.IsNullOrWhiteSpace(NextLink);
+
+    /// <summary>Creates a page.</summary>
+    /// <param name="items">Entities in this page.</param>
+    /// <param name="totalCount">Server-reported total, when requested.</param>
+    /// <param name="nextLink">Absolute URL of the next page, when present.</param>
+    public BusinessCentralPage(IReadOnlyList<TEntity> items, long? totalCount, string? nextLink)
+    {
+        Items = items;
+        TotalCount = totalCount;
+        NextLink = nextLink;
+    }
+}

--- a/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
+++ b/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
@@ -1,0 +1,285 @@
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+
+namespace Dynamics365.BusinessCentral.OData;
+
+/// <summary>
+/// Default <see cref="IBusinessCentralQuery{TEntity}"/> implementation.
+/// </summary>
+/// <remarks>
+/// Builder state is kept as primitives and materialised into a fresh
+/// <see cref="QueryOptions"/> per execution, so terminal operators that need to adjust
+/// paging — <c>FirstOrDefaultAsync</c>, <c>CountAsync</c> — do not mutate the builder.
+/// </remarks>
+internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEntity>
+{
+    private const int DefaultPageSize = 1000;
+
+    private readonly IBusinessCentralQueryExecutor _executor;
+    private readonly string _path;
+
+    private readonly List<string> _orderBy = [];
+    private readonly List<string> _expand = [];
+    private readonly List<string> _select = [];
+
+    private ODataFilter? _filter;
+    private int? _top;
+    private int? _skip;
+    private int? _pageSize;
+
+    public BusinessCentralQuery(IBusinessCentralQueryExecutor executor, string path)
+    {
+        _executor = executor;
+        _path = path;
+    }
+
+    public IBusinessCentralQuery<TEntity> Where(ODataFilter filter)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        _filter = _filter is null ? filter : _filter.And(filter);
+        return this;
+    }
+
+    public IBusinessCentralQuery<TEntity> Where(string filter) =>
+        string.IsNullOrWhiteSpace(filter) ? this : Where(new ODataFilter(filter));
+
+    public IBusinessCentralQuery<TEntity> OrderBy(Expression<Func<TEntity, object?>> field)
+    {
+        _orderBy.Clear();
+        return ThenBy(field);
+    }
+
+    public IBusinessCentralQuery<TEntity> OrderByDescending(Expression<Func<TEntity, object?>> field)
+    {
+        _orderBy.Clear();
+        return ThenByDescending(field);
+    }
+
+    public IBusinessCentralQuery<TEntity> ThenBy(Expression<Func<TEntity, object?>> field)
+    {
+        _orderBy.Add($"{PropertyPath.Resolve(field)} asc");
+        return this;
+    }
+
+    public IBusinessCentralQuery<TEntity> ThenByDescending(Expression<Func<TEntity, object?>> field)
+    {
+        _orderBy.Add($"{PropertyPath.Resolve(field)} desc");
+        return this;
+    }
+
+    public IBusinessCentralQuery<TEntity> Select(params Expression<Func<TEntity, object?>>[] fields)
+    {
+        foreach (var field in fields)
+        {
+            var name = PropertyPath.Resolve(field);
+            if (!_select.Contains(name))
+                _select.Add(name);
+        }
+
+        return this;
+    }
+
+    public IBusinessCentralQuery<TEntity> Expand(params Expression<Func<TEntity, object?>>[] fields)
+    {
+        foreach (var field in fields)
+        {
+            var name = PropertyPath.Resolve(field);
+            if (!_expand.Contains(name))
+                _expand.Add(name);
+        }
+
+        return this;
+    }
+
+    public IBusinessCentralQuery<TEntity> Expand(params string[] fields)
+    {
+        foreach (var field in fields)
+        {
+            if (!string.IsNullOrWhiteSpace(field) && !_expand.Contains(field))
+                _expand.Add(field);
+        }
+
+        return this;
+    }
+
+    public IBusinessCentralQuery<TEntity> Top(int count)
+    {
+        _top = count;
+        return this;
+    }
+
+    public IBusinessCentralQuery<TEntity> Skip(int count)
+    {
+        _skip = count;
+        return this;
+    }
+
+    public IBusinessCentralQuery<TEntity> PageSize(int size)
+    {
+        _pageSize = size;
+        return this;
+    }
+
+    public async Task<List<TEntity>> ToListAsync(CancellationToken cancellationToken = default)
+    {
+        var page = await _executor
+            .FetchPageAsync<TEntity>(_path, FilterValue, BuildOptions(), SelectOrNull, cancellationToken)
+            .ConfigureAwait(false);
+
+        return page.Value;
+    }
+
+    public async Task<BusinessCentralPage<TEntity>> ToPageAsync(CancellationToken cancellationToken = default)
+    {
+        var options = BuildOptions();
+        options.WithCount();
+
+        var page = await _executor
+            .FetchPageAsync<TEntity>(_path, FilterValue, options, SelectOrNull, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new BusinessCentralPage<TEntity>(page.Value, page.Count, page.NextLink);
+    }
+
+    public async Task<List<TEntity>> ToAllAsync(CancellationToken cancellationToken = default)
+    {
+        var all = new List<TEntity>();
+
+        await foreach (var entity in StreamAsync(cancellationToken).ConfigureAwait(false))
+            all.Add(entity);
+
+        return all;
+    }
+
+    public async IAsyncEnumerable<TEntity> StreamAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var pageSize = _pageSize ?? DefaultPageSize;
+        var limit = _top;
+        var skip = _skip ?? 0;
+        var emitted = 0;
+
+        var requested = NextTop(pageSize, limit, emitted);
+        var page = await FetchAsync(requested, skip, cancellationToken).ConfigureAwait(false);
+
+        // True once the server started driving paging via @odata.nextLink, at which point
+        // it — not our $top — decides where the collection ends.
+        var serverDriven = false;
+
+        while (true)
+        {
+            var inPage = 0;
+
+            foreach (var entity in page.Value)
+            {
+                yield return entity;
+
+                emitted++;
+                inPage++;
+
+                if (limit is { } cap && emitted >= cap)
+                    yield break;
+            }
+
+            if (!string.IsNullOrWhiteSpace(page.NextLink))
+            {
+                serverDriven = true;
+
+                page = await _executor
+                    .FetchNextPageAsync<TEntity>(page.NextLink!, cancellationToken)
+                    .ConfigureAwait(false);
+
+                continue;
+            }
+
+            // The server was paging and stopped offering a nextLink: nothing left.
+            if (serverDriven)
+                yield break;
+
+            // No nextLink and a short page means the collection is exhausted.
+            if (inPage < requested)
+                yield break;
+
+            skip += inPage;
+            requested = NextTop(pageSize, limit, emitted);
+
+            page = await FetchAsync(requested, skip, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private Task<ODataResponse<TEntity>> FetchAsync(int top, int skip, CancellationToken cancellationToken)
+    {
+        var options = BuildOptions();
+        options.Top = top;
+        options.Skip = skip;
+
+        return _executor.FetchPageAsync<TEntity>(_path, FilterValue, options, SelectOrNull, cancellationToken);
+    }
+
+    /// <summary>Page size for the next request, never overshooting a caller-set <c>$top</c>.</summary>
+    private static int NextTop(int pageSize, int? limit, int emitted)
+    {
+        if (limit is not { } cap)
+            return pageSize;
+
+        var remaining = cap - emitted;
+        return remaining < pageSize ? remaining : pageSize;
+    }
+
+    public async Task<TEntity?> FirstOrDefaultAsync(CancellationToken cancellationToken = default)
+    {
+        var options = BuildOptions();
+        options.Top = 1;
+
+        var page = await _executor
+            .FetchPageAsync<TEntity>(_path, FilterValue, options, SelectOrNull, cancellationToken)
+            .ConfigureAwait(false);
+
+        return page.Value.Count == 0 ? default : page.Value[0];
+    }
+
+    public async Task<long> CountAsync(CancellationToken cancellationToken = default)
+    {
+        var options = BuildOptions();
+        options.WithCount();
+        options.Top = 0;
+
+        var page = await _executor
+            .FetchPageAsync<TEntity>(_path, FilterValue, options, SelectOrNull, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (page.Count is { } count)
+            return count;
+
+        // Endpoint ignored $count — fall back to walking the collection.
+        var walked = 0L;
+
+        await foreach (var _ in StreamAsync(cancellationToken).ConfigureAwait(false))
+            walked++;
+
+        return walked;
+    }
+
+    private string FilterValue => _filter?.Value ?? string.Empty;
+
+    private IEnumerable<string>? SelectOrNull => _select.Count == 0 ? null : _select;
+
+    private QueryOptions BuildOptions()
+    {
+        var options = new QueryOptions
+        {
+            Top = _top,
+            Skip = _skip,
+            PageSize = _pageSize
+        };
+
+        foreach (var clause in _orderBy)
+            options.AppendOrderByClause(clause);
+
+        if (_expand.Count > 0)
+            options.WithExpand([.. _expand]);
+
+        return options;
+    }
+}

--- a/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
+++ b/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
@@ -105,18 +105,24 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
 
     public IBusinessCentralQuery<TEntity> Top(int count)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
         _top = count;
         return this;
     }
 
     public IBusinessCentralQuery<TEntity> Skip(int count)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
         _skip = count;
         return this;
     }
 
     public IBusinessCentralQuery<TEntity> PageSize(int size)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(size, 1);
+
         _pageSize = size;
         return this;
     }
@@ -155,8 +161,18 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
     public async IAsyncEnumerable<TEntity> StreamAsync(
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var pageSize = _pageSize ?? DefaultPageSize;
         var limit = _top;
+
+        // Top(0) is a request for no rows. Returning here also keeps the loop below from
+        // requesting $top=0 forever without ever advancing.
+        if (limit == 0)
+            yield break;
+
+        var pageSize = _pageSize ?? DefaultPageSize;
+
+        if (pageSize <= 0)
+            yield break;
+
         var skip = _skip ?? 0;
         var emitted = 0;
 

--- a/src/Dynamics365.BusinessCentral/OData/EntityPath.cs
+++ b/src/Dynamics365.BusinessCentral/OData/EntityPath.cs
@@ -1,0 +1,31 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace Dynamics365.BusinessCentral.OData;
+
+/// <summary>
+/// Resolves the OData entity set path for a CLR type from
+/// <see cref="BusinessCentralEntityAttribute"/>.
+/// </summary>
+internal static class EntityPath
+{
+    private static readonly ConcurrentDictionary<Type, string> _cache = new();
+
+    /// <summary>
+    /// Returns the path declared by <typeparamref name="TEntity"/>, or throws with an
+    /// actionable message when the type is not annotated.
+    /// </summary>
+    public static string For<TEntity>() => For(typeof(TEntity));
+
+    /// <inheritdoc cref="For{TEntity}"/>
+    public static string For(Type type) => _cache.GetOrAdd(type, static t =>
+    {
+        var attribute = t.GetCustomAttribute<BusinessCentralEntityAttribute>(inherit: true)
+            ?? throw new InvalidOperationException(
+                $"Type '{t.Name}' has no [BusinessCentralEntity] attribute, so its OData path " +
+                $"cannot be inferred. Either annotate it — [BusinessCentralEntity(\"salesOrders\")] — " +
+                $"or pass the path explicitly, e.g. client.Query<{t.Name}>(\"salesOrders\").");
+
+        return attribute.Path;
+    });
+}

--- a/src/Dynamics365.BusinessCentral/OData/Filter.cs
+++ b/src/Dynamics365.BusinessCentral/OData/Filter.cs
@@ -1,61 +1,145 @@
-﻿using System.Globalization;
+using System.Globalization;
+using System.Linq.Expressions;
 
 namespace Dynamics365.BusinessCentral.OData;
 
 /// <summary>
 /// Factory methods for creating OData filter expressions.
 /// </summary>
+/// <remarks>
+/// Every method has a string overload and a typed overload taking a property selector.
+/// Prefer the typed form — it survives renames and guarantees the field name matches how
+/// the entity is deserialized:
+/// <code>
+/// Filter.Equals&lt;SalesOrder&gt;(o =&gt; o.Status, "Open")
+///       .And(Filter.GreaterThan&lt;SalesOrder&gt;(o =&gt; o.Amount, 100));
+/// </code>
+/// </remarks>
 public static class Filter
 {
     /// <summary>Creates a filter of the form: field eq value</summary>
-    public static ODataFilter Equals(string field, object value) =>
+    public static ODataFilter Equals(string field, object? value) =>
         new($"{field} eq {Format(value)}");
 
+    /// <summary>Creates a filter of the form: field eq value</summary>
+    public static ODataFilter Equals<TEntity>(Expression<Func<TEntity, object?>> field, object? value) =>
+        Equals(PropertyPath.Resolve(field), value);
+
     /// <summary>Creates a filter of the form: field ne value</summary>
-    public static ODataFilter NotEquals(string field, object value) =>
+    public static ODataFilter NotEquals(string field, object? value) =>
         new($"{field} ne {Format(value)}");
+
+    /// <summary>Creates a filter of the form: field ne value</summary>
+    public static ODataFilter NotEquals<TEntity>(Expression<Func<TEntity, object?>> field, object? value) =>
+        NotEquals(PropertyPath.Resolve(field), value);
 
     /// <summary>Creates a filter of the form: field gt value</summary>
     public static ODataFilter GreaterThan(string field, object value) =>
         new($"{field} gt {Format(value)}");
 
+    /// <summary>Creates a filter of the form: field gt value</summary>
+    public static ODataFilter GreaterThan<TEntity>(Expression<Func<TEntity, object?>> field, object value) =>
+        GreaterThan(PropertyPath.Resolve(field), value);
+
     /// <summary>Creates a filter of the form: field ge value</summary>
     public static ODataFilter GreaterOrEqual(string field, object value) =>
         new($"{field} ge {Format(value)}");
+
+    /// <summary>Creates a filter of the form: field ge value</summary>
+    public static ODataFilter GreaterOrEqual<TEntity>(Expression<Func<TEntity, object?>> field, object value) =>
+        GreaterOrEqual(PropertyPath.Resolve(field), value);
 
     /// <summary>Creates a filter of the form: field lt value</summary>
     public static ODataFilter LessThan(string field, object value) =>
         new($"{field} lt {Format(value)}");
 
+    /// <summary>Creates a filter of the form: field lt value</summary>
+    public static ODataFilter LessThan<TEntity>(Expression<Func<TEntity, object?>> field, object value) =>
+        LessThan(PropertyPath.Resolve(field), value);
+
     /// <summary>Creates a filter of the form: field le value</summary>
     public static ODataFilter LessOrEqual(string field, object value) =>
         new($"{field} le {Format(value)}");
+
+    /// <summary>Creates a filter of the form: field le value</summary>
+    public static ODataFilter LessOrEqual<TEntity>(Expression<Func<TEntity, object?>> field, object value) =>
+        LessOrEqual(PropertyPath.Resolve(field), value);
 
     /// <summary>Creates a filter using the contains(...) function.</summary>
     public static ODataFilter Contains(string field, string value) =>
         new($"contains({field}, {Format(value)})");
 
+    /// <summary>Creates a filter using the contains(...) function.</summary>
+    public static ODataFilter Contains<TEntity>(Expression<Func<TEntity, object?>> field, string value) =>
+        Contains(PropertyPath.Resolve(field), value);
+
     /// <summary>Creates a filter using the startswith(...) function.</summary>
     public static ODataFilter StartsWith(string field, string value) =>
         new($"startswith({field}, {Format(value)})");
+
+    /// <summary>Creates a filter using the startswith(...) function.</summary>
+    public static ODataFilter StartsWith<TEntity>(Expression<Func<TEntity, object?>> field, string value) =>
+        StartsWith(PropertyPath.Resolve(field), value);
 
     /// <summary>Creates a filter using the endswith(...) function.</summary>
     public static ODataFilter EndsWith(string field, string value) =>
         new($"endswith({field}, {Format(value)})");
 
-    /// <summary>Creates a filter of the form: field in (value1,value2,...)</summary>
-    public static ODataFilter In(string field, params object[] values) =>
-        new($"{field} in ({string.Join(",", values.Select(Format))})");
+    /// <summary>Creates a filter using the endswith(...) function.</summary>
+    public static ODataFilter EndsWith<TEntity>(Expression<Func<TEntity, object?>> field, string value) =>
+        EndsWith(PropertyPath.Resolve(field), value);
+
+    /// <summary>
+    /// Creates a filter of the form: field in (value1,value2,...).
+    /// </summary>
+    /// <remarks>
+    /// An empty <paramref name="values"/> produces a filter that matches nothing
+    /// (<c>false</c>) rather than the invalid OData expression <c>field in ()</c>. This
+    /// makes <c>Filter.In(field, ids)</c> safe when <c>ids</c> turns out to be empty.
+    /// </remarks>
+    public static ODataFilter In(string field, params object[] values)
+    {
+        if (values is null || values.Length == 0)
+            return new ODataFilter("false");
+
+        return new ODataFilter($"{field} in ({string.Join(",", values.Select(Format))})");
+    }
+
+    /// <inheritdoc cref="In(string, object[])"/>
+    public static ODataFilter In(string field, IEnumerable<object> values) =>
+        In(field, values?.ToArray() ?? []);
+
+    /// <inheritdoc cref="In(string, object[])"/>
+    public static ODataFilter In<TEntity>(Expression<Func<TEntity, object?>> field, params object[] values) =>
+        In(PropertyPath.Resolve(field), values);
+
+    /// <inheritdoc cref="In(string, object[])"/>
+    public static ODataFilter In<TEntity>(Expression<Func<TEntity, object?>> field, IEnumerable<object> values) =>
+        In(PropertyPath.Resolve(field), values);
 
     /// <summary>Creates a filter of the form: field eq null</summary>
     public static ODataFilter IsNull(string field) =>
         new($"{field} eq null");
 
+    /// <summary>Creates a filter of the form: field eq null</summary>
+    public static ODataFilter IsNull<TEntity>(Expression<Func<TEntity, object?>> field) =>
+        IsNull(PropertyPath.Resolve(field));
+
     /// <summary>Creates a filter of the form: field ne null</summary>
     public static ODataFilter IsNotNull(string field) =>
         new($"{field} ne null");
 
-    private static string Format(object value) =>
+    /// <summary>Creates a filter of the form: field ne null</summary>
+    public static ODataFilter IsNotNull<TEntity>(Expression<Func<TEntity, object?>> field) =>
+        IsNotNull(PropertyPath.Resolve(field));
+
+    /// <summary>A filter that matches every row. Emitted as no <c>$filter</c> at all.</summary>
+    public static ODataFilter All => new("true");
+
+    /// <summary>A filter that matches nothing.</summary>
+    public static ODataFilter None => new("false");
+
+    private static string Format(object? value) =>
         value switch
         {
             null => "null",
@@ -63,6 +147,7 @@ public static class Filter
             DateTime dt => dt.ToUniversalTime().ToString("O"),
             DateTimeOffset dto => dto.ToUniversalTime().ToString("O"),
             bool b => b.ToString().ToLowerInvariant(),
+            Guid g => g.ToString(),
             Enum e => $"'{e}'",
             _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? "null"
         };

--- a/src/Dynamics365.BusinessCentral/OData/IBusinessCentralQuery.cs
+++ b/src/Dynamics365.BusinessCentral/OData/IBusinessCentralQuery.cs
@@ -1,0 +1,81 @@
+using System.Linq.Expressions;
+
+namespace Dynamics365.BusinessCentral.OData;
+
+/// <summary>
+/// Fluent, strongly-typed query over a Business Central entity set.
+/// </summary>
+/// <remarks>
+/// Field names come from property selectors, so they survive renames and always agree with
+/// how the entity is deserialized. Builder methods mutate and return the same instance —
+/// call <c>Query&lt;T&gt;()</c> again for an independent query.
+/// <code>
+/// var orders = await client.Query&lt;SalesOrder&gt;()
+///     .Where(Filter.Equals&lt;SalesOrder&gt;(o =&gt; o.Status, "Open"))
+///     .OrderByDescending(o =&gt; o.Amount)
+///     .ThenBy(o =&gt; o.No)
+///     .Select(o =&gt; o.No, o =&gt; o.Amount)
+///     .Top(50)
+///     .ToListAsync();
+/// </code>
+/// </remarks>
+/// <typeparam name="TEntity">Entity type being queried.</typeparam>
+public interface IBusinessCentralQuery<TEntity>
+{
+    /// <summary>Adds a filter, combined with any existing filter using <c>and</c>.</summary>
+    IBusinessCentralQuery<TEntity> Where(ODataFilter filter);
+
+    /// <summary>Adds a raw OData <c>$filter</c> expression, combined using <c>and</c>.</summary>
+    IBusinessCentralQuery<TEntity> Where(string filter);
+
+    /// <summary>Orders ascending, replacing any ordering set so far.</summary>
+    IBusinessCentralQuery<TEntity> OrderBy(Expression<Func<TEntity, object?>> field);
+
+    /// <summary>Orders descending, replacing any ordering set so far.</summary>
+    IBusinessCentralQuery<TEntity> OrderByDescending(Expression<Func<TEntity, object?>> field);
+
+    /// <summary>Appends an ascending sort key.</summary>
+    IBusinessCentralQuery<TEntity> ThenBy(Expression<Func<TEntity, object?>> field);
+
+    /// <summary>Appends a descending sort key.</summary>
+    IBusinessCentralQuery<TEntity> ThenByDescending(Expression<Func<TEntity, object?>> field);
+
+    /// <summary>Restricts the returned fields (<c>$select</c>).</summary>
+    IBusinessCentralQuery<TEntity> Select(params Expression<Func<TEntity, object?>>[] fields);
+
+    /// <summary>Expands navigation properties (<c>$expand</c>).</summary>
+    IBusinessCentralQuery<TEntity> Expand(params Expression<Func<TEntity, object?>>[] fields);
+
+    /// <summary>Expands navigation properties using raw OData expand syntax.</summary>
+    IBusinessCentralQuery<TEntity> Expand(params string[] fields);
+
+    /// <summary>Limits the number of entities returned (<c>$top</c>).</summary>
+    IBusinessCentralQuery<TEntity> Top(int count);
+
+    /// <summary>Skips entities (<c>$skip</c>).</summary>
+    IBusinessCentralQuery<TEntity> Skip(int count);
+
+    /// <summary>Sets rows fetched per round trip when auto-paging. Not a result limit.</summary>
+    IBusinessCentralQuery<TEntity> PageSize(int size);
+
+    /// <summary>Executes a single request and returns that page's entities.</summary>
+    Task<List<TEntity>> ToListAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Pages through the whole result set and returns everything.</summary>
+    Task<List<TEntity>> ToAllAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Streams the whole result set, fetching pages lazily. Prefer this over
+    /// <see cref="ToAllAsync"/> for large sets, or when you may stop early.
+    /// </summary>
+    IAsyncEnumerable<TEntity> StreamAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Executes a single request and returns the page plus the total count.</summary>
+    Task<BusinessCentralPage<TEntity>> ToPageAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Returns the first matching entity, or <see langword="null"/> when none match.</summary>
+    Task<TEntity?> FirstOrDefaultAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Returns how many entities match, without fetching them.</summary>
+    Task<long> CountAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Dynamics365.BusinessCentral/OData/ODataResponse.cs
+++ b/src/Dynamics365.BusinessCentral/OData/ODataResponse.cs
@@ -1,0 +1,35 @@
+using System.Text.Json.Serialization;
+
+namespace Dynamics365.BusinessCentral.OData;
+
+/// <summary>
+/// The OData collection envelope Business Central wraps results in.
+/// </summary>
+internal sealed class ODataResponse<TEntity>
+{
+    [JsonPropertyName("value")]
+    public List<TEntity> Value { get; set; } = [];
+
+    [JsonPropertyName("@odata.nextLink")]
+    public string? NextLink { get; set; }
+
+    [JsonPropertyName("@odata.count")]
+    public long? Count { get; set; }
+}
+
+/// <summary>
+/// Page-fetching primitives the fluent query builder needs from the client.
+/// </summary>
+internal interface IBusinessCentralQueryExecutor
+{
+    Task<ODataResponse<TEntity>> FetchPageAsync<TEntity>(
+        string path,
+        string filter,
+        QueryOptions options,
+        IEnumerable<string>? select,
+        CancellationToken cancellationToken);
+
+    Task<ODataResponse<TEntity>> FetchNextPageAsync<TEntity>(
+        string absoluteUrl,
+        CancellationToken cancellationToken);
+}

--- a/src/Dynamics365.BusinessCentral/OData/PropertyPath.cs
+++ b/src/Dynamics365.BusinessCentral/OData/PropertyPath.cs
@@ -1,0 +1,67 @@
+using Dynamics365.BusinessCentral.Options;
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Dynamics365.BusinessCentral.OData;
+
+/// <summary>
+/// Turns a property selector such as <c>o =&gt; o.Amount</c> into the OData field name.
+/// </summary>
+/// <remarks>
+/// Names are resolved exactly the way <see cref="BusinessCentralJson"/> serializes them —
+/// <see cref="JsonPropertyNameAttribute"/> first, then the configured naming policy. That
+/// keeps <c>$filter</c>, <c>$select</c> and <c>$orderby</c> in agreement with
+/// deserialization, which is the usual cause of "field not found" errors when field names
+/// are typed by hand.
+/// </remarks>
+internal static class PropertyPath
+{
+    private static readonly ConcurrentDictionary<MemberInfo, string> _cache = new();
+
+    /// <summary>
+    /// Resolves a selector to an OData field name. Nested selectors such as
+    /// <c>o =&gt; o.Customer.Name</c> become navigation paths (<c>customer/name</c>).
+    /// </summary>
+    public static string Resolve<TEntity>(Expression<Func<TEntity, object?>> selector)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+
+        var body = Unwrap(selector.Body);
+
+        if (body is not MemberExpression member)
+        {
+            throw new ArgumentException(
+                $"Expected a property selector such as x => x.Name, but got '{selector.Body}'. " +
+                "Method calls and computed expressions cannot be translated to OData.",
+                nameof(selector));
+        }
+
+        var segments = new List<string>();
+
+        for (MemberExpression? current = member; current != null; current = Unwrap(current.Expression) as MemberExpression)
+            segments.Insert(0, ResolveName(current.Member));
+
+        return string.Join("/", segments);
+    }
+
+    /// <summary>Strips the boxing conversion the compiler inserts for value-typed properties.</summary>
+    private static Expression? Unwrap(Expression? expression) =>
+        expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary
+            ? unary.Operand
+            : expression;
+
+    private static string ResolveName(MemberInfo member) => _cache.GetOrAdd(member, static m =>
+    {
+        var attribute = m.GetCustomAttribute<JsonPropertyNameAttribute>(inherit: true);
+
+        if (attribute != null)
+            return attribute.Name;
+
+        var policy = BusinessCentralJson.Options.PropertyNamingPolicy;
+
+        return policy?.ConvertName(m.Name) ?? m.Name;
+    });
+}

--- a/src/Dynamics365.BusinessCentral/OData/QueryOptions.cs
+++ b/src/Dynamics365.BusinessCentral/OData/QueryOptions.cs
@@ -1,44 +1,123 @@
-﻿namespace Dynamics365.BusinessCentral.OData;
+namespace Dynamics365.BusinessCentral.OData;
 
 /// <summary>
-/// Represents optional OData query modifiers such as $top, $skip and $orderby.
+/// Optional OData query modifiers: <c>$top</c>, <c>$skip</c>, <c>$orderby</c>,
+/// <c>$expand</c> and <c>$count</c>.
 /// </summary>
 public sealed class QueryOptions
 {
-    /// <summary>Limits the number of returned entities.</summary>
+    private readonly List<string> _orderBy = [];
+    private readonly List<string> _expand = [];
+
+    /// <summary>Maximum number of entities to return (<c>$top</c>).</summary>
     public int? Top { get; internal set; }
 
-    /// <summary>Skips the specified number of entities.</summary>
+    /// <summary>Number of entities to skip (<c>$skip</c>).</summary>
     public int? Skip { get; internal set; }
 
-    /// <summary>Defines the ordering of the result set.</summary>
-    public string? OrderBy { get; internal set; }
+    /// <summary>
+    /// Rows fetched per request when auto-paging. This is <b>not</b> a result limit —
+    /// use <see cref="WithTop"/> for that.
+    /// </summary>
+    public int? PageSize { get; internal set; }
 
-    /// <summary>Sets the $top query option.</summary>
+    /// <summary>Whether to request a total count (<c>$count=true</c>).</summary>
+    public bool IncludeCount { get; internal set; }
+
+    /// <summary>Navigation properties to expand (<c>$expand</c>).</summary>
+    public IReadOnlyList<string> Expand => _expand;
+
+    /// <summary>
+    /// The composed <c>$orderby</c> clause, or <see langword="null"/> when no ordering was set.
+    /// </summary>
+    public string? OrderBy
+    {
+        get => _orderBy.Count == 0 ? null : string.Join(",", _orderBy);
+        internal set
+        {
+            _orderBy.Clear();
+            if (!string.IsNullOrWhiteSpace(value))
+                _orderBy.Add(value!);
+        }
+    }
+
+    /// <summary>Limits the result to <paramref name="value"/> entities (<c>$top</c>).</summary>
     public QueryOptions WithTop(int value)
     {
         Top = value;
         return this;
     }
 
-    /// <summary>Sets the $skip query option.</summary>
+    /// <summary>Skips <paramref name="value"/> entities (<c>$skip</c>).</summary>
     public QueryOptions WithSkip(int value)
     {
         Skip = value;
         return this;
     }
 
-    /// <summary>Orders the result set ascending by the given field.</summary>
-    public QueryOptions OrderByAsc(string field)
+    /// <summary>
+    /// Sets how many rows are fetched per request when auto-paging. Affects the number of
+    /// round trips, not how many entities come back.
+    /// </summary>
+    public QueryOptions WithPageSize(int value)
     {
-        OrderBy = $"{field} asc";
+        PageSize = value;
         return this;
     }
 
-    /// <summary>Orders the result set descending by the given field.</summary>
+    /// <summary>Requests a total count alongside the page (<c>$count=true</c>).</summary>
+    public QueryOptions WithCount(bool include = true)
+    {
+        IncludeCount = include;
+        return this;
+    }
+
+    /// <summary>Expands the given navigation properties (<c>$expand</c>).</summary>
+    public QueryOptions WithExpand(params string[] fields)
+    {
+        foreach (var field in fields)
+        {
+            if (!string.IsNullOrWhiteSpace(field) && !_expand.Contains(field))
+                _expand.Add(field);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Orders ascending by <paramref name="field"/>, <b>replacing</b> any ordering set so far.
+    /// Use <see cref="ThenByAsc"/> to add a secondary key.
+    /// </summary>
+    public QueryOptions OrderByAsc(string field)
+    {
+        _orderBy.Clear();
+        return ThenByAsc(field);
+    }
+
+    /// <summary>
+    /// Orders descending by <paramref name="field"/>, <b>replacing</b> any ordering set so far.
+    /// Use <see cref="ThenByDesc"/> to add a secondary key.
+    /// </summary>
     public QueryOptions OrderByDesc(string field)
     {
-        OrderBy = $"{field} desc";
+        _orderBy.Clear();
+        return ThenByDesc(field);
+    }
+
+    /// <summary>Appends an ascending sort key, keeping the existing ordering.</summary>
+    public QueryOptions ThenByAsc(string field) =>
+        string.IsNullOrWhiteSpace(field) ? this : AppendOrderByClause($"{field} asc");
+
+    /// <summary>Appends a descending sort key, keeping the existing ordering.</summary>
+    public QueryOptions ThenByDesc(string field) =>
+        string.IsNullOrWhiteSpace(field) ? this : AppendOrderByClause($"{field} desc");
+
+    /// <summary>Appends an already-formatted clause such as <c>"no asc"</c>.</summary>
+    internal QueryOptions AppendOrderByClause(string clause)
+    {
+        if (!string.IsNullOrWhiteSpace(clause))
+            _orderBy.Add(clause);
+
         return this;
     }
 }

--- a/src/Dynamics365.BusinessCentral/OData/QueryOptions.cs
+++ b/src/Dynamics365.BusinessCentral/OData/QueryOptions.cs
@@ -42,15 +42,21 @@ public sealed class QueryOptions
     }
 
     /// <summary>Limits the result to <paramref name="value"/> entities (<c>$top</c>).</summary>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is negative.</exception>
     public QueryOptions WithTop(int value)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(value);
+
         Top = value;
         return this;
     }
 
     /// <summary>Skips <paramref name="value"/> entities (<c>$skip</c>).</summary>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is negative.</exception>
     public QueryOptions WithSkip(int value)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(value);
+
         Skip = value;
         return this;
     }
@@ -59,8 +65,14 @@ public sealed class QueryOptions
     /// Sets how many rows are fetched per request when auto-paging. Affects the number of
     /// round trips, not how many entities come back.
     /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="value"/> is less than 1. A page size of zero would request <c>$top=0</c>
+    /// forever without advancing.
+    /// </exception>
     public QueryOptions WithPageSize(int value)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+
         PageSize = value;
         return this;
     }

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralJson.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralJson.cs
@@ -2,8 +2,14 @@
 
 namespace Dynamics365.BusinessCentral.Options;
 
+/// <summary>
+/// The single <see cref="JsonSerializerOptions"/> used for every payload the client reads
+/// or writes. Property-name resolution for filters and projections follows the same
+/// settings, so typed field selectors always agree with deserialization.
+/// </summary>
 public static class BusinessCentralJson
 {
+    /// <summary>camelCase on write, case-insensitive on read.</summary>
     public static readonly JsonSerializerOptions Options = new()
     {
         PropertyNameCaseInsensitive = true,

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptions.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptions.cs
@@ -1,13 +1,69 @@
-﻿namespace Dynamics365.BusinessCentral.Options;
+namespace Dynamics365.BusinessCentral.Options;
 
+/// <summary>
+/// Connection settings for a Business Central environment.
+/// </summary>
+/// <remarks>
+/// Only <see cref="TenantId"/>, <see cref="ClientId"/>, <see cref="ClientSecret"/> and
+/// <see cref="Company"/> are required. <see cref="BaseUrl"/> and <see cref="TokenEndpoint"/>
+/// default to the Business Central SaaS endpoints and support the placeholders
+/// <c>{tenant}</c> and <c>{environment}</c>, which are substituted from
+/// <see cref="TenantId"/> and <see cref="Environment"/>.
+/// </remarks>
 public sealed class BusinessCentralOptions
 {
+    /// <summary>Microsoft Entra tenant ID (GUID) that owns the Business Central subscription.</summary>
     public string TenantId { get; set; } = default!;
+
+    /// <summary>Application (client) ID of the Entra app registration used for authentication.</summary>
     public string ClientId { get; set; } = default!;
+
+    /// <summary>Client secret of the Entra app registration.</summary>
     public string ClientSecret { get; set; } = default!;
-    public string BaseUrl { get; set; } = default!;
+
+    /// <summary>Display name of the Business Central company, e.g. <c>CRONUS AG</c>.</summary>
     public string Company { get; set; } = default!;
+
+    /// <summary>
+    /// Business Central environment name. Substituted for <c>{environment}</c> in
+    /// <see cref="BaseUrl"/>. Defaults to <c>Production</c>.
+    /// </summary>
+    public string Environment { get; set; } = "Production";
+
+    /// <summary>
+    /// OData service root. Supports the <c>{tenant}</c> and <c>{environment}</c> placeholders.
+    /// Defaults to the Business Central SaaS OData v4 endpoint.
+    /// </summary>
+    public string BaseUrl { get; set; } =
+        "https://api.businesscentral.dynamics.com/v2.0/{tenant}/{environment}/ODataV4";
+
+    /// <summary>OAuth2 scope requested for the access token.</summary>
     public string Scope { get; set; } = "https://api.businesscentral.dynamics.com/.default";
+
+    /// <summary>
+    /// OAuth2 token endpoint. Supports the <c>{tenant}</c> placeholder.
+    /// </summary>
     public string TokenEndpoint { get; set; } =
-        "https://login.microsoftonline.com/{TenantId}/oauth2/v2.0/token";
+        "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token";
+
+    /// <summary>Controls automatic retrying of throttled and transient failures.</summary>
+    public BusinessCentralRetryOptions Retry { get; set; } = new();
+
+    /// <summary><see cref="BaseUrl"/> with all placeholders substituted.</summary>
+    internal string ResolvedBaseUrl => ResolvePlaceholders(BaseUrl);
+
+    /// <summary><see cref="TokenEndpoint"/> with all placeholders substituted.</summary>
+    internal string ResolvedTokenEndpoint => ResolvePlaceholders(TokenEndpoint);
+
+    private string ResolvePlaceholders(string template)
+    {
+        if (string.IsNullOrEmpty(template))
+            return template;
+
+        return template
+            // {TenantId} is the historical spelling and stays supported.
+            .Replace("{TenantId}", TenantId ?? string.Empty, StringComparison.OrdinalIgnoreCase)
+            .Replace("{tenant}", TenantId ?? string.Empty, StringComparison.OrdinalIgnoreCase)
+            .Replace("{environment}", Environment ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptionsValidator.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptionsValidator.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Options;
+
+namespace Dynamics365.BusinessCentral.Options;
+
+/// <summary>
+/// Validates <see cref="BusinessCentralOptions"/> and reports every missing setting by
+/// name, rather than collapsing the whole configuration into a single pass/fail.
+/// </summary>
+internal sealed class BusinessCentralOptionsValidator : IValidateOptions<BusinessCentralOptions>
+{
+    public ValidateOptionsResult Validate(string? name, BusinessCentralOptions options)
+    {
+        var failures = new List<string>();
+
+        Require(options.TenantId, nameof(options.TenantId), failures);
+        Require(options.ClientId, nameof(options.ClientId), failures);
+        Require(options.ClientSecret, nameof(options.ClientSecret), failures);
+        Require(options.BaseUrl, nameof(options.BaseUrl), failures);
+        Require(options.Company, nameof(options.Company), failures);
+        Require(options.Scope, nameof(options.Scope), failures);
+        Require(options.TokenEndpoint, nameof(options.TokenEndpoint), failures);
+
+        if (!string.IsNullOrWhiteSpace(options.BaseUrl) &&
+            !Uri.TryCreate(options.BaseUrl, UriKind.Absolute, out _))
+        {
+            failures.Add($"{nameof(options.BaseUrl)} must be an absolute URL.");
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+
+    private static void Require(string? value, string propertyName, List<string> failures)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            failures.Add($"{nameof(BusinessCentralOptions)}.{propertyName} must not be empty.");
+    }
+}

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptionsValidator.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptionsValidator.cs
@@ -15,16 +15,18 @@ internal sealed class BusinessCentralOptionsValidator : IValidateOptions<Busines
         Require(options.TenantId, nameof(options.TenantId), failures);
         Require(options.ClientId, nameof(options.ClientId), failures);
         Require(options.ClientSecret, nameof(options.ClientSecret), failures);
-        Require(options.BaseUrl, nameof(options.BaseUrl), failures);
         Require(options.Company, nameof(options.Company), failures);
+
+        // These have defaults, so an empty value means the caller cleared them.
+        Require(options.BaseUrl, nameof(options.BaseUrl), failures);
         Require(options.Scope, nameof(options.Scope), failures);
         Require(options.TokenEndpoint, nameof(options.TokenEndpoint), failures);
+        Require(options.Environment, nameof(options.Environment), failures);
 
-        if (!string.IsNullOrWhiteSpace(options.BaseUrl) &&
-            !Uri.TryCreate(options.BaseUrl, UriKind.Absolute, out _))
-        {
-            failures.Add($"{nameof(options.BaseUrl)} must be an absolute URL.");
-        }
+        // Validate the resolved URLs: an unsubstituted placeholder is the failure mode
+        // this is really guarding against.
+        RequireAbsoluteUrl(options.ResolvedBaseUrl, nameof(options.BaseUrl), failures);
+        RequireAbsoluteUrl(options.ResolvedTokenEndpoint, nameof(options.TokenEndpoint), failures);
 
         return failures.Count == 0
             ? ValidateOptionsResult.Success
@@ -35,5 +37,23 @@ internal sealed class BusinessCentralOptionsValidator : IValidateOptions<Busines
     {
         if (string.IsNullOrWhiteSpace(value))
             failures.Add($"{nameof(BusinessCentralOptions)}.{propertyName} must not be empty.");
+    }
+
+    private static void RequireAbsoluteUrl(string? resolved, string propertyName, List<string> failures)
+    {
+        if (string.IsNullOrWhiteSpace(resolved))
+            return;
+
+        if (resolved.Contains('{') || resolved.Contains('}'))
+        {
+            failures.Add(
+                $"{nameof(BusinessCentralOptions)}.{propertyName} still contains an unsubstituted " +
+                $"placeholder after resolution ('{resolved}'). Supported placeholders are " +
+                $"{{tenant}} and {{environment}}.");
+            return;
+        }
+
+        if (!Uri.TryCreate(resolved, UriKind.Absolute, out _))
+            failures.Add($"{nameof(BusinessCentralOptions)}.{propertyName} must be an absolute URL.");
     }
 }

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptionsValidator.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptionsValidator.cs
@@ -49,7 +49,7 @@ internal sealed class BusinessCentralOptionsValidator : IValidateOptions<Busines
             failures.Add(
                 $"{nameof(BusinessCentralOptions)}.{propertyName} still contains an unsubstituted " +
                 $"placeholder after resolution ('{resolved}'). Supported placeholders are " +
-                $"{{tenant}} and {{environment}}.");
+                $"{{tenant}} (or the historical {{TenantId}}) and {{environment}}.");
             return;
         }
 

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralRetryOptions.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralRetryOptions.cs
@@ -52,6 +52,12 @@ public sealed class BusinessCentralRetryOptions
     /// Set this to <see langword="true"/> only when the endpoint you POST to deduplicates
     /// server-side, or when duplicates are acceptable.
     /// </para>
+    /// <para>
+    /// This setting covers <c>POST</c> only. <c>PATCH</c> is always replayed, because this
+    /// client sends a JSON merge of absolute field values, which converges when applied
+    /// twice. Disable retries entirely, or pass a real <c>If-Match</c> ETag, if you need a
+    /// <c>PATCH</c> held back.
+    /// </para>
     /// </remarks>
     public bool RetryPostOnTransientFailures { get; set; }
 }

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralRetryOptions.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralRetryOptions.cs
@@ -1,8 +1,8 @@
 namespace Dynamics365.BusinessCentral.Options;
 
 /// <summary>
-/// Controls how the client retries throttled (<c>429</c>) and transient (<c>503</c>,
-/// <c>504</c>, <c>408</c>) responses.
+/// Controls how the client retries throttled (<c>429</c>) and transient (<c>408</c>,
+/// <c>502</c>, <c>503</c>, <c>504</c>) responses.
 /// </summary>
 /// <remarks>
 /// Business Central throttles aggressively and answers with a <c>Retry-After</c> header;

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralRetryOptions.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralRetryOptions.cs
@@ -1,0 +1,34 @@
+namespace Dynamics365.BusinessCentral.Options;
+
+/// <summary>
+/// Controls how the client retries throttled (<c>429</c>) and transient (<c>503</c>,
+/// <c>504</c>, <c>408</c>) responses.
+/// </summary>
+/// <remarks>
+/// Business Central throttles aggressively and answers with a <c>Retry-After</c> header;
+/// honouring it is almost always the correct behaviour. This is separate from the
+/// single automatic retry performed after a <c>401</c>, which is not configurable.
+/// </remarks>
+public sealed class BusinessCentralRetryOptions
+{
+    /// <summary>Set to <see langword="false"/> to surface transient failures immediately.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Total number of attempts, including the first. <c>3</c> means the original request
+    /// plus two retries. Values below <c>1</c> are treated as <c>1</c>.
+    /// </summary>
+    public int MaxAttempts { get; set; } = 3;
+
+    /// <summary>Delay before the first retry; doubles on each subsequent attempt.</summary>
+    public TimeSpan BaseDelay { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>Upper bound for a single delay, including one taken from <c>Retry-After</c>.</summary>
+    public TimeSpan MaxDelay { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// When <see langword="true"/> (the default) a <c>Retry-After</c> header takes precedence
+    /// over the computed backoff, capped by <see cref="MaxDelay"/>.
+    /// </summary>
+    public bool HonorRetryAfter { get; set; } = true;
+}

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralRetryOptions.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralRetryOptions.cs
@@ -31,4 +31,27 @@ public sealed class BusinessCentralRetryOptions
     /// over the computed backoff, capped by <see cref="MaxDelay"/>.
     /// </summary>
     public bool HonorRetryAfter { get; set; } = true;
+
+    /// <summary>
+    /// Whether a <c>POST</c> may be replayed after a transient failure <i>other than</i>
+    /// <c>429</c>. Defaults to <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>429</c> means the request was rejected before it was processed, so replaying it is
+    /// always safe and happens regardless of this setting.
+    /// </para>
+    /// <para>
+    /// <c>408</c>, <c>502</c>, <c>503</c> and <c>504</c> are ambiguous: Business Central may
+    /// have applied the write before the failure surfaced. Replaying a <c>POST</c> would then
+    /// create a duplicate record, so by default it is not retried and the exception is raised
+    /// for the caller to handle. Idempotent methods — <c>GET</c>, <c>PUT</c>, <c>DELETE</c> —
+    /// are always retried, because replaying them converges on the same state.
+    /// </para>
+    /// <para>
+    /// Set this to <see langword="true"/> only when the endpoint you POST to deduplicates
+    /// server-side, or when duplicates are acceptable.
+    /// </para>
+    /// </remarks>
+    public bool RetryPostOnTransientFailures { get; set; }
 }

--- a/src/Dynamics365.BusinessCentral/README.md
+++ b/src/Dynamics365.BusinessCentral/README.md
@@ -253,7 +253,13 @@ already have been applied — so:
 | Method | `429` | `408` / `502` / `503` / `504` |
 | ------ | ----- | ----------------------------- |
 | `GET`, `PUT`, `DELETE` | retried | retried (idempotent — replay converges) |
+| `PATCH` | retried | retried (see below) |
 | `POST` | retried | **not** retried; the exception is raised |
+
+`PATCH` is replayed too. RFC 9110 does not guarantee PATCH is idempotent, but this client
+only ever sends a JSON merge of absolute field values, so applying it twice converges on the
+same state. If your payload carries relative operations, disable retries or pass a real
+`If-Match` ETag instead of `*`.
 
 Without this, a `504` on a `POST` could duplicate a record that Business Central had already
 created. If your endpoint deduplicates server-side, or duplicates are acceptable, opt back

--- a/src/Dynamics365.BusinessCentral/README.md
+++ b/src/Dynamics365.BusinessCentral/README.md
@@ -226,6 +226,19 @@ services.AddBusinessCentral(options =>
 });
 ```
 
+**Writes are not blindly replayed.** A `429` is rejected before Business Central processes
+it, so replaying is always safe. The other transient statuses are ambiguous — the write may
+already have been applied — so:
+
+| Method | `429` | `408` / `502` / `503` / `504` |
+| ------ | ----- | ----------------------------- |
+| `GET`, `PUT`, `DELETE` | retried | retried (idempotent — replay converges) |
+| `POST` | retried | **not** retried; the exception is raised |
+
+Without this, a `504` on a `POST` could duplicate a record that Business Central had already
+created. If your endpoint deduplicates server-side, or duplicates are acceptable, opt back
+in with `options.Retry.RetryPostOnTransientFailures = true`.
+
 # ⚠️ Errors
 
 All failures derive from `BusinessCentralException`. `Message` is a single line suitable

--- a/src/Dynamics365.BusinessCentral/README.md
+++ b/src/Dynamics365.BusinessCentral/README.md
@@ -3,12 +3,14 @@
 
 # ✨ Features
 
-- Typed OData querying with fluent filter composition
-- Built-in OAuth2 client credentials authentication
-- Automatic token caching and refresh
-- Fluent paging, ordering and selection helpers
+- Strongly-typed queries — field names come from your entity, not from strings
+- Built-in OAuth2 client credentials authentication, with a shared token cache
+- Automatic retry of throttled (`429`) and transient failures, honouring `Retry-After`
+- Streaming and automatic paging, including server-driven `@odata.nextLink`
+- Filtering, ordering, projection, expansion and counting
+- Multi-company support from a single registration
 - Clean DI integration
-- No runtime dependencies beyond HttpClient and System.Text.Json
+- No runtime dependencies beyond `HttpClient` and `System.Text.Json`
 
 # 📦 Installation
 
@@ -16,111 +18,245 @@
 dotnet add package Dynamics365.BusinessCentral
 ```
 
-# 🧩 Dependency Injection
+# 🧩 Setup
+
+Only four settings are required. `BaseUrl` and `TokenEndpoint` default to the Business
+Central SaaS endpoints and understand the `{tenant}` and `{environment}` placeholders.
 
 ```csharp
 services.AddBusinessCentral(options =>
 {
-    options.TenantId = "your-tenant-id";
-    options.ClientId = "your-client-id";
+    options.TenantId     = "your-tenant-id";
+    options.ClientId     = "your-client-id";
     options.ClientSecret = "your-client-secret";
-    options.Company = "CRONUS AG";
-    options.BaseUrl = "https://api.businesscentral.dynamics.com/v2.0/{tenant}/Production/ODataV4";
-    options.TokenEndpoint = "https://login.microsoftonline.com/{TenantId}/oauth2/v2.0/token";
-    options.Scope = "https://api.businesscentral.dynamics.com/.default";
+    options.Company      = "CRONUS AG";
+
+    // Optional — defaults to "Production"
+    options.Environment  = "Sandbox";
 });
+```
 
-public class MyService
+Or bind from configuration:
+
+```csharp
+services.AddBusinessCentral(builder.Configuration.GetSection("BusinessCentral"));
+```
+
+```json
 {
-    private readonly IBusinessCentralClient _client;
+  "BusinessCentral": {
+    "TenantId": "...",
+    "ClientId": "...",
+    "ClientSecret": "...",
+    "Company": "CRONUS AG",
+    "Environment": "Production",
+    "Retry": { "MaxAttempts": 3 }
+  }
+}
+```
 
-    public MyService(IBusinessCentralClient client)
-    {
-        _client = client;
-    }
+Then inject `IBusinessCentralClient`:
+
+```csharp
+public class MyService(IBusinessCentralClient client)
+{
+    public Task<List<SalesOrder>> GetOpenOrders() =>
+        client.Query<SalesOrder>()
+              .Where(Filter.Equals<SalesOrder>(o => o.Status, "Open"))
+              .ToListAsync();
+}
+```
+
+Point an entity at its OData entity set once, and stop repeating the path:
+
+```csharp
+[BusinessCentralEntity("salesOrders")]
+public sealed class SalesOrder
+{
+    public string No { get; set; } = "";
+    public string Status { get; set; } = "";
+    public decimal Amount { get; set; }
 }
 ```
 
 # 🔍 Querying
 
-Simple Query
+`Query<T>()` is the recommended entry point. Field names come from property selectors, so
+they survive renames and always match how the entity is deserialized.
+
 ```csharp
-var orders = await client.QueryAsync<Order>("salesOrders");
+var orders = await client.Query<SalesOrder>()
+    .Where(Filter.Equals<SalesOrder>(o => o.Status, "Open"))
+    .Where(Filter.GreaterThan<SalesOrder>(o => o.Amount, 100))
+    .OrderByDescending(o => o.Amount)
+    .ThenBy(o => o.No)
+    .Select(o => o.No, o => o.Amount)
+    .Top(50)
+    .ToListAsync();
 ```
 
-With Filters
-```csharp
-var filter =
-    Filter.Equals("Status", "Open")
-          .And(Filter.GreaterThan("Amount", 100));
+| Operation | Method |
+| --------- | ------ |
+| One page | `ToListAsync()` |
+| Everything, auto-paged | `ToAllAsync()` |
+| Everything, lazily | `StreamAsync()` |
+| Page plus total | `ToPageAsync()` |
+| Single row | `FirstOrDefaultAsync()` |
+| Count only | `CountAsync()` |
 
-var orders = await client.QueryAsync<Order>("salesOrders", filter);
+## Streaming
+
+`StreamAsync` fetches pages as you consume them and stops fetching when you stop reading —
+prefer it over `ToAllAsync` for large sets.
+
+```csharp
+await foreach (var order in client.Query<SalesOrder>().PageSize(500).StreamAsync())
+{
+    if (Process(order) is Done) break;   // no further pages are requested
+}
 ```
 
-Paging and Ordering
+## Counting and paging
+
 ```csharp
-var orders = await client.QueryAsync<Order>(
-    "salesOrders",
-    Filter.Equals("Status", "Open"),
-    o => o.WithTop(100).OrderByAsc("No"));
+var page = await client.Query<SalesOrder>().Top(50).ToPageAsync();
+
+Console.WriteLine($"{page.Items.Count} of {page.TotalCount}");
+
+var total = await client.Query<SalesOrder>()
+    .Where(Filter.Equals<SalesOrder>(o => o.Status, "Open"))
+    .CountAsync();
 ```
 
-Query All
+## Expanding
+
 ```csharp
-var allOrders = await client.QueryAllAsync<Order>("salesOrders");
+var orders = await client.Query<SalesOrder>()
+    .Expand(o => o.Lines)
+    .ToListAsync();
+
+// Raw OData expand syntax also works
+var withNested = await client.Query<SalesOrder>()
+    .Expand("salesOrderLines($select=lineNo,amount)")
+    .ToListAsync();
 ```
 
-Raw Query
+## Path-based access
+
+The lower-level API remains available when you do not want an annotated type.
+
 ```csharp
-var raw = await client.QueryRawAsync<JsonElement>("salesOrders?$top=5");
+var orders = await client.QueryAsync<SalesOrder>("salesOrders", Filter.Equals("status", "Open"));
+var all    = await client.QueryAllAsync<SalesOrder>("salesOrders");
+var raw    = await client.QueryRawAsync<JsonElement>("salesOrders?$top=5");
+
+await foreach (var o in client.QueryStreamAsync<SalesOrder>("salesOrders")) { }
 ```
 
-Patch
+# ✏️ Writing
+
 ```csharp
-await client.PatchAsync(
-    "salesOrders",
-    "No='1000'",
-    new { Status = "Released" });
+await client.PostAsync("salesOrders", new SalesOrder { No = "1000" });
+
+await client.PatchAsync("salesOrders", "No='1000'", new { Status = "Released" });
+
+await client.PutAsync("salesOrders", systemId, order, ifMatch: etag);
+
+await client.DeleteAsync("salesOrders", systemId);
+```
+
+Writes send `Prefer: return=representation`. If the server answers `204 No Content`, the
+payload you sent is returned instead of throwing. Keys may be a `systemId` or an alternate
+key such as `No='1000'`.
+
+# 🏢 Multiple companies
+
+One registration serves every company in the tenant. `ForCompany` shares the underlying
+HTTP client and token cache, so it costs nothing.
+
+```csharp
+foreach (var company in await client.GetCompaniesAsync())
+{
+    var scoped = client.ForCompany(company.Name);
+    var orders = await scoped.Query<SalesOrder>().ToAllAsync();
+}
 ```
 
 # 🧪 Filters
 
-| Method                  | Expression                |
-| ----------------------- | ------------------------- |
-| `Filter.Equals`         | `field eq value`          |
-| `Filter.NotEquals`      | `field ne value`          |
-| `Filter.GreaterThan`    | `field gt value`          |
-| `Filter.GreaterOrEqual` | `field ge value`          |
-| `Filter.LessThan`       | `field lt value`          |
-| `Filter.LessOrEqual`    | `field le value`          |
-| `Filter.Contains`       | `contains(field,value)`   |
-| `Filter.StartsWith`     | `startswith(field,value)` |
-| `Filter.EndsWith`       | `endswith(field,value)`   |
-| `Filter.In`             | `field in (...)`          |
-| `Filter.IsNull`         | `field eq null`           |
-| `Filter.IsNotNull`      | `field ne null`           |
+Every method has a string overload and a typed overload.
 
-# Example
+| Method | Expression |
+| ------ | ---------- |
+| `Filter.Equals` | `field eq value` |
+| `Filter.NotEquals` | `field ne value` |
+| `Filter.GreaterThan` | `field gt value` |
+| `Filter.GreaterOrEqual` | `field ge value` |
+| `Filter.LessThan` | `field lt value` |
+| `Filter.LessOrEqual` | `field le value` |
+| `Filter.Contains` | `contains(field,value)` |
+| `Filter.StartsWith` | `startswith(field,value)` |
+| `Filter.EndsWith` | `endswith(field,value)` |
+| `Filter.In` | `field in (...)` |
+| `Filter.IsNull` | `field eq null` |
+| `Filter.IsNotNull` | `field ne null` |
+
+Combine with `.And(...)`, `.Or(...)` and `.Not()`:
+
 ```csharp
-public static class SmokeTestEndpoints
+var filter = Filter.Equals<SalesOrder>(o => o.Status, "Open")
+                   .And(Filter.GreaterThan<SalesOrder>(o => o.Amount, 100));
+```
+
+`Filter.In` with an empty collection yields a filter matching nothing, rather than the
+invalid OData expression `field in ()`.
+
+# ♻️ Throttling and retries
+
+Business Central throttles aggressively. Throttled (`429`) and transient (`408`, `502`,
+`503`, `504`) responses are retried automatically, honouring `Retry-After` when present.
+
+```csharp
+services.AddBusinessCentral(options =>
 {
-    public static void MapSmokeTests(this WebApplication app)
-    {
-        app.MapGet("/bc/orders", async (IBusinessCentralClient client) =>
-        {
-            var orders = await client.QueryAsync<dynamic>(
-                "LDATProductionOrd1er",
-                Filter.Equals("Status", "Released"),
-                o => o.WithTop(5));
+    options.Retry.MaxAttempts = 5;
+    options.Retry.BaseDelay   = TimeSpan.FromSeconds(2);
+    options.Retry.MaxDelay    = TimeSpan.FromSeconds(30);
+    // options.Retry.Enabled  = false;   // surface transient failures immediately
+});
+```
 
-            return Results.Ok(orders);
-        });
+# ⚠️ Errors
 
-        app.MapGet("/bc/orders/all", async (IBusinessCentralClient client) =>
-        {
-            var orders = await client.QueryAllAsync<dynamic>("salesOrders");
-            return Results.Ok(orders.Count);
-        });
-    }
+All failures derive from `BusinessCentralException`. `Message` is a single line suitable
+for logging; the detail lives on properties, and `ToString()` renders everything.
+
+| Type | When |
+| ---- | ---- |
+| `BusinessCentralValidationException` | `400` |
+| `BusinessCentralAuthException` | `401`, `403` |
+| `BusinessCentralNotFoundException` | `404` |
+| `BusinessCentralThrottledException` | `429` |
+| `BusinessCentralServerException` | everything else, and deserialization failures |
+
+```csharp
+catch (BusinessCentralException ex)
+{
+    logger.LogError(ex, "BC call failed: {Code} {CorrelationId}",
+        ex.ODataErrorCode, ex.CorrelationId);
+
+    if (ex.IsTransient) { /* safe to try again */ }
 }
 ```
+
+# 📊 Diagnostics
+
+There is no logging dependency. Implement `IBusinessCentralObserver` to hook requests,
+retries and the token lifecycle:
+
+```csharp
+services.AddObserver<MyObserver>();
+```
+
+Every member except the core request callbacks has a default implementation, so you only
+override what you care about.

--- a/src/Dynamics365.BusinessCentral/README.md
+++ b/src/Dynamics365.BusinessCentral/README.md
@@ -12,6 +12,8 @@
 - Clean DI integration
 - No runtime dependencies beyond `HttpClient` and `System.Text.Json`
 
+Upgrading from 1.x? See the migration guide: https://github.com/kraldev/Dynamics365-BusinessCentral/blob/master/MIGRATION.md
+
 # 📦 Installation
 
 ```bash
@@ -168,6 +170,24 @@ await client.DeleteAsync("salesOrders", systemId);
 Writes send `Prefer: return=representation`. If the server answers `204 No Content`, the
 payload you sent is returned instead of throwing. Keys may be a `systemId` or an alternate
 key such as `No='1000'`.
+
+When the response type differs from the payload — posting an anonymous object and reading
+back an entity — use the two-generic overloads instead of `dynamic`:
+
+```csharp
+var created = await client.PostAsync<object, CreatedRow>(
+    "ldatSummary",
+    new { serialNo = "S1", productionOrderNo = "PO1" });
+
+// null means BC applied the write but returned no representation. Failures throw.
+if (created is null) { /* handle "created but not echoed" */ }
+```
+
+`TResult` is unconstrained, so `JsonElement` works when you have no model:
+
+```csharp
+var element = await client.PostAsync<object, JsonElement>("ldatSummary", payload);
+```
 
 # 🏢 Multiple companies
 

--- a/src/Dynamics365.BusinessCentral/README.md
+++ b/src/Dynamics365.BusinessCentral/README.md
@@ -12,7 +12,7 @@
 - Clean DI integration
 - No runtime dependencies beyond `HttpClient` and `System.Text.Json`
 
-Upgrading from 1.x? See the migration guide: https://github.com/kraldev/Dynamics365-BusinessCentral/blob/master/MIGRATION.md
+Upgrading from 1.x? See the [migration guide](https://github.com/KralGmbh/Dynamics365-BusinessCentral/blob/master/MIGRATION.md). Full history in the [changelog](https://github.com/KralGmbh/Dynamics365-BusinessCentral/blob/master/CHANGELOG.md).
 
 # 📦 Installation
 

--- a/src/Dynamics365.BusinessCentral/ServiceCollectionExtensions.cs
+++ b/src/Dynamics365.BusinessCentral/ServiceCollectionExtensions.cs
@@ -1,15 +1,20 @@
-﻿using Dynamics365.BusinessCentral.Client;
+using Dynamics365.BusinessCentral.Client;
 using Dynamics365.BusinessCentral.Diagnostics;
 using Dynamics365.BusinessCentral.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Options;
 
 namespace Dynamics365.BusinessCentral;
 
-[ExcludeFromCodeCoverage]
 public static class ServiceCollectionExtensions
 {
+    /// <summary>Name of the internal HttpClient used for token acquisition.</summary>
+    internal const string TokenHttpClientName = "Dynamics365.BusinessCentral.Token";
+
+    /// <summary>Name of the HttpClient used for data requests.</summary>
+    internal const string ClientHttpClientName = "Dynamics365.BusinessCentral.Client";
+
     public static IServiceCollection AddBusinessCentral(
         this IServiceCollection services,
         Action<BusinessCentralOptions> configure)
@@ -17,10 +22,29 @@ public static class ServiceCollectionExtensions
         services
             .AddOptions<BusinessCentralOptions>()
             .Configure(configure)
-            .Validate(ValidateOption, "BusinessCentralOptions contain invalid configuration.")
             .ValidateOnStart();
 
-        services.AddHttpClient<IBusinessCentralClient, BusinessCentralClient>();
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<BusinessCentralOptions>, BusinessCentralOptionsValidator>());
+
+        services.AddHttpClient(TokenHttpClientName);
+
+        // Singleton so the access-token cache is shared. Typed HTTP clients are registered
+        // as transient, so a per-client cache would re-authenticate on every injection.
+        services.TryAddSingleton(sp => new BusinessCentralTokenProvider(
+            sp.GetRequiredService<IHttpClientFactory>().CreateClient(TokenHttpClientName),
+            sp.GetRequiredService<IOptions<BusinessCentralOptions>>(),
+            sp.GetService<IBusinessCentralObserver>()));
+
+        // Explicit factory rather than ActivatorUtilities: the constructor taking the
+        // token provider is internal and would otherwise not be selected.
+        services.AddHttpClient<IBusinessCentralClient, BusinessCentralClient>(
+            ClientHttpClientName,
+            (http, sp) => new BusinessCentralClient(
+                http,
+                sp.GetRequiredService<IOptions<BusinessCentralOptions>>(),
+                sp.GetRequiredService<BusinessCentralTokenProvider>(),
+                sp.GetService<IBusinessCentralObserver>()));
 
         return services;
     }
@@ -31,16 +55,5 @@ public static class ServiceCollectionExtensions
     {
         services.TryAddSingleton<IBusinessCentralObserver, TObserver>();
         return services;
-    }
-
-    private static bool ValidateOption(BusinessCentralOptions options)
-    {
-        return !string.IsNullOrWhiteSpace(options.TenantId)
-               && !string.IsNullOrWhiteSpace(options.ClientId)
-               && !string.IsNullOrWhiteSpace(options.ClientSecret)
-               && !string.IsNullOrWhiteSpace(options.BaseUrl)
-               && !string.IsNullOrWhiteSpace(options.Company)
-               && !string.IsNullOrWhiteSpace(options.Scope)
-               && !string.IsNullOrWhiteSpace(options.TokenEndpoint);
     }
 }

--- a/src/Dynamics365.BusinessCentral/ServiceCollectionExtensions.cs
+++ b/src/Dynamics365.BusinessCentral/ServiceCollectionExtensions.cs
@@ -1,12 +1,16 @@
 using Dynamics365.BusinessCentral.Client;
 using Dynamics365.BusinessCentral.Diagnostics;
 using Dynamics365.BusinessCentral.Options;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace Dynamics365.BusinessCentral;
 
+/// <summary>
+/// Registration helpers for the Business Central client.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
     /// <summary>Name of the internal HttpClient used for token acquisition.</summary>
@@ -15,15 +19,69 @@ public static class ServiceCollectionExtensions
     /// <summary>Name of the HttpClient used for data requests.</summary>
     internal const string ClientHttpClientName = "Dynamics365.BusinessCentral.Client";
 
+    /// <summary>
+    /// Registers <see cref="IBusinessCentralClient"/> configured in code.
+    /// </summary>
+    /// <param name="services">Service collection to add to.</param>
+    /// <param name="configure">Callback that populates <see cref="BusinessCentralOptions"/>.</param>
+    /// <example>
+    /// <code>
+    /// services.AddBusinessCentral(o =>
+    /// {
+    ///     o.TenantId     = "...";
+    ///     o.ClientId     = "...";
+    ///     o.ClientSecret = "...";
+    ///     o.Company      = "CRONUS AG";
+    /// });
+    /// </code>
+    /// </example>
     public static IServiceCollection AddBusinessCentral(
         this IServiceCollection services,
         Action<BusinessCentralOptions> configure)
     {
+        ArgumentNullException.ThrowIfNull(configure);
+
         services
             .AddOptions<BusinessCentralOptions>()
             .Configure(configure)
             .ValidateOnStart();
 
+        return AddBusinessCentralCore(services);
+    }
+
+    /// <summary>
+    /// Registers <see cref="IBusinessCentralClient"/> bound to a configuration section.
+    /// </summary>
+    /// <param name="services">Service collection to add to.</param>
+    /// <param name="configuration">
+    /// Section holding the settings, e.g. <c>configuration.GetSection("BusinessCentral")</c>.
+    /// </param>
+    /// <param name="configure">Optional callback applied after binding, to override values in code.</param>
+    /// <example>
+    /// <code>
+    /// services.AddBusinessCentral(builder.Configuration.GetSection("BusinessCentral"));
+    /// </code>
+    /// </example>
+    public static IServiceCollection AddBusinessCentral(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        Action<BusinessCentralOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var builder = services
+            .AddOptions<BusinessCentralOptions>()
+            .Bind(configuration)
+            .ValidateOnStart();
+
+        if (configure != null)
+            builder.Configure(configure);
+
+        return AddBusinessCentralCore(services);
+    }
+
+    private static IServiceCollection AddBusinessCentralCore(IServiceCollection services)
+    {
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IValidateOptions<BusinessCentralOptions>, BusinessCentralOptionsValidator>());
 
@@ -49,6 +107,12 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    /// <summary>
+    /// Registers a diagnostics observer. Call after <c>AddBusinessCentral</c>, or before —
+    /// resolution order does not matter.
+    /// </summary>
+    /// <typeparam name="TObserver">Observer implementation.</typeparam>
+    /// <param name="services">Service collection to add to.</param>
     public static IServiceCollection AddObserver<TObserver>(
         this IServiceCollection services)
         where TObserver : class, IBusinessCentralObserver

--- a/test/Dynamics365.BusinessCentral.Tests/ClientTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ClientTests.cs
@@ -1665,10 +1665,45 @@ public partial class ClientTests
         var ex = await Assert.ThrowsAsync<BusinessCentralValidationException>(() =>
             client.QueryAsync<TestEntity>("orders", "true"));
 
-        // Assert
+        // Assert — Message stays a single line; the structured detail lives on properties.
         Assert.Contains("Resource not found", ex.Message);
-        Assert.Contains("BadRequest_ResourceNotFound", ex.Message);
-        Assert.Contains("953b8867-cd45-4516-becf-e22d63f7f98c", ex.Message);
+        Assert.DoesNotContain(System.Environment.NewLine, ex.Message);
+
+        Assert.Equal("BadRequest_ResourceNotFound", ex.ODataErrorCode);
+        Assert.Equal("953b8867-cd45-4516-becf-e22d63f7f98c", ex.CorrelationId);
+
+        // ToString() is where everything shows up.
+        var detailed = ex.ToString();
+        Assert.Contains("BadRequest_ResourceNotFound", detailed);
+        Assert.Contains("953b8867-cd45-4516-becf-e22d63f7f98c", detailed);
+        Assert.Contains(bcError.Trim(), detailed);
+    }
+
+    [Fact]
+    public async Task Exception_Message_Stays_A_Single_Line()
+    {
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                };
+
+            return new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent(new string('x', 5000))
+            };
+        });
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralServerException>(() =>
+            client.QueryAsync<TestEntity>("orders", "true"));
+
+        // A 5 KB body must not end up in the log line.
+        Assert.DoesNotContain("xxxx", ex.Message);
+        Assert.Contains("GET", ex.Message);
+        Assert.Contains("500", ex.Message);
+        Assert.Contains("xxxx", ex.ResponseBody);
     }
 
     [Fact]

--- a/test/Dynamics365.BusinessCentral.Tests/ClientTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ClientTests.cs
@@ -258,11 +258,91 @@ public partial class ClientTests
 
         var payload = new TestPatchEntity { Id = "abc 123", Name = "Test" };
 
-        await Assert.ThrowsAsync<BusinessCentralServerException>(() =>
-            client.PatchAsync("orders", "abc 123", payload));
+        var result = await client.PatchAsync("orders", "abc 123", payload);
 
         Assert.NotNull(capturedUrl);
         Assert.Contains("abc%20123", capturedUrl);
+
+        // 204 NoContent is a successful write; the sent payload is echoed back.
+        Assert.Same(payload, result);
+    }
+
+    [Fact]
+    public async Task PatchAsync_Preserves_Alternate_Key_Syntax()
+    {
+        string? capturedUrl = null;
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                };
+
+            capturedUrl = req.RequestUri!.AbsoluteUri;
+
+            return new HttpResponseMessage(HttpStatusCode.NoContent);
+        });
+
+        await client.PatchAsync("salesOrders", "No='1000'", new TestPatchEntity { Id = "1", Name = "x" });
+
+        Assert.NotNull(capturedUrl);
+
+        // Quotes and '=' are OData key syntax and must survive verbatim.
+        Assert.Contains("salesOrders(No='1000')", capturedUrl);
+        Assert.DoesNotContain("%27", capturedUrl);
+        Assert.DoesNotContain("%3D", capturedUrl);
+    }
+
+    [Fact]
+    public async Task Writes_Ask_For_Return_Representation()
+    {
+        HttpRequestMessage? captured = null;
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                };
+
+            captured = req;
+
+            return new HttpResponseMessage(HttpStatusCode.NoContent);
+        });
+
+        await client.PostAsync("orders", new TestPatchEntity { Id = "1", Name = "x" });
+
+        Assert.NotNull(captured);
+        Assert.Contains("return=representation", captured!.Headers.GetValues("Prefer"));
+    }
+
+    [Fact]
+    public async Task Writes_Return_Payload_On_Empty_Body()
+    {
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                };
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("")
+            };
+        });
+
+        var payload = new TestPatchEntity { Id = "1", Name = "x" };
+
+        var posted = await client.PostAsync("orders", payload);
+        var put = await client.PutAsync("orders", "1", payload);
+
+        Assert.Same(payload, posted);
+        Assert.Same(payload, put);
     }
 
     [Fact]
@@ -311,8 +391,7 @@ public partial class ClientTests
 
         var payload = new TestPatchEntity { Id = "test-id", Name = "Updated" };
 
-        await Assert.ThrowsAsync<BusinessCentralServerException>(() =>
-            client.PatchAsync("orders", "test-id", payload));
+        await client.PatchAsync("orders", "test-id", payload);
 
         Assert.NotNull(capturedBody);
 
@@ -1752,6 +1831,257 @@ public partial class ClientTests
             client.DeleteAsync("orders", "1"));
     }
 
+
+    #region Raw URL Tests
+
+    [Fact]
+    public async Task QueryRawAsync_Preserves_Query_String()
+    {
+        string? capturedUrl = null;
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                };
+
+            capturedUrl = req.RequestUri!.AbsoluteUri;
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"id\":1,\"name\":\"x\"}")
+            };
+        });
+
+        await client.QueryRawAsync<TestRawResponse>("salesOrders?$top=5");
+
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("salesOrders?$top=5", capturedUrl);
+        Assert.DoesNotContain("%3F", capturedUrl);
+        Assert.DoesNotContain("%24", capturedUrl);
+    }
+
+    [Fact]
+    public async Task QueryRawAsync_Preserves_Path_Separators()
+    {
+        string? capturedUrl = null;
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                };
+
+            capturedUrl = req.RequestUri!.AbsoluteUri;
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"id\":1,\"name\":\"x\"}")
+            };
+        });
+
+        await client.QueryRawAsync<TestRawResponse>("orders/raw");
+
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("orders/raw", capturedUrl);
+        Assert.DoesNotContain("%2F", capturedUrl);
+    }
+
+    [Fact]
+    public async Task Query_Preserves_Navigation_Path_But_Encodes_Spaces()
+    {
+        string? capturedUrl = null;
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                };
+
+            capturedUrl = req.RequestUri!.AbsoluteUri;
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"value\":[]}")
+            };
+        });
+
+        await client.QueryAsync<TestEntity>("salesOrders/Sales Lines", "true");
+
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("salesOrders/Sales%20Lines", capturedUrl);
+    }
+
+    #endregion
+
+    #region Server-Driven Paging Tests
+
+    [Fact]
+    public async Task QueryAll_Follows_ODataNextLink()
+    {
+        var urls = new List<string>();
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                };
+
+            urls.Add(req.RequestUri!.AbsoluteUri);
+
+            // First page is short *and* carries a nextLink — the old "short page means
+            // done" rule would have truncated the result here.
+            var body = urls.Count == 1
+                ? "{\"value\":[{\"id\":1}],\"@odata.nextLink\":\"https://test/page2\"}"
+                : "{\"value\":[{\"id\":2}]}";
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body)
+            };
+        });
+
+        var result = await client.QueryAllAsync<TestEntity>("orders");
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(2, urls.Count);
+        Assert.Equal("https://test/page2", urls[1]);
+    }
+
+    [Fact]
+    public async Task QueryAll_Stops_On_Short_Page_Without_NextLink()
+    {
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                };
+
+            dataCalls++;
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"value\":[{\"id\":1},{\"id\":2}]}")
+            };
+        });
+
+        var result = await client.QueryAllAsync<TestEntity>("orders", options: o => o.WithTop(10));
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1, dataCalls);
+    }
+
+    [Fact]
+    public async Task QueryAll_Pages_Until_Short_Page()
+    {
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                };
+
+            dataCalls++;
+
+            // Two full pages of 2, then a short page.
+            var body = dataCalls <= 2
+                ? "{\"value\":[{\"id\":1},{\"id\":2}]}"
+                : "{\"value\":[{\"id\":3}]}";
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body)
+            };
+        });
+
+        var result = await client.QueryAllAsync<TestEntity>("orders", options: o => o.WithTop(2));
+
+        Assert.Equal(5, result.Count);
+        Assert.Equal(3, dataCalls);
+    }
+
+    #endregion
+
+    #region Observer Reporting Tests
+
+    [Fact]
+    public async Task Failed_Request_Is_Reported_To_Observer_Exactly_Once()
+    {
+        var observer = new TestObserver();
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                };
+
+            return new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("{\"error\":{\"code\":\"Bad\",\"message\":\"nope\"}}")
+            };
+        }, observer);
+
+        await Assert.ThrowsAsync<BusinessCentralValidationException>(() =>
+            client.QueryAsync<TestEntity>("orders", "true"));
+
+        Assert.Single(observer.Failures);
+        Assert.Equal(400, observer.Failures[0].StatusCode);
+        Assert.Contains("nope", observer.Failures[0].ResponseBody);
+    }
+
+    [Fact]
+    public async Task Unauthorized_Retry_Reports_One_Failure_Then_Success()
+    {
+        var observer = new TestObserver();
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                };
+
+            dataCalls++;
+
+            if (dataCalls == 1)
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Content = new StringContent("unauthorized")
+                };
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"value\":[]}")
+            };
+        }, observer);
+
+        await client.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.Single(observer.Failures);
+        Assert.Equal(401, observer.Failures[0].StatusCode);
+        Assert.Contains("success:200", observer.Events);
+    }
+
+    #endregion
 
     #region Test Helper Classes
 

--- a/test/Dynamics365.BusinessCentral.Tests/ClientTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ClientTests.cs
@@ -1869,6 +1869,32 @@ public partial class ClientTests
 
     #region Raw URL Tests
 
+    // The README has documented QueryRawAsync<JsonElement> since 1.0, but the old
+    // `where TResponse : class` constraint meant it never compiled for consumers.
+    [Fact]
+    public async Task QueryRawAsync_Accepts_A_Value_Type_Response()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            TestBase.Json("{\"value\":[{\"no\":\"1000\"}]}")));
+
+        var raw = await client.QueryRawAsync<JsonElement>("salesOrders?$top=5");
+
+        Assert.Equal(JsonValueKind.Object, raw.ValueKind);
+        Assert.Equal("1000", raw.GetProperty("value")[0].GetProperty("no").GetString());
+    }
+
+    [Fact]
+    public async Task QueryRawAsync_Still_Accepts_Reference_Types()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            TestBase.Json("{\"id\":7,\"name\":\"Seven\"}")));
+
+        var typed = await client.QueryRawAsync<TestRawResponse>("orders/raw");
+
+        Assert.Equal(7, typed.Id);
+    }
+
+
     [Fact]
     public async Task QueryRawAsync_Preserves_Query_String()
     {

--- a/test/Dynamics365.BusinessCentral.Tests/Dynamics365.BusinessCentral.Tests.csproj
+++ b/test/Dynamics365.BusinessCentral.Tests/Dynamics365.BusinessCentral.Tests.csproj
@@ -17,6 +17,17 @@
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
     </ItemGroup>
 
+    <!-- Match the library's per-TFM dependency majors to avoid NU1605 downgrades. -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    </ItemGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\..\src\Dynamics365.BusinessCentral\Dynamics365.BusinessCentral.csproj" />
     </ItemGroup>

--- a/test/Dynamics365.BusinessCentral.Tests/OptionsTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/OptionsTests.cs
@@ -1,0 +1,207 @@
+using Dynamics365.BusinessCentral.Client;
+using Dynamics365.BusinessCentral.Options;
+using Dynamics365.BusinessCentral.Tests.Utils;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System.Net;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+public class OptionsTests
+{
+    [Fact]
+    public void Defaults_Require_Only_Four_Settings()
+    {
+        var options = new BusinessCentralOptions
+        {
+            TenantId = "11111111-2222-3333-4444-555555555555",
+            ClientId = "client",
+            ClientSecret = "secret",
+            Company = "CRONUS AG"
+        };
+
+        Assert.Equal(
+            "https://api.businesscentral.dynamics.com/v2.0/11111111-2222-3333-4444-555555555555/Production/ODataV4",
+            options.ResolvedBaseUrl);
+
+        Assert.Equal(
+            "https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/oauth2/v2.0/token",
+            options.ResolvedTokenEndpoint);
+    }
+
+    [Fact]
+    public void Environment_Placeholder_Is_Substituted()
+    {
+        var options = new BusinessCentralOptions
+        {
+            TenantId = "tenant",
+            Environment = "Sandbox",
+            ClientId = "c",
+            ClientSecret = "s",
+            Company = "Test"
+        };
+
+        Assert.Contains("/tenant/Sandbox/ODataV4", options.ResolvedBaseUrl);
+    }
+
+    [Fact]
+    public void Legacy_TenantId_Placeholder_Still_Works()
+    {
+        var options = new BusinessCentralOptions
+        {
+            TenantId = "tenant",
+            ClientId = "c",
+            ClientSecret = "s",
+            Company = "Test",
+            TokenEndpoint = "https://login.microsoftonline.com/{TenantId}/oauth2/v2.0/token"
+        };
+
+        Assert.Equal("https://login.microsoftonline.com/tenant/oauth2/v2.0/token", options.ResolvedTokenEndpoint);
+    }
+
+    [Fact]
+    public async Task BaseUrl_Placeholder_Reaches_The_Wire()
+    {
+        string? capturedUrl = null;
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(req =>
+            {
+                capturedUrl = req.RequestUri!.AbsoluteUri;
+                return TestBase.Json("{\"value\":[]}");
+            }),
+            configure: o =>
+            {
+                o.TenantId = "abc-123";
+                o.Environment = "UAT";
+                o.BaseUrl = "https://api.businesscentral.dynamics.com/v2.0/{tenant}/{environment}/ODataV4";
+            });
+
+        await client.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("/v2.0/abc-123/UAT/ODataV4/", capturedUrl);
+        Assert.DoesNotContain("%7B", capturedUrl);
+        Assert.DoesNotContain("{", capturedUrl);
+    }
+
+    [Fact]
+    public void Unsubstituted_Placeholder_Fails_Validation_With_A_Clear_Message()
+    {
+        var services = new ServiceCollection();
+
+        services.AddBusinessCentral(o =>
+        {
+            o.TenantId = "tenant";
+            o.ClientId = "client";
+            o.ClientSecret = "secret";
+            o.Company = "Test";
+            o.BaseUrl = "https://api.businesscentral.dynamics.com/v2.0/{unknown}/ODataV4";
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        var ex = Assert.Throws<OptionsValidationException>(() =>
+            provider.GetRequiredService<IOptions<BusinessCentralOptions>>().Value);
+
+        var message = string.Join(" | ", ex.Failures);
+
+        Assert.Contains("unsubstituted placeholder", message);
+        Assert.Contains("{tenant}", message);
+    }
+
+    [Fact]
+    public async Task Client_Can_Be_Bound_From_Configuration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["BusinessCentral:TenantId"] = "tenant",
+                ["BusinessCentral:ClientId"] = "client",
+                ["BusinessCentral:ClientSecret"] = "secret",
+                ["BusinessCentral:Company"] = "CRONUS AG",
+                ["BusinessCentral:Environment"] = "Sandbox",
+                ["BusinessCentral:Retry:MaxAttempts"] = "7"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+
+        services.AddBusinessCentral(configuration.GetSection("BusinessCentral"));
+
+        var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<BusinessCentralOptions>>().Value;
+
+        Assert.Equal("CRONUS AG", options.Company);
+        Assert.Equal("Sandbox", options.Environment);
+        Assert.Equal(7, options.Retry.MaxAttempts);
+        Assert.Contains("/tenant/Sandbox/", options.ResolvedBaseUrl);
+
+        var client = provider.GetRequiredService<IBusinessCentralClient>();
+
+        Assert.Equal("CRONUS AG", client.Company);
+
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public void Configuration_Overload_Accepts_A_Code_Override()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["TenantId"] = "tenant",
+                ["ClientId"] = "client",
+                ["ClientSecret"] = "from-config",
+                ["Company"] = "Test"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+
+        services.AddBusinessCentral(configuration, o => o.ClientSecret = "from-code");
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<BusinessCentralOptions>>().Value;
+
+        Assert.Equal("from-code", options.ClientSecret);
+        Assert.Equal("tenant", options.TenantId);
+    }
+
+    [Fact]
+    public async Task Token_Endpoint_Uses_The_Resolved_Placeholder()
+    {
+        string? tokenUrl = null;
+
+        var client = TestBase.CreateClient(
+            req =>
+            {
+                if (req.RequestUri!.AbsoluteUri.Contains("login") || req.RequestUri!.AbsoluteUri.Contains("auth"))
+                {
+                    tokenUrl = req.RequestUri!.AbsoluteUri;
+                    return TestBase.Json("{\"access_token\":\"abc\",\"expires_in\":3600}");
+                }
+
+                return TestBase.Json("{\"value\":[]}");
+            },
+            configure: o =>
+            {
+                o.TenantId = "my-tenant";
+                o.TokenEndpoint = "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token";
+            });
+
+        await client.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.Equal("https://login.microsoftonline.com/my-tenant/oauth2/v2.0/token", tokenUrl);
+    }
+
+    [Fact]
+    public void Filter_In_With_Empty_Collection_Is_Valid_OData()
+    {
+        Assert.Equal("false", Dynamics365.BusinessCentral.OData.Filter.In("id").Value);
+        Assert.Equal("false", Dynamics365.BusinessCentral.OData.Filter.In("id", Array.Empty<object>()).Value);
+        Assert.Equal("id in ('a','b')", Dynamics365.BusinessCentral.OData.Filter.In("id", "a", "b").Value);
+    }
+}

--- a/test/Dynamics365.BusinessCentral.Tests/OptionsTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/OptionsTests.cs
@@ -108,7 +108,12 @@ public class OptionsTests
         var message = string.Join(" | ", ex.Failures);
 
         Assert.Contains("unsubstituted placeholder", message);
+
+        // The message must list every placeholder ResolvePlaceholders actually handles,
+        // including the historical {TenantId}, or it sends users the wrong way.
         Assert.Contains("{tenant}", message);
+        Assert.Contains("{TenantId}", message);
+        Assert.Contains("{environment}", message);
     }
 
     [Fact]

--- a/test/Dynamics365.BusinessCentral.Tests/PagingGuardTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/PagingGuardTests.cs
@@ -1,0 +1,227 @@
+using Dynamics365.BusinessCentral.Client;
+using Dynamics365.BusinessCentral.OData;
+using Dynamics365.BusinessCentral.Tests.Utils;
+using System.Reflection;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+/// <summary>
+/// Regression cover for non-positive paging values, which previously produced a
+/// non-terminating paging loop: with a page size of zero the "short page" termination
+/// check (<c>inPage &lt; pageSize</c>) can never fire, so the same empty page is requested
+/// forever without <c>$skip</c> ever advancing.
+/// </summary>
+public class PagingGuardTests
+{
+    /// <summary>Fails fast rather than hanging the suite if a loop stops terminating.</summary>
+    private static (Dynamics365.BusinessCentral.Client.BusinessCentralClient Client, Func<int> Requests) Bounded(
+        int limit = 25)
+    {
+        var requests = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            if (++requests > limit)
+                throw new InvalidOperationException("Paging loop did not terminate.");
+
+            return TestBase.Json("{\"value\":[]}");
+        }));
+
+        return (client, () => requests);
+    }
+
+    #region Values are rejected at the boundary
+
+    [Fact]
+    public void PageSize_Must_Be_Positive()
+    {
+        var (client, _) = Bounded();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => client.Query<SalesOrder>().PageSize(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => client.Query<SalesOrder>().PageSize(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new QueryOptions().WithPageSize(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new QueryOptions().WithPageSize(-5));
+    }
+
+    [Fact]
+    public void Top_And_Skip_Must_Not_Be_Negative()
+    {
+        var (client, _) = Bounded();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => client.Query<SalesOrder>().Top(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => client.Query<SalesOrder>().Skip(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new QueryOptions().WithTop(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new QueryOptions().WithSkip(-1));
+    }
+
+    // $top=0 stays legal — it is how a count-only query is expressed.
+    [Fact]
+    public void Top_Zero_Is_Allowed()
+    {
+        var (client, _) = Bounded();
+
+        client.Query<SalesOrder>().Top(0);
+        new QueryOptions().WithTop(0);
+    }
+
+    #endregion
+
+    #region Zero-row requests terminate instead of looping
+
+    [Fact]
+    public async Task Fluent_Top_Zero_Returns_Empty_Without_Paging()
+    {
+        var (client, requests) = Bounded();
+
+        var result = await client.Query<SalesOrder>().Top(0).ToAllAsync();
+
+        Assert.Empty(result);
+        Assert.Equal(0, requests());
+    }
+
+    [Fact]
+    public async Task Fluent_Top_Zero_Stream_Terminates()
+    {
+        var (client, requests) = Bounded();
+
+        await foreach (var _ in client.Query<SalesOrder>().Top(0).StreamAsync())
+            Assert.Fail("no rows were requested");
+
+        Assert.Equal(0, requests());
+    }
+
+    [Fact]
+    public async Task Path_Based_Top_Zero_Returns_Empty_Without_Paging()
+    {
+        var (client, requests) = Bounded();
+
+        var result = await client.QueryAllAsync<TestEntity>("orders", options: o => o.WithTop(0));
+
+        Assert.Empty(result);
+        Assert.Equal(0, requests());
+    }
+
+    [Fact]
+    public async Task Path_Based_Stream_Top_Zero_Terminates()
+    {
+        var (client, requests) = Bounded();
+
+        await foreach (var _ in client.QueryStreamAsync<TestEntity>("orders", options: o => o.WithTop(0)))
+            Assert.Fail("no rows were requested");
+
+        Assert.Equal(0, requests());
+    }
+
+    // The internal setters bypass the public guards, so the loop keeps its own.
+    [Fact]
+    public async Task Non_Positive_Page_Size_Set_Internally_Still_Terminates()
+    {
+        var (client, requests) = Bounded();
+
+        var options = new QueryOptions();
+        typeof(QueryOptions).GetProperty(nameof(QueryOptions.PageSize))!
+            .SetValue(options, 0);
+
+        Assert.Equal(0, options.PageSize);
+
+        var result = await client.QueryAllAsync<TestEntity>(
+            "orders",
+            options: o => typeof(QueryOptions).GetProperty(nameof(QueryOptions.PageSize))!.SetValue(o, 0));
+
+        Assert.Empty(result);
+        Assert.Equal(0, requests());
+    }
+
+    #endregion
+
+    #region Normal paging is unaffected
+
+    [Fact]
+    public async Task Positive_Page_Size_Still_Pages()
+    {
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            dataCalls++;
+
+            return dataCalls <= 2
+                ? TestBase.Json("{\"value\":[{\"no\":\"a\"},{\"no\":\"b\"}]}")
+                : TestBase.Json("{\"value\":[{\"no\":\"c\"}]}");
+        }));
+
+        var all = await client.Query<SalesOrder>().PageSize(2).ToAllAsync();
+
+        Assert.Equal(5, all.Count);
+        Assert.Equal(3, dataCalls);
+    }
+
+    #endregion
+
+    #region Token lifetime and user agent
+
+    [Theory]
+    [InlineData(3600, 3540)]   // normal: full 60s margin
+    [InlineData(120, 60)]      // margin still fits
+    [InlineData(60, 30)]       // margin equals lifetime -> half
+    [InlineData(30, 15)]       // margin exceeds lifetime -> half
+    [InlineData(1, 0)]         // sub-second lifetimes floor to zero, never negative
+    [InlineData(0, 0)]
+    [InlineData(-1, 0)]
+    public void Token_Cache_Lifetime_Is_Never_Negative(int expiresIn, int expectedSeconds)
+    {
+        var lifetime = BusinessCentralTokenProvider.CacheLifetime(expiresIn);
+
+        Assert.True(lifetime >= TimeSpan.Zero, "cache lifetime must never be negative");
+        Assert.Equal(expectedSeconds, (int)lifetime.TotalSeconds);
+    }
+
+    [Fact]
+    public async Task Short_Lived_Token_Is_Still_Cached()
+    {
+        var tokenCalls = 0;
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+            {
+                tokenCalls++;
+                // 30s lifetime is shorter than the 60s margin; the token must not be
+                // treated as expired on arrival.
+                return TestBase.Json("{\"access_token\":\"abc\",\"expires_in\":30}");
+            }
+
+            return TestBase.Json("{\"value\":[]}");
+        });
+
+        await client.QueryAsync<TestEntity>("orders", "true");
+        await client.QueryAsync<TestEntity>("orders", "true");
+        await client.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.Equal(1, tokenCalls);
+    }
+
+    [Fact]
+    public async Task User_Agent_Reports_The_Assembly_Version()
+    {
+        string? userAgent = null;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
+        {
+            userAgent = req.Headers.UserAgent.ToString();
+            return TestBase.Json("{\"value\":[]}");
+        }));
+
+        await client.QueryAsync<TestEntity>("orders", "true");
+
+        var expected = typeof(IBusinessCentralClient).Assembly.GetName().Version!.ToString(3);
+
+        Assert.NotNull(userAgent);
+        Assert.Contains($"Dynamics365.BusinessCentral.Client/{expected}", userAgent);
+
+        // Guards against the version drifting out of the string again.
+        Assert.StartsWith("2.", expected);
+    }
+
+    #endregion
+}

--- a/test/Dynamics365.BusinessCentral.Tests/PagingGuardTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/PagingGuardTests.cs
@@ -2,6 +2,8 @@ using Dynamics365.BusinessCentral.Client;
 using Dynamics365.BusinessCentral.OData;
 using Dynamics365.BusinessCentral.Tests.Utils;
 using System.Reflection;
+using System.Net;
+using Dynamics365.BusinessCentral.Errors;
 
 namespace Dynamics365.BusinessCentral.Tests;
 
@@ -221,6 +223,60 @@ public class PagingGuardTests
 
         // Guards against the version drifting out of the string again.
         Assert.StartsWith("2.", expected);
+    }
+
+    [Fact]
+    public async Task Token_Response_Is_Disposed_After_Acquisition()
+    {
+        var disposed = false;
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new DisposeTrackingContent(
+                        "{\"access_token\":\"abc\",\"expires_in\":3600}",
+                        () => disposed = true)
+                };
+
+            return TestBase.Json("{\"value\":[]}");
+        });
+
+        await client.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.True(disposed, "the token response should be released once the token is read");
+    }
+
+    [Fact]
+    public async Task Delete_Error_Message_States_The_Real_Contract()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.Accepted) { Content = new StringContent("?") }));
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralServerException>(() =>
+            client.DeleteAsync("orders", "1"));
+
+        // 200 is accepted too, so the message must not claim 204 is the only success.
+        Assert.Contains("200", ex.Message);
+        Assert.Contains("204", ex.Message);
+        Assert.Contains("202", ex.Message);
+    }
+
+    private sealed class DisposeTrackingContent : StringContent
+    {
+        private readonly Action _onDispose;
+
+        public DisposeTrackingContent(string content, Action onDispose) : base(content)
+            => _onDispose = onDispose;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _onDispose();
+
+            base.Dispose(disposing);
+        }
     }
 
     #endregion

--- a/test/Dynamics365.BusinessCentral.Tests/QueryBuilderTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/QueryBuilderTests.cs
@@ -1,0 +1,368 @@
+using Dynamics365.BusinessCentral.OData;
+using Dynamics365.BusinessCentral.Tests.Utils;
+using System.Net;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+public class QueryBuilderTests
+{
+    private static (Dynamics365.BusinessCentral.Client.BusinessCentralClient Client, List<string> Urls) Capturing(
+        params string[] bodies)
+    {
+        var urls = new List<string>();
+        var call = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
+        {
+            urls.Add(req.RequestUri!.AbsoluteUri);
+
+            var body = bodies.Length == 0
+                ? "{\"value\":[]}"
+                : bodies[Math.Min(call, bodies.Length - 1)];
+
+            call++;
+
+            return TestBase.Json(body);
+        }));
+
+        return (client, urls);
+    }
+
+    private static string Query(string url) => new Uri(url).Query;
+
+    private static string Decode(string url) => Uri.UnescapeDataString(url);
+
+    #region Path inference
+
+    [Fact]
+    public async Task Path_Comes_From_Entity_Attribute()
+    {
+        var (client, urls) = Capturing();
+
+        await client.Query<SalesOrder>().ToListAsync();
+
+        Assert.Contains("Company('Test')/salesOrders", urls[0]);
+    }
+
+    [Fact]
+    public void Unannotated_Entity_Gives_An_Actionable_Error()
+    {
+        var (client, _) = Capturing();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => client.Query<UnannotatedEntity>());
+
+        Assert.Contains("BusinessCentralEntity", ex.Message);
+        Assert.Contains("UnannotatedEntity", ex.Message);
+    }
+
+    [Fact]
+    public async Task Explicit_Path_Overrides_Inference()
+    {
+        var (client, urls) = Capturing();
+
+        await client.Query<SalesOrder>("customPage").ToListAsync();
+
+        Assert.Contains("Company('Test')/customPage", urls[0]);
+    }
+
+    #endregion
+
+    #region Typed field names
+
+    [Fact]
+    public async Task Selectors_Use_The_Json_Naming_Policy()
+    {
+        var (client, urls) = Capturing();
+
+        await client.Query<SalesOrder>()
+            .Where(Filter.Equals<SalesOrder>(o => o.Status, "Open"))
+            .Select(o => o.No, o => o.Amount)
+            .ToListAsync();
+
+        var decoded = Decode(urls[0]);
+
+        // camelCase, matching how the entity is deserialized.
+        Assert.Contains("$filter=status eq 'Open'", decoded);
+        Assert.Contains("$select=no,amount", decoded);
+    }
+
+    [Fact]
+    public async Task Selectors_Honour_JsonPropertyName()
+    {
+        var (client, urls) = Capturing();
+
+        await client.Query<SalesOrder>()
+            .Where(Filter.Equals<SalesOrder>(o => o.CustomerNo, "C0001"))
+            .ToListAsync();
+
+        Assert.Contains("$filter=Sell_to_Customer_No eq 'C0001'", Decode(urls[0]));
+    }
+
+    [Fact]
+    public async Task Selectors_Support_Nested_Navigation_Paths()
+    {
+        var (client, urls) = Capturing();
+
+        await client.Query<SalesOrder>()
+            .Where(Filter.Equals<SalesOrder>(o => o.Customer!.Name, "ACME"))
+            .ToListAsync();
+
+        Assert.Contains("$filter=customer/name eq 'ACME'", Decode(urls[0]));
+    }
+
+    [Fact]
+    public void Non_Property_Selectors_Are_Rejected()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            Filter.Equals<SalesOrder>(o => o.No.ToUpperInvariant(), "X"));
+
+        Assert.Contains("property selector", ex.Message);
+    }
+
+    #endregion
+
+    #region Ordering
+
+    [Fact]
+    public async Task Multi_Field_Ordering_Is_Preserved()
+    {
+        var (client, urls) = Capturing();
+
+        await client.Query<SalesOrder>()
+            .OrderByDescending(o => o.Amount)
+            .ThenBy(o => o.No)
+            .ToListAsync();
+
+        Assert.Contains("$orderby=amount desc,no asc", Decode(urls[0]));
+    }
+
+    [Fact]
+    public async Task OrderBy_Resets_But_ThenBy_Appends()
+    {
+        var (client, urls) = Capturing();
+
+        await client.Query<SalesOrder>()
+            .OrderBy(o => o.Amount)
+            .OrderBy(o => o.No)
+            .ThenByDescending(o => o.Status)
+            .ToListAsync();
+
+        Assert.Contains("$orderby=no asc,status desc", Decode(urls[0]));
+    }
+
+    [Fact]
+    public void QueryOptions_ThenBy_Appends_Instead_Of_Overwriting()
+    {
+        var options = new QueryOptions()
+            .OrderByAsc("a")
+            .ThenByDesc("b")
+            .ThenByAsc("c");
+
+        Assert.Equal("a asc,b desc,c asc", options.OrderBy);
+    }
+
+    #endregion
+
+    #region Expand and count
+
+    [Fact]
+    public async Task Expand_Emits_Navigation_Properties()
+    {
+        var (client, urls) = Capturing();
+
+        await client.Query<SalesOrder>().Expand(o => o.Lines).ToListAsync();
+
+        Assert.Contains("$expand=lines", Decode(urls[0]));
+    }
+
+    [Fact]
+    public async Task Expand_Accepts_Raw_Nested_Syntax()
+    {
+        var (client, urls) = Capturing();
+
+        await client.Query<SalesOrder>().Expand("lines($select=lineNo)").ToListAsync();
+
+        Assert.Contains("$expand=lines($select=lineNo)", Decode(urls[0]));
+    }
+
+    [Fact]
+    public async Task ToPageAsync_Returns_Items_And_Total()
+    {
+        var (client, urls) = Capturing("{\"@odata.count\":42,\"value\":[{\"no\":\"1\"},{\"no\":\"2\"}]}");
+
+        var page = await client.Query<SalesOrder>().Top(2).ToPageAsync();
+
+        Assert.Contains("$count=true", Decode(urls[0]));
+        Assert.Equal(2, page.Items.Count);
+        Assert.Equal(42, page.TotalCount);
+        Assert.False(page.HasMore);
+    }
+
+    [Fact]
+    public async Task CountAsync_Uses_Server_Count_Without_Fetching_Rows()
+    {
+        var (client, urls) = Capturing("{\"@odata.count\":137,\"value\":[]}");
+
+        var count = await client.Query<SalesOrder>().CountAsync();
+
+        Assert.Equal(137, count);
+        Assert.Single(urls);
+        Assert.Contains("$top=0", Decode(urls[0]));
+    }
+
+    #endregion
+
+    #region Paging and streaming
+
+    [Fact]
+    public async Task StreamAsync_Stops_Fetching_When_Enumeration_Stops()
+    {
+        var requests = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            requests++;
+            return TestBase.Json("{\"value\":[{\"no\":\"a\"},{\"no\":\"b\"}]}");
+        }));
+
+        var seen = new List<string>();
+
+        await foreach (var order in client.Query<SalesOrder>().PageSize(2).StreamAsync())
+        {
+            seen.Add(order.No);
+            if (seen.Count == 3)
+                break;
+        }
+
+        Assert.Equal(3, seen.Count);
+
+        // Two pages of two is enough for three items — the third page is never requested.
+        Assert.Equal(2, requests);
+    }
+
+    [Fact]
+    public async Task Top_Caps_Results_Across_Pages()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            TestBase.Json("{\"value\":[{\"no\":\"a\"},{\"no\":\"b\"}]}")));
+
+        var all = await client.Query<SalesOrder>().PageSize(2).Top(3).ToAllAsync();
+
+        Assert.Equal(3, all.Count);
+    }
+
+    [Fact]
+    public async Task StreamAsync_Follows_NextLink()
+    {
+        var urls = new List<string>();
+        var call = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
+        {
+            urls.Add(req.RequestUri!.AbsoluteUri);
+
+            var body = call++ == 0
+                ? "{\"value\":[{\"no\":\"a\"}],\"@odata.nextLink\":\"https://test/next\"}"
+                : "{\"value\":[{\"no\":\"b\"}]}";
+
+            return TestBase.Json(body);
+        }));
+
+        var all = await client.Query<SalesOrder>().ToAllAsync();
+
+        Assert.Equal(["a", "b"], all.Select(o => o.No));
+        Assert.Equal("https://test/next", urls[1]);
+    }
+
+    [Fact]
+    public async Task FirstOrDefaultAsync_Requests_A_Single_Row()
+    {
+        var (client, urls) = Capturing("{\"value\":[{\"no\":\"a\"}]}");
+
+        var first = await client.Query<SalesOrder>().FirstOrDefaultAsync();
+
+        Assert.Equal("a", first!.No);
+        Assert.Contains("$top=1", Decode(urls[0]));
+    }
+
+    [Fact]
+    public async Task FirstOrDefaultAsync_Returns_Null_When_Empty()
+    {
+        var (client, _) = Capturing("{\"value\":[]}");
+
+        Assert.Null(await client.Query<SalesOrder>().FirstOrDefaultAsync());
+    }
+
+    [Fact]
+    public async Task Where_Combines_With_And()
+    {
+        var (client, urls) = Capturing();
+
+        await client.Query<SalesOrder>()
+            .Where(Filter.Equals<SalesOrder>(o => o.Status, "Open"))
+            .Where(Filter.GreaterThan<SalesOrder>(o => o.Amount, 100))
+            .ToListAsync();
+
+        Assert.Contains("$filter=(status eq 'Open') and (amount gt 100)", Decode(urls[0]));
+    }
+
+    #endregion
+
+    #region Multi-company
+
+    [Fact]
+    public async Task ForCompany_Scopes_Urls_Without_Reauthenticating()
+    {
+        var tokenCalls = 0;
+        var urls = new List<string>();
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+            {
+                tokenCalls++;
+                return TestBase.Json("{\"access_token\":\"abc\",\"expires_in\":3600}");
+            }
+
+            urls.Add(req.RequestUri!.AbsoluteUri);
+            return TestBase.Json("{\"value\":[]}");
+        });
+
+        await client.Query<SalesOrder>().ToListAsync();
+        await client.ForCompany("KRAL AG").Query<SalesOrder>().ToListAsync();
+
+        Assert.Contains("Company('Test')", urls[0]);
+        Assert.Contains("Company('KRAL%20AG')", urls[1]);
+
+        // The token cache is shared with the scoped client.
+        Assert.Equal(1, tokenCalls);
+    }
+
+    [Fact]
+    public void ForCompany_Returns_Same_Instance_For_Same_Company()
+    {
+        var (client, _) = Capturing();
+
+        Assert.Same(client, client.ForCompany("Test"));
+        Assert.NotSame(client, client.ForCompany("Other"));
+    }
+
+    [Fact]
+    public async Task GetCompaniesAsync_Queries_The_Service_Root()
+    {
+        var (client, urls) = Capturing(
+            "{\"value\":[{\"Name\":\"CRONUS AG\",\"Display_Name\":\"CRONUS\"},{\"Name\":\"KRAL AG\"}]}");
+
+        var companies = await client.GetCompaniesAsync();
+
+        // No Company('...') segment — the company list is tenant-level.
+        Assert.DoesNotContain("Company(", urls[0]);
+        Assert.EndsWith("/Company", urls[0]);
+
+        Assert.Equal(["CRONUS AG", "KRAL AG"], companies.Select(c => c.Name));
+        Assert.Equal("CRONUS", companies[0].DisplayName);
+        Assert.Null(companies[1].DisplayName);
+    }
+
+    #endregion
+}

--- a/test/Dynamics365.BusinessCentral.Tests/RequestReplayTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/RequestReplayTests.cs
@@ -1,0 +1,254 @@
+using Dynamics365.BusinessCentral.Client;
+using Dynamics365.BusinessCentral.Options;
+using Dynamics365.BusinessCentral.Tests.Utils;
+using System.Net;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+/// <summary>
+/// Covers request construction across retries.
+/// </summary>
+/// <remarks>
+/// <see cref="FakeHttpHandler"/> never disposes anything, so it cannot reproduce the real
+/// <see cref="HttpClient"/> contract: request content is disposed once a send completes.
+/// Replaying a previously sent request therefore throws <see cref="ObjectDisposedException"/>
+/// for anything carrying a body. These tests use a handler that disposes content the way a
+/// real send does, so a regression to request-reuse fails here instead of in production on
+/// the first token expiry during a write.
+/// </remarks>
+public class RequestReplayTests
+{
+    /// <summary>Mimics HttpClient, which disposes request content once a send completes.</summary>
+    private sealed class ContentDisposingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+        public ContentDisposingHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+            => _handler = handler;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            // Read the body the way a real send would, then release it.
+            if (request.Content != null)
+                await request.Content.ReadAsByteArrayAsync(cancellationToken);
+
+            var response = _handler(request);
+
+            request.Content?.Dispose();
+
+            return response;
+        }
+    }
+
+    private static BusinessCentralClient RealisticClient(
+        Func<HttpRequestMessage, HttpResponseMessage> handler)
+    {
+        var http = new HttpClient(new ContentDisposingHandler(handler));
+
+        var options = new BusinessCentralOptions
+        {
+            BaseUrl = "https://test",
+            Company = "Test",
+            TenantId = "tenant",
+            ClientId = "client",
+            ClientSecret = "secret",
+            Scope = "scope",
+            TokenEndpoint = "https://auth/{TenantId}",
+            Retry = new BusinessCentralRetryOptions
+            {
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero
+            }
+        };
+
+        return new BusinessCentralClient(http, Microsoft.Extensions.Options.Options.Create(options));
+    }
+
+    [Fact]
+    public async Task Post_With_Body_Survives_A_Throttled_Retry()
+    {
+        var calls = 0;
+
+        var client = RealisticClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return TestBase.Json("{\"access_token\":\"abc\",\"expires_in\":3600}");
+
+            calls++;
+
+            return calls == 1
+                ? new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+                {
+                    Content = new StringContent("slow down")
+                }
+                : TestBase.Json("{\"id\":\"1\",\"name\":\"x\"}");
+        });
+
+        var result = await client.PostAsync("orders", new TestPatchEntity { Id = "1", Name = "x" });
+
+        Assert.Equal("x", result.Name);
+        Assert.Equal(2, calls);
+    }
+
+    // The most likely real-world trigger: a token expires mid-write.
+    [Fact]
+    public async Task Patch_With_Body_Survives_A_401_Retry()
+    {
+        var dataCalls = 0;
+        var bodies = new List<string>();
+
+        var client = RealisticClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return TestBase.Json("{\"access_token\":\"abc\",\"expires_in\":3600}");
+
+            bodies.Add(req.Content!.ReadAsStringAsync().Result);
+            dataCalls++;
+
+            return dataCalls == 1
+                ? new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Content = new StringContent("expired")
+                }
+                : TestBase.Json("{\"id\":\"1\",\"name\":\"Updated\"}");
+        });
+
+        var result = await client.PatchAsync("orders", "1", new TestPatchEntity { Id = "1", Name = "Updated" });
+
+        Assert.Equal("Updated", result.Name);
+        Assert.Equal(2, dataCalls);
+
+        // The replayed attempt must carry the same body, not an empty one.
+        Assert.Equal(2, bodies.Count);
+        Assert.Equal(bodies[0], bodies[1]);
+        Assert.Contains("Updated", bodies[1]);
+    }
+
+    [Fact]
+    public async Task Put_With_Body_Survives_A_Transient_Retry()
+    {
+        var calls = 0;
+
+        var client = RealisticClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return TestBase.Json("{\"access_token\":\"abc\",\"expires_in\":3600}");
+
+            calls++;
+
+            return calls == 1
+                ? new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Content = new StringContent("down")
+                }
+                : TestBase.Json("{\"id\":\"1\",\"name\":\"x\"}");
+        });
+
+        await client.PutAsync("orders", "1", new TestPatchEntity { Id = "1", Name = "x" });
+
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public async Task Headers_Are_Rebuilt_On_Every_Attempt()
+    {
+        var ifMatch = new List<string>();
+        var prefer = new List<string>();
+        var dataCalls = 0;
+
+        var client = RealisticClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return TestBase.Json("{\"access_token\":\"abc\",\"expires_in\":3600}");
+
+            ifMatch.Add(string.Join(",", req.Headers.GetValues("If-Match")));
+            prefer.Add(string.Join(",", req.Headers.GetValues("Prefer")));
+            dataCalls++;
+
+            return dataCalls == 1
+                ? new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new StringContent("x") }
+                : TestBase.Json("{\"id\":\"1\",\"name\":\"x\"}");
+        });
+
+        await client.PatchAsync("orders", "1", new TestPatchEntity(), "W/\"etag-1\"");
+
+        Assert.Equal(["W/\"etag-1\"", "W/\"etag-1\""], ifMatch);
+        Assert.All(prefer, p => Assert.Contains("return=representation", p));
+    }
+
+    [Fact]
+    public async Task Get_Survives_Repeated_Transient_Retries()
+    {
+        var calls = 0;
+
+        var client = RealisticClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                return TestBase.Json("{\"access_token\":\"abc\",\"expires_in\":3600}");
+
+            calls++;
+
+            return calls < 3
+                ? new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Content = new StringContent("down")
+                }
+                : TestBase.Json("{\"value\":[]}");
+        });
+
+        var result = await client.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.Empty(result);
+        Assert.Equal(3, calls);
+    }
+
+    #region Caller-supplied $skip
+
+    [Fact]
+    public async Task QueryAllAsync_Honours_A_Caller_Supplied_Skip()
+    {
+        var urls = new List<string>();
+
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
+        {
+            urls.Add(Uri.UnescapeDataString(req.RequestUri!.AbsoluteUri));
+            return TestBase.Json("{\"value\":[]}");
+        }));
+
+        await client.QueryAllAsync<TestEntity>("orders", options: o => o.WithSkip(100));
+
+        Assert.Contains("$skip=100", urls[0]);
+    }
+
+    [Fact]
+    public async Task QueryStreamAsync_Continues_Paging_From_The_Supplied_Skip()
+    {
+        var skips = new List<string>();
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
+        {
+            var query = new Uri(req.RequestUri!.AbsoluteUri).Query;
+            skips.Add(Uri.UnescapeDataString(query));
+
+            dataCalls++;
+
+            return dataCalls == 1
+                ? TestBase.Json("{\"value\":[{\"id\":1},{\"id\":2}]}")
+                : TestBase.Json("{\"value\":[]}");
+        }));
+
+        var all = await client.QueryAllAsync<TestEntity>(
+            "orders", options: o => o.WithPageSize(2).WithSkip(10));
+
+        Assert.Equal(2, all.Count);
+        Assert.Contains("$skip=10", skips[0]);
+
+        // Second page continues from the offset rather than restarting.
+        Assert.Contains("$skip=12", skips[1]);
+    }
+
+    #endregion
+}

--- a/test/Dynamics365.BusinessCentral.Tests/RetryTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/RetryTests.cs
@@ -312,6 +312,58 @@ public class RetryTests
 
     #endregion
 
+    #region Backoff bounds
+
+    // A large BaseDelay with a high attempt count overflows TimeSpan, and
+    // TimeSpan.FromMilliseconds throws on both overflow and Infinity — which would turn a
+    // transient failure into an unrelated crash.
+    [Fact]
+    public async Task Huge_Backoff_Is_Clamped_Instead_Of_Overflowing()
+    {
+        var observer = new RecordingObserver();
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ => Throttled()),
+            observer,
+            o => o.Retry = new BusinessCentralRetryOptions
+            {
+                MaxAttempts = 40,
+                BaseDelay = TimeSpan.FromHours(1),
+                MaxDelay = TimeSpan.Zero,
+                HonorRetryAfter = false
+            });
+
+        var ex = await Record.ExceptionAsync(() => client.QueryAsync<TestEntity>("orders", "true"));
+
+        Assert.IsType<BusinessCentralThrottledException>(ex);
+        Assert.Equal(39, observer.Retries.Count);
+        Assert.All(observer.Retries, r => Assert.Equal(TimeSpan.Zero, r.Delay));
+    }
+
+    [Fact]
+    public async Task Negative_Delays_Are_Floored_At_Zero()
+    {
+        var observer = new RecordingObserver();
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ => Throttled()),
+            observer,
+            o => o.Retry = new BusinessCentralRetryOptions
+            {
+                MaxAttempts = 3,
+                BaseDelay = TimeSpan.FromSeconds(-5),
+                MaxDelay = TimeSpan.FromSeconds(-1),
+                HonorRetryAfter = false
+            });
+
+        await Assert.ThrowsAsync<BusinessCentralThrottledException>(() =>
+            client.QueryAsync<TestEntity>("orders", "true"));
+
+        Assert.All(observer.Retries, r => Assert.True(r.Delay >= TimeSpan.Zero));
+    }
+
+    #endregion
+
     private sealed class RecordingObserver : IBusinessCentralObserver
     {
         public readonly List<BusinessCentralRetryInfo> Retries = [];

--- a/test/Dynamics365.BusinessCentral.Tests/RetryTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/RetryTests.cs
@@ -187,6 +187,131 @@ public class RetryTests
         Assert.All(observer.Retries, r => Assert.False(r.FromRetryAfter));
     }
 
+    #region Replay safety
+
+    // 429 is rejected before processing, so replaying it can never duplicate a write.
+    [Fact]
+    public async Task Post_Is_Retried_On_429()
+    {
+        var posts = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            posts++;
+            return posts == 1 ? Throttled() : TestBase.Json("{\"id\":\"1\",\"name\":\"x\"}");
+        }));
+
+        await client.PostAsync("ldatSummary", new TestPatchEntity { Id = "1", Name = "x" });
+
+        Assert.Equal(2, posts);
+    }
+
+    // 408/502/503/504 are ambiguous — the row may already exist. Replaying a POST would
+    // orphan a duplicate, so it must surface instead.
+    [Theory]
+    [InlineData(HttpStatusCode.RequestTimeout)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    public async Task Post_Is_Not_Replayed_On_Ambiguous_Transient_Failures(HttpStatusCode status)
+    {
+        var posts = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            posts++;
+            return new HttpResponseMessage(status) { Content = new StringContent("x") };
+        }));
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralServerException>(() =>
+            client.PostAsync("ldatSummary", new TestPatchEntity()));
+
+        Assert.Equal(1, posts);
+
+        // Still reported as transient so the caller can decide for itself.
+        Assert.True(ex.IsTransient);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    public async Task Idempotent_Methods_Are_Still_Replayed(HttpStatusCode status)
+    {
+        var gets = 0;
+        var puts = 0;
+        var deletes = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
+        {
+            if (req.Method == HttpMethod.Get) gets++;
+            if (req.Method == HttpMethod.Put) puts++;
+            if (req.Method == HttpMethod.Delete) deletes++;
+
+            return new HttpResponseMessage(status) { Content = new StringContent("x") };
+        }));
+
+        await Assert.ThrowsAsync<BusinessCentralServerException>(() =>
+            client.QueryAsync<TestEntity>("orders", "true"));
+
+        await Assert.ThrowsAsync<BusinessCentralServerException>(() =>
+            client.PutAsync("orders", "1", new TestPatchEntity()));
+
+        await Assert.ThrowsAsync<BusinessCentralServerException>(() =>
+            client.DeleteAsync("orders", "1"));
+
+        Assert.Equal(3, gets);
+        Assert.Equal(3, puts);
+        Assert.Equal(3, deletes);
+    }
+
+    [Fact]
+    public async Task Post_Replay_Can_Be_Opted_Into()
+    {
+        var posts = 0;
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ =>
+            {
+                posts++;
+                return new HttpResponseMessage(HttpStatusCode.GatewayTimeout)
+                {
+                    Content = new StringContent("x")
+                };
+            }),
+            configure: o => o.Retry = new BusinessCentralRetryOptions
+            {
+                MaxAttempts = 3,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero,
+                RetryPostOnTransientFailures = true
+            });
+
+        await Assert.ThrowsAsync<BusinessCentralServerException>(() =>
+            client.PostAsync("ldatSummary", new TestPatchEntity()));
+
+        Assert.Equal(3, posts);
+    }
+
+    [Fact]
+    public async Task Post_Not_Replayed_Reports_A_Single_Failure_And_No_Retry_Event()
+    {
+        var observer = new RecordingObserver();
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ => new HttpResponseMessage(HttpStatusCode.GatewayTimeout)
+            {
+                Content = new StringContent("x")
+            }),
+            observer);
+
+        await Assert.ThrowsAsync<BusinessCentralServerException>(() =>
+            client.PostAsync("ldatSummary", new TestPatchEntity()));
+
+        Assert.Empty(observer.Retries);
+    }
+
+    #endregion
+
     private sealed class RecordingObserver : IBusinessCentralObserver
     {
         public readonly List<BusinessCentralRetryInfo> Retries = [];

--- a/test/Dynamics365.BusinessCentral.Tests/RetryTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/RetryTests.cs
@@ -312,6 +312,28 @@ public class RetryTests
 
     #endregion
 
+    // PATCH is deliberately replayed even though RFC 9110 does not guarantee it is
+    // idempotent: this client only sends absolute field values, so a replay converges.
+    // Pinned because it is a behavioural contract, documented in the README retry table.
+    [Theory]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    public async Task Patch_Is_Replayed_On_Ambiguous_Transient_Failures(HttpStatusCode status)
+    {
+        var patches = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            patches++;
+            return new HttpResponseMessage(status) { Content = new StringContent("x") };
+        }));
+
+        await Assert.ThrowsAsync<BusinessCentralServerException>(() =>
+            client.PatchAsync("prodOrders", "id-1", new TestPatchEntity()));
+
+        Assert.Equal(3, patches);
+    }
+
     #region Backoff bounds
 
     // A large BaseDelay with a high attempt count overflows TimeSpan, and
@@ -360,6 +382,73 @@ public class RetryTests
             client.QueryAsync<TestEntity>("orders", "true"));
 
         Assert.All(observer.Retries, r => Assert.True(r.Delay >= TimeSpan.Zero));
+    }
+
+    #endregion
+
+    #region Resource release
+
+    /// <summary>Records when its content is disposed, relative to a stopwatch.</summary>
+    private sealed class TrackingContent : StringContent
+    {
+        private readonly Action _onDispose;
+
+        public TrackingContent(string content, Action onDispose) : base(content)
+            => _onDispose = onDispose;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _onDispose();
+
+            base.Dispose(disposing);
+        }
+    }
+
+    // The failed response must be released before the backoff sleep, not after: under
+    // throttling the sleep is exactly when buffered responses would pile up.
+    [Fact]
+    public async Task Failed_Response_Is_Released_Before_The_Backoff_Sleep()
+    {
+        var backoff = TimeSpan.FromMilliseconds(600);
+        var clock = System.Diagnostics.Stopwatch.StartNew();
+
+        long? disposedAtMs = null;
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ =>
+            {
+                dataCalls++;
+
+                if (dataCalls > 1)
+                    return TestBase.Json("{\"value\":[]}");
+
+                return new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+                {
+                    Content = new TrackingContent(
+                        "slow down",
+                        () => disposedAtMs ??= clock.ElapsedMilliseconds)
+                };
+            }),
+            configure: o => o.Retry = new BusinessCentralRetryOptions
+            {
+                MaxAttempts = 2,
+                BaseDelay = backoff,
+                MaxDelay = backoff,
+                HonorRetryAfter = false
+            });
+
+        await client.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.Equal(2, dataCalls);
+        Assert.NotNull(disposedAtMs);
+
+        // Disposed near the start of the window rather than after it elapsed. Generous
+        // margin so this does not turn flaky on a loaded CI box.
+        Assert.True(
+            disposedAtMs < backoff.TotalMilliseconds * 0.75,
+            $"response was released after {disposedAtMs}ms, expected before the {backoff.TotalMilliseconds}ms sleep");
     }
 
     #endregion

--- a/test/Dynamics365.BusinessCentral.Tests/RetryTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/RetryTests.cs
@@ -1,0 +1,203 @@
+using Dynamics365.BusinessCentral.Diagnostics;
+using Dynamics365.BusinessCentral.Errors;
+using Dynamics365.BusinessCentral.Options;
+using Dynamics365.BusinessCentral.Tests.Utils;
+using System.Net;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+public class RetryTests
+{
+    private static HttpResponseMessage Throttled(TimeSpan? retryAfter = null)
+    {
+        var res = new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+        {
+            Content = new StringContent("{\"error\":{\"code\":\"TooManyRequests\",\"message\":\"slow down\"}}")
+        };
+
+        if (retryAfter is { } delay)
+            res.Headers.Add("Retry-After", ((int)delay.TotalSeconds).ToString());
+
+        return res;
+    }
+
+    [Fact]
+    public async Task Throttled_Request_Is_Retried_And_Succeeds()
+    {
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            dataCalls++;
+            return dataCalls == 1 ? Throttled() : TestBase.Json("{\"value\":[]}");
+        }));
+
+        var result = await client.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.Empty(result);
+        Assert.Equal(2, dataCalls);
+    }
+
+    [Fact]
+    public async Task Retry_Gives_Up_After_MaxAttempts_And_Throws_Throttled()
+    {
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ =>
+            {
+                dataCalls++;
+                return Throttled();
+            }),
+            configure: o => o.Retry = new BusinessCentralRetryOptions
+            {
+                MaxAttempts = 3,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero
+            });
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralThrottledException>(() =>
+            client.QueryAsync<TestEntity>("orders", "true"));
+
+        Assert.Equal(3, dataCalls);
+        Assert.True(ex.IsTransient);
+    }
+
+    [Fact]
+    public async Task Retry_Can_Be_Disabled()
+    {
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ =>
+            {
+                dataCalls++;
+                return Throttled();
+            }),
+            configure: o => o.Retry = new BusinessCentralRetryOptions { Enabled = false });
+
+        await Assert.ThrowsAsync<BusinessCentralThrottledException>(() =>
+            client.QueryAsync<TestEntity>("orders", "true"));
+
+        Assert.Equal(1, dataCalls);
+    }
+
+    [Fact]
+    public async Task Validation_Errors_Are_Not_Retried()
+    {
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            dataCalls++;
+            return new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("nope")
+            };
+        }));
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralValidationException>(() =>
+            client.QueryAsync<TestEntity>("orders", "true"));
+
+        Assert.Equal(1, dataCalls);
+        Assert.False(ex.IsTransient);
+    }
+
+    [Fact]
+    public async Task ServiceUnavailable_Is_Transient_But_NotFound_Is_Not()
+    {
+        var client503 = TestBase.CreateClient(TestBase.WithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Content = new StringContent("down") }));
+
+        var ex503 = await Assert.ThrowsAsync<BusinessCentralServerException>(() =>
+            client503.QueryAsync<TestEntity>("orders", "true"));
+
+        Assert.True(ex503.IsTransient);
+
+        var client404 = TestBase.CreateClient(TestBase.WithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("gone") }));
+
+        var ex404 = await Assert.ThrowsAsync<BusinessCentralNotFoundException>(() =>
+            client404.QueryAsync<TestEntity>("orders", "true"));
+
+        Assert.False(ex404.IsTransient);
+    }
+
+    [Fact]
+    public async Task RetryAfter_Header_Is_Surfaced_On_The_Exception()
+    {
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ => Throttled(TimeSpan.FromSeconds(7))),
+            configure: o => o.Retry = new BusinessCentralRetryOptions { Enabled = false });
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralThrottledException>(() =>
+            client.QueryAsync<TestEntity>("orders", "true"));
+
+        Assert.Equal(TimeSpan.FromSeconds(7), ex.RetryAfter);
+    }
+
+    [Fact]
+    public async Task Observer_Sees_Retry_With_Server_Requested_Delay()
+    {
+        var observer = new RecordingObserver();
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ =>
+            {
+                dataCalls++;
+                return dataCalls == 1 ? Throttled(TimeSpan.FromSeconds(5)) : TestBase.Json("{\"value\":[]}");
+            }),
+            observer);
+
+        await client.QueryAsync<TestEntity>("orders", "true");
+
+        var retry = Assert.Single(observer.Retries);
+
+        Assert.Equal(429, retry.StatusCode);
+        Assert.Equal(1, retry.Attempt);
+        Assert.True(retry.FromRetryAfter);
+
+        // MaxDelay is zero in tests, so the 5s request is capped rather than slept off.
+        Assert.Equal(TimeSpan.Zero, retry.Delay);
+    }
+
+    [Fact]
+    public async Task Backoff_Doubles_When_No_RetryAfter_Header()
+    {
+        var observer = new RecordingObserver();
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ => Throttled()),
+            observer,
+            o => o.Retry = new BusinessCentralRetryOptions
+            {
+                MaxAttempts = 4,
+                BaseDelay = TimeSpan.FromMilliseconds(1),
+                MaxDelay = TimeSpan.FromSeconds(10)
+            });
+
+        await Assert.ThrowsAsync<BusinessCentralThrottledException>(() =>
+            client.QueryAsync<TestEntity>("orders", "true"));
+
+        Assert.Equal(
+            [TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(2), TimeSpan.FromMilliseconds(4)],
+            observer.Retries.Select(r => r.Delay));
+
+        Assert.All(observer.Retries, r => Assert.False(r.FromRetryAfter));
+    }
+
+    private sealed class RecordingObserver : IBusinessCentralObserver
+    {
+        public readonly List<BusinessCentralRetryInfo> Retries = [];
+
+        public void OnRequestStarting(BusinessCentralRequestInfo request) { }
+        public void OnRequestSucceeded(BusinessCentralRequestInfo request) { }
+        public void OnRequestFailed(BusinessCentralErrorInfo error) { }
+        public void OnTokenRequested() { }
+        public void OnTokenRefreshed(BusinessCentralTokenInfo token) { }
+        public void OnDeserializationFailed(BusinessCentralErrorInfo error) { }
+
+        public void OnRequestRetrying(BusinessCentralRetryInfo retry) => Retries.Add(retry);
+    }
+}

--- a/test/Dynamics365.BusinessCentral.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,7 +1,10 @@
 ﻿using Dynamics365.BusinessCentral.Client;
 using Dynamics365.BusinessCentral.Diagnostics;
 using Dynamics365.BusinessCentral.Options;
+using Dynamics365.BusinessCentral.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System.Net;
 
 namespace Dynamics365.BusinessCentral.Tests;
 
@@ -85,6 +88,103 @@ public class ServiceCollectionExtensionsTests
         Assert.Equal("tenant", options!.Value.TenantId);
     }
 
+
+    [Fact]
+    public void Validation_Names_Every_Missing_Option()
+    {
+        var services = new ServiceCollection();
+
+        services.AddBusinessCentral(options =>
+        {
+            options.TenantId = "tenant";
+            options.ClientId = "";
+            options.ClientSecret = "  ";
+            options.BaseUrl = "https://test";
+            options.Company = "Test";
+            options.Scope = "scope";
+            options.TokenEndpoint = "https://auth/{TenantId}";
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        var ex = Assert.Throws<OptionsValidationException>(() =>
+            provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<BusinessCentralOptions>>().Value);
+
+        var message = string.Join(" | ", ex.Failures);
+
+        Assert.Contains(nameof(BusinessCentralOptions.ClientId), message);
+        Assert.Contains(nameof(BusinessCentralOptions.ClientSecret), message);
+        Assert.DoesNotContain(nameof(BusinessCentralOptions.TenantId), message);
+    }
+
+    [Fact]
+    public void Validation_Rejects_Relative_BaseUrl()
+    {
+        var services = new ServiceCollection();
+
+        services.AddBusinessCentral(options =>
+        {
+            options.TenantId = "tenant";
+            options.ClientId = "client";
+            options.ClientSecret = "secret";
+            options.BaseUrl = "not-a-url";
+            options.Company = "Test";
+            options.Scope = "scope";
+            options.TokenEndpoint = "https://auth/{TenantId}";
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        var ex = Assert.Throws<OptionsValidationException>(() =>
+            provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<BusinessCentralOptions>>().Value);
+
+        Assert.Contains("absolute URL", string.Join(" | ", ex.Failures));
+    }
+
+    [Fact]
+    public async Task Token_Cache_Is_Shared_Across_Resolved_Clients()
+    {
+        // Typed HTTP clients are transient, so the token cache must live on a singleton
+        // or every injection would re-authenticate.
+        var tokenCalls = 0;
+
+        var services = new ServiceCollection();
+
+        services.AddBusinessCentral(DefaultOptions);
+
+        // Configure the named handlers rather than re-registering the typed client,
+        // which would replace the registration under test.
+        services
+            .AddHttpClient(ServiceCollectionExtensions.TokenHttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(() => new FakeHttpHandler(_ =>
+            {
+                Interlocked.Increment(ref tokenCalls);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                };
+            }));
+
+        services
+            .AddHttpClient(ServiceCollectionExtensions.ClientHttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(() => new FakeHttpHandler(_ =>
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"value\":[]}")
+                }));
+
+        var provider = services.BuildServiceProvider();
+
+        var first = provider.GetRequiredService<IBusinessCentralClient>();
+        var second = provider.GetRequiredService<IBusinessCentralClient>();
+
+        Assert.NotSame(first, second);
+
+        await first.QueryAsync<TestEntity>("orders", "true");
+        await second.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.Equal(1, tokenCalls);
+    }
 
     private class TestObserver : IBusinessCentralObserver
     {

--- a/test/Dynamics365.BusinessCentral.Tests/TestBase.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/TestBase.cs
@@ -1,4 +1,4 @@
-﻿using Dynamics365.BusinessCentral.Client;
+using Dynamics365.BusinessCentral.Client;
 using Dynamics365.BusinessCentral.Diagnostics;
 using Dynamics365.BusinessCentral.Options;
 using Dynamics365.BusinessCentral.Tests.Utils;
@@ -9,7 +9,8 @@ public abstract class TestBase
 {
     public static BusinessCentralClient CreateClient(
         Func<HttpRequestMessage, HttpResponseMessage> handler,
-        IBusinessCentralObserver? observer = null)
+        IBusinessCentralObserver? observer = null,
+        Action<BusinessCentralOptions>? configure = null)
     {
         var http = new HttpClient(new FakeHttpHandler(handler));
 
@@ -21,9 +22,35 @@ public abstract class TestBase
             ClientId = "client",
             ClientSecret = "secret",
             Scope = "scope",
-            TokenEndpoint = "https://auth/{TenantId}"
+            TokenEndpoint = "https://auth/{TenantId}",
+
+            // Keep retries instant so tests do not sleep.
+            Retry = new BusinessCentralRetryOptions
+            {
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero
+            }
         };
+
+        configure?.Invoke(options);
 
         return new BusinessCentralClient(http, Microsoft.Extensions.Options.Options.Create(options), observer);
     }
+
+    /// <summary>
+    /// Handler that answers the token request and delegates everything else, so tests do
+    /// not repeat the auth branch.
+    /// </summary>
+    public static Func<HttpRequestMessage, HttpResponseMessage> WithToken(
+        Func<HttpRequestMessage, HttpResponseMessage> handler)
+        => req => req.RequestUri!.AbsoluteUri.Contains("auth")
+            ? new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+            }
+            : handler(req);
+
+    /// <summary>Shorthand for a JSON 200 response.</summary>
+    public static HttpResponseMessage Json(string body) =>
+        new(System.Net.HttpStatusCode.OK) { Content = new StringContent(body) };
 }

--- a/test/Dynamics365.BusinessCentral.Tests/Utils/SalesOrder.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/Utils/SalesOrder.cs
@@ -1,0 +1,40 @@
+using Dynamics365.BusinessCentral.OData;
+using System.Text.Json.Serialization;
+
+namespace Dynamics365.BusinessCentral.Tests.Utils;
+
+/// <summary>Annotated entity used to exercise path inference and typed selectors.</summary>
+[BusinessCentralEntity("salesOrders")]
+public sealed class SalesOrder
+{
+    public string No { get; set; } = string.Empty;
+
+    public string Status { get; set; } = string.Empty;
+
+    public decimal Amount { get; set; }
+
+    /// <summary>Exercises the JsonPropertyName branch of property-name resolution.</summary>
+    [JsonPropertyName("Sell_to_Customer_No")]
+    public string CustomerNo { get; set; } = string.Empty;
+
+    /// <summary>Exercises nested navigation paths.</summary>
+    public SalesOrderCustomer? Customer { get; set; }
+
+    public List<SalesOrderLine> Lines { get; set; } = [];
+}
+
+public sealed class SalesOrderCustomer
+{
+    public string Name { get; set; } = string.Empty;
+}
+
+public sealed class SalesOrderLine
+{
+    public int LineNo { get; set; }
+}
+
+/// <summary>Deliberately not annotated, to test the error path.</summary>
+public sealed class UnannotatedEntity
+{
+    public string Name { get; set; } = string.Empty;
+}

--- a/test/Dynamics365.BusinessCentral.Tests/Utils/TestObserver.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/Utils/TestObserver.cs
@@ -1,10 +1,12 @@
-﻿using Dynamics365.BusinessCentral.Diagnostics;
+using Dynamics365.BusinessCentral.Diagnostics;
 
 namespace Dynamics365.BusinessCentral.Tests.Utils;
 
 public sealed class TestObserver : IBusinessCentralObserver
 {
     public readonly List<string> Events = [];
+
+    public readonly List<BusinessCentralErrorInfo> Failures = [];
 
     public void OnRequestStarting(BusinessCentralRequestInfo info)
         => Events.Add($"start:{info.Method}");
@@ -13,13 +15,19 @@ public sealed class TestObserver : IBusinessCentralObserver
         => Events.Add($"success:{info.StatusCode}");
 
     public void OnRequestFailed(BusinessCentralErrorInfo info)
-        => Events.Add($"fail:{info.StatusCode}");
+    {
+        Events.Add($"fail:{info.StatusCode}");
+        Failures.Add(info);
+    }
 
     public void OnTokenRequested()
         => Events.Add("token-requested");
 
     public void OnTokenRefreshed(BusinessCentralTokenInfo info)
-        => Events.Add(info.FromCache ? "token-cached" : "token-refreshed");
+        => Events.Add("token-refreshed");
+
+    public void OnTokenServedFromCache(BusinessCentralTokenInfo info)
+        => Events.Add("token-cached");
 
     public void OnDeserializationFailed(BusinessCentralErrorInfo info)
         => Events.Add("deserialization-failed");

--- a/test/Dynamics365.BusinessCentral.Tests/WriteOverloadTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/WriteOverloadTests.cs
@@ -1,0 +1,179 @@
+using Dynamics365.BusinessCentral.Tests.Utils;
+using System.Net;
+using System.Text.Json;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+/// <summary>
+/// Covers the two-generic write overloads and, critically, that adding them did not change
+/// how existing single-generic call sites resolve.
+/// </summary>
+public class WriteOverloadTests
+{
+    private sealed class CreatedRow
+    {
+        public string SystemId { get; set; } = string.Empty;
+    }
+
+    #region Overload resolution — existing call shapes must be unaffected
+
+    // The exact shape used by existing consumers: one explicit type argument.
+    [Fact]
+    public async Task Single_Generic_Call_Still_Echoes_Payload_On_204()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.NoContent)));
+
+        var payload = new { serialNo = "S1" };
+
+        object? raw = await client.PostAsync<dynamic>("ldatSummary", payload);
+
+        // Arity picks the one-generic overload, whose 204 contract is unchanged.
+        Assert.Same(payload, raw);
+    }
+
+    [Fact]
+    public async Task Single_Generic_Patch_With_Positional_IfMatch_Still_Binds()
+    {
+        HttpRequestMessage? captured = null;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
+        {
+            captured = req;
+            return new HttpResponseMessage(HttpStatusCode.NoContent);
+        }));
+
+        await client.PatchAsync<dynamic>(
+            "prodOrders",
+            Guid.NewGuid().ToString(),
+            new { status = "Active" },
+            "*",
+            cancellationToken: CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal(HttpMethod.Patch, captured!.Method);
+    }
+
+    // No explicit type arguments at all — inference must still pick the one-generic form.
+    [Fact]
+    public async Task Inferred_Call_Binds_To_Single_Generic_Overload()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.NoContent)));
+
+        var payload = new TestPatchEntity { Id = "1", Name = "x" };
+
+        var result = await client.PostAsync("orders", payload);
+
+        Assert.Same(payload, result);
+    }
+
+    #endregion
+
+    #region Two-generic overloads
+
+    [Fact]
+    public async Task Post_Can_Deserialize_Into_A_Different_Type()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            TestBase.Json("{\"systemId\":\"abc-123\"}")));
+
+        var created = await client.PostAsync<object, CreatedRow>(
+            "ldatSummary",
+            new { serialNo = "S1", productionOrderNo = "PO1" });
+
+        Assert.NotNull(created);
+        Assert.Equal("abc-123", created!.SystemId);
+    }
+
+    [Fact]
+    public async Task Post_Returns_Null_When_Server_Returns_No_Representation()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.NoContent)));
+
+        var created = await client.PostAsync<object, CreatedRow>("ldatSummary", new { serialNo = "S1" });
+
+        // null means "applied, not echoed" — not "failed". Failures throw.
+        Assert.Null(created);
+    }
+
+    [Fact]
+    public async Task Post_Returns_Null_On_Empty_Body()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.Created) { Content = new StringContent("") }));
+
+        Assert.Null(await client.PostAsync<object, CreatedRow>("ldatSummary", new { serialNo = "S1" }));
+    }
+
+    // Value-typed results stay usable — JsonElement is the common "I have no model" case.
+    [Fact]
+    public async Task Two_Generic_Overload_Supports_Value_Type_Results()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            TestBase.Json("{\"systemId\":\"abc-123\"}")));
+
+        var element = await client.PostAsync<object, JsonElement>("ldatSummary", new { serialNo = "S1" });
+
+        Assert.Equal("abc-123", element.GetProperty("systemId").GetString());
+    }
+
+    // Value types cannot be null, so a 204 yields default(TResult). For JsonElement that is
+    // ValueKind.Undefined — the check callers must use instead of a null comparison.
+    [Fact]
+    public async Task Value_Type_Result_Is_Undefined_On_204()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.NoContent)));
+
+        var element = await client.PostAsync<object, JsonElement>("ldatSummary", new { serialNo = "S1" });
+
+        Assert.Equal(JsonValueKind.Undefined, element.ValueKind);
+    }
+
+    [Fact]
+    public async Task Patch_And_Put_Support_Distinct_Result_Types()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            TestBase.Json("{\"systemId\":\"xyz\"}")));
+
+        var patched = await client.PatchAsync<object, CreatedRow>(
+            "prodOrders", "id-1", new { status = "Active" });
+
+        var put = await client.PutAsync<object, CreatedRow>(
+            "prodOrders", "id-1", new { status = "Active" });
+
+        Assert.Equal("xyz", patched!.SystemId);
+        Assert.Equal("xyz", put!.SystemId);
+    }
+
+    [Fact]
+    public async Task Two_Generic_Overload_Still_Throws_On_Failure()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = new StringContent("bad") }));
+
+        await Assert.ThrowsAsync<Dynamics365.BusinessCentral.Errors.BusinessCentralValidationException>(() =>
+            client.PostAsync<object, CreatedRow>("ldatSummary", new { serialNo = "S1" }));
+    }
+
+    [Fact]
+    public async Task Two_Generic_Post_Is_Not_Replayed_On_Ambiguous_Failure()
+    {
+        var posts = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            posts++;
+            return new HttpResponseMessage(HttpStatusCode.GatewayTimeout) { Content = new StringContent("x") };
+        }));
+
+        await Assert.ThrowsAsync<Dynamics365.BusinessCentral.Errors.BusinessCentralServerException>(() =>
+            client.PostAsync<object, CreatedRow>("ldatSummary", new { serialNo = "S1" }));
+
+        Assert.Equal(1, posts);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Bumps the package to **2.0.0-alpha** — shipped as a prerelease first so it can be validated against a real Business Central environment before a stable 2.0.0. Starts from six defects found reading the client end to end, then reworks the API around what those defects exposed.

Full upgrade notes, including every silent behavioural change, are in **[MIGRATION.md](MIGRATION.md)**. Version-by-version history is in **[CHANGELOG.md](CHANGELOG.md)**, and `<PackageReleaseNotes>` now points at both so nuget.org shows something for the first time.

---

## Defects fixed

| | Problem | Effect |
|---|---|---|
| 1 | Token cache lived on the client, but typed `HttpClient`s are transient | Every injection of `IBusinessCentralClient` triggered a fresh token request |
| 2 | `QueryRawAsync` percent-encoded the query string into the path | `salesOrders?$top=5` became `salesOrders%3F%24top%3D5` — the documented usage never worked |
| 3 | `Uri.EscapeDataString` applied to whole entity keys | The README's `No='1000'` became `No%3D%271000%27` |
| 4 | `OnRequestFailed` raised at the throw site *and* in the catch-all | Every HTTP error reported twice |
| 5 | `204 No Content` treated as an error on writes | A successful write surfaced as `BusinessCentralServerException` |
| 6 | `@odata.nextLink` ignored | `QueryAllAsync` silently truncated under server-driven paging |

Smaller ones alongside: `BusinessCentralErrorInfo.ResponseBody` was declared but never populated; `OnTokenRefreshed` fired on cache hits; options validation collapsed seven settings into one boolean; the constructor mutated the injected `HttpClient`.

## API overhaul

**Packaging.** `GenerateDocumentationFile` was off, so consumers got no IntelliSense at all despite the source being well documented. Turning it on surfaced 122 undocumented public members, all now written. Added `PublishRepositoryUrl`/`EmbedUntrackedSources` so the existing snupkg is usable for step-into debugging. Dependencies are declared per TFM instead of pinning every target to the 8.0.0 floor.

**Setup.** `BaseUrl` never had its placeholders substituted, so the README's own `{tenant}` example put a literal placeholder into every request URL. `BaseUrl` and `TokenEndpoint` now resolve `{tenant}`/`{environment}` and default to the SaaS endpoints — required settings drop from seven to four. Added an `AddBusinessCentral(IConfiguration)` overload.

**Typed queries.** Field names were strings, so typos surfaced as HTTP 400 at runtime, and the README's PascalCase filters disagreed with the camelCase serializer.

```csharp
var orders = await client.Query<SalesOrder>()          // path from [BusinessCentralEntity]
    .Where(Filter.Equals<SalesOrder>(o => o.Status, "Open"))
    .OrderByDescending(o => o.Amount)
    .ThenBy(o => o.No)
    .Select(o => o.No, o => o.Amount)
    .Top(50)
    .ToListAsync();
```

Names resolve through the same `JsonSerializerOptions` used for deserialization, so filters and projections cannot drift from the model.

**Throttling.** BC throttles hard and sends `Retry-After`; that previously threw immediately. Transient failures are now retried with `Retry-After`-aware backoff. Writes are **not** blindly replayed — a `429` is rejected before processing so replay is safe, but `408/502/503/504` are ambiguous, so a `POST` is not retried on them and the exception surfaces instead. A duplicate record is worse than a surfaced error. `Retry.RetryPostOnTransientFailures` opts back in.

**Errors.** `Message` embedded the entire response body, flooding structured logs. Now a single line, with the body, URL, OData code and correlation ID on properties and `ToString()` rendering everything. `429` gets its own `BusinessCentralThrottledException`, and every exception exposes `IsTransient`/`RetryAfter`.

**Capability gaps.** `$expand`, `$count`, `IAsyncEnumerable` streaming that stops fetching when enumeration stops, `ForCompany()` so one registration serves every company, `GetCompaniesAsync()`. `QueryOptions` gained `WithPageSize` — `WithTop` silently meant "page size" inside `QueryAllAsync` — and `ThenByAsc/Desc`, since chained `OrderByAsc` calls used to discard all but the last.

**Writes.** `PostAsync<T>` used one type parameter for both request and response, forcing callers into `PostAsync<dynamic>` plus a runtime type check. Added `PostAsync<TPayload, TResult>` and the same for PATCH/PUT. The two forms are separated purely by generic arity, which is what keeps existing calls binding unchanged — three tests pin that resolution.

Also: `ConfigureAwait(false)` throughout, so sync-over-async callers cannot deadlock; `Filter.In` with an empty collection yields `false` instead of the invalid `field in ()`.

## Testing

**80 → 141 tests**, green on net8.0/net9.0/net10.0 with zero warnings. New suites cover the query builder, retry/replay safety, options resolution and write-overload resolution.

Three pre-existing tests were rewritten because they asserted the buggy behaviour: two expected a throw on `204`, and one asserted the OData error code lived inside `Message`.

## Known limitations

- Every test runs against a fake handler; **none of this has production mileage**.
- `GetCompaniesAsync` targets `{BaseUrl}/Company` and `BusinessCentralCompany` exposes `Name` reliably, but `DisplayName`/`Id`/`IsEvaluationCompany` are best-effort and null when absent. Not verified against a live tenant.
- Whether BC honours `Prefer: return=representation` on any given endpoint is unverified, which determines how often the `204` path is hit.
- No Native AOT / trimming support — `System.Text.Json` reflection plus the reflection in `PropertyPath`/`EntityPath` block it.
- ETags remain effectively write-only: `ifMatch` is accepted but the library gives no help obtaining one.

## Review notes

- `ExcludeFromCodeCoverage` was removed from `ServiceCollectionExtensions` now that the DI wiring carries real logic and is covered — revert if you'd rather keep it excluded for Sonar.
- `Filter.Equals` was deliberately **not** renamed despite colliding with `object.Equals(object, object)` in overload resolution; `Eq` reads worse and the typed overloads sidestep it.
- A real LINQ provider was deliberately not attempted. The builder covers the same ground at a fraction of the complexity.
- The branch name predates the scope growth and describes only the first commit.


