### PR TITLE
Pre-stable fixes: DateOnly/TimeOnly filter literals, network-failure retry, Sonar cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`BusinessCentralConnectionException`.** Connection-level failures and client-side
+  timeouts — where no response was received at all — now surface as a
+  `BusinessCentralException` subtype (`StatusCode` is `0`) instead of escaping as raw
+  `HttpRequestException`/`TaskCanceledException`, so `catch (BusinessCentralException)`
+  sees every failure the client produces. The original exception is preserved as
+  `InnerException`. Cancellation via the caller's own token still throws
+  `OperationCanceledException`, unwrapped.
+
+### Changed
+
+- **Network failures are retried.** Connection failures and client-side timeouts now go
+  through the transient-retry budget under the same replay rules as `408`/`502`/`503`/`504`:
+  idempotent methods are replayed, `POST` is held back unless
+  `Retry.RetryPostOnTransientFailures` is set. Previously they bypassed retry entirely and
+  failed on the first attempt.
+
+### Fixed
+
+- **`DateOnly` and `TimeOnly` filter values produce valid OData literals**
+  (`2026-07-29`, `13:45:30.0000000`). They previously fell through to a culture-formatted
+  string such as `07/29/2026`, which Business Central rejects — notably breaking filters
+  on date fields like `postingDate`.
+
 ## [2.0.0-alpha] - 2026-07-28
 
 **Prerelease.** Published for validation against real Business Central environments before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`WithTop` is a result cap in `QueryAllAsync`/`QueryStreamAsync`**, matching its own
+  documentation and the fluent builder's `Top()`. It was previously repurposed as the page
+  size — `WithTop(10)` returned the entire collection in pages of 10 — and was silently
+  ignored outright when `WithPageSize` was also set. Requests never overshoot the cap
+  (`$top` shrinks to what is still wanted). Use `WithPageSize` to size round trips.
+- **Kindless `DateTime` filter values are no longer shifted by the machine's timezone.**
+  `DateTimeKind.Unspecified` — the kind of anything parsed from config or loaded from a
+  database — was run through `ToUniversalTime()`, which assumes local time, so the same
+  filter matched different rows depending on where the code ran. Unspecified is now taken
+  to already be UTC. `Utc` and `Local` values are unaffected.
 - **`DateOnly` and `TimeOnly` filter values produce valid OData literals**
   (`2026-07-29`, `13:45:30.0000000`). They previously fell through to a culture-formatted
   string such as `07/29/2026`, which Business Central rejects — notably breaking filters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Default implementations on every `IBusinessCentralClient` member.** Hand-written test
+  fakes now implement only the members they exercise; everything else throws
+  `NotSupportedException` naming the member. Interface growth no longer breaks consumer
+  builds. `FirstOrDefaultAsync` composes over `QueryAsync`, so fakes get it for free.
+- **Single-entity reads on the path-based API.** `GetAsync<T>(path, key, select?)` fetches
+  by systemId or alternate key and returns `null` on `404` — "does it exist" is a question,
+  not an error. `FirstOrDefaultAsync<T>(path, filter?, select?)` sends `$top=1`.
+- **`BusinessCentralHttpClients`** exposes the package's two `IHttpClientFactory` client
+  names, so a global resilience handler (e.g. Aspire's `AddStandardResilienceHandler`) can
+  exempt them instead of double-retrying — the README's *"Composing with an existing
+  resilience pipeline"* section shows how.
+- **Predicate properties on `BusinessCentralException`**: `IsNotFound`, `IsThrottled`,
+  `IsValidation`, `IsAuth`, `IsConnectionFailure`. The subtypes are sealed siblings, so
+  `catch (BusinessCentralServerException ex) when (ex.StatusCode == NotFound)` compiles but
+  never matches; `when (ex.IsNotFound)` is the supported form.
+- **`BusinessCentralField.Of<T>(selector)`** resolves a property selector to its wire name
+  (`[JsonPropertyName]` first, then the camelCase policy), and **`EntityPath` is now
+  public** — path-based consumers can delete hand-maintained field/path constants.
+
 - **`BusinessCentralConnectionException`.** Connection-level failures and client-side
   timeouts — where no response was received at all — now surface as a
   `BusinessCentralException` subtype (`StatusCode` is `0`) instead of escaping as raw

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,10 +35,10 @@ CI: `.github/workflows/sonar.yml` builds + tests on net8.0 and runs SonarCloud o
 
 `src/Dynamics365.BusinessCentral/` — one assembly, folders by concern:
 
-- **`Client/`** — `BusinessCentralClient` (sealed, the only implementation of `IBusinessCentralClient`) plus the internal `BusinessCentralTokenProvider`, `BusinessCentralUrlBuilder` and `HttpRequestExtensions`.
+- **`Client/`** — `BusinessCentralClient` (sealed, the only implementation of `IBusinessCentralClient`) plus the internal `BusinessCentralTokenProvider`, `BusinessCentralUrlBuilder` and `HttpRequestExtensions`. Every `IBusinessCentralClient` member has a **default implementation** so hand-written consumer fakes keep compiling across interface growth — a new member must either throw via the interface's private `NotImplemented` helper or, when it can be composed from other members (like `FirstOrDefaultAsync` over `QueryAsync`), do that so fakes inherit it. `DefaultInterfaceTests` pins the contract.
 - **`OData/`** — the typed query surface: `IBusinessCentralQuery<T>`/`BusinessCentralQuery<T>` (fluent builder), `PropertyPath` (selector → field name), `EntityPath` + `BusinessCentralEntityAttribute` (type → entity set), `Filter`/`ODataFilter`/`FilterExtensions`, `QueryOptions`, `ODataResponse<T>`, `BusinessCentralPage<T>`, `BusinessCentralCompany`.
 - **`Options/`** — `BusinessCentralOptions` (credentials, base URL, company), `BusinessCentralOptionsValidator`, and `BusinessCentralJson.Options`, the single shared `JsonSerializerOptions` (camelCase policy, case-insensitive read) used by both the client and the exception factory.
-- **`Errors/`** — `BusinessCentralException` base + five sealed subtypes (incl. `BusinessCentralThrottledException`); `BusinessCentralExceptionFactory` maps status codes and parses `Retry-After`.
+- **`Errors/`** — `BusinessCentralException` base + six sealed subtypes (incl. `BusinessCentralThrottledException` and `BusinessCentralConnectionException`, whose `StatusCode` is `0` — no response); `BusinessCentralExceptionFactory` maps status codes and parses `Retry-After`. The subtypes are sealed siblings, so the base carries predicates (`IsNotFound`, `IsThrottled`, `IsValidation`, `IsAuth`, `IsConnectionFailure`) — add one when adding a subtype.
 - **`Diagnostics/`** — `IBusinessCentralObserver` and its info DTOs.
 - **`ServiceCollectionExtensions.cs`** — `AddBusinessCentral` / `AddObserver<T>`.
 
@@ -108,7 +108,7 @@ There is no `ILogger` dependency. Instead the client takes an optional `IBusines
 
 ### DI registration
 
-Two `AddBusinessCentral` overloads (lambda and `IConfiguration`) share `AddBusinessCentralCore`, which wires options + `BusinessCentralOptionsValidator` (an `IValidateOptions<>` that names *each* missing setting rather than collapsing to one boolean), a named token `HttpClient`, the singleton `BusinessCentralTokenProvider`, and the typed client. Both HTTP clients are registered under explicit names (`TokenHttpClientName`, `ClientHttpClientName`) so tests can swap primary handlers without replacing the registration.
+Two `AddBusinessCentral` overloads (lambda and `IConfiguration`) share `AddBusinessCentralCore`, which wires options + `BusinessCentralOptionsValidator` (an `IValidateOptions<>` that names *each* missing setting rather than collapsing to one boolean), a named token `HttpClient`, the singleton `BusinessCentralTokenProvider`, and the typed client. Both HTTP clients are registered under explicit names — public via `BusinessCentralHttpClients.Token`/`.Client`, a deliberate API so consumers can exempt them from global resilience handlers — so tests can swap primary handlers without replacing the registration.
 
 The typed client uses the explicit-factory overload of `AddHttpClient`, not `ActivatorUtilities` — the constructor taking `BusinessCentralTokenProvider` is `internal` and would otherwise never be selected.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Two paging implementations exist and must stay in agreement: `BusinessCentralCli
 2. Once `serverDriven`, a missing nextLink means the collection is exhausted — the `$top` short-page rule no longer applies.
 3. Otherwise stop on the first page shorter than the requested size.
 
-`QueryOptions.PageSize` is rows-per-round-trip; `Top` is a result cap. `PageSize ?? Top ?? 1000` keeps the old `WithTop`-as-page-size behaviour working.
+`QueryOptions.PageSize` is rows-per-round-trip; `Top` is a result cap — in both implementations. Each computes the next request's `$top` via `NextTop(pageSize, limit, emitted)` so a request never overshoots the cap. The old `WithTop`-as-page-size behaviour is gone (2.0); `WithPageSize` is the only way to size round trips.
 
 ### Writes
 

--- a/CONSUMER-FEEDBACK-BASTION.md
+++ b/CONSUMER-FEEDBACK-BASTION.md
@@ -1,0 +1,612 @@
+# Consumer feedback: Bastion
+
+Improvement proposals for **Dynamics365.BusinessCentral**, derived from migrating a large
+production consumer (Bastion) from `1.0.0` to `2.0.0-alpha` on 2026-07-29.
+
+This document is written to be self-contained: an agent working in this repository does not
+need access to the Bastion codebase. All supporting evidence is quoted inline.
+
+**How to use this file.** Each proposal is independent and issue-shaped: problem → evidence →
+proposal → acceptance criteria. Implement in priority order, or split into separate issues.
+Nothing here is a bug report against the package — everything below is behaving as designed.
+The argument is that some of those designs push avoidable work onto consumers.
+
+---
+
+## Context: how Bastion uses this package
+
+| Property | Value |
+| --- | --- |
+| Consumer | Bastion — event-sourced modular monolith, live in production since 2026-05-03 |
+| Package version | `2.0.0-alpha` (tag `v2.0.0-alpha` = commit `1d6dc8f`) |
+| Target framework | `net10.0` |
+| Call style | **100% path-based** (`QueryAsync`, `QueryAllAsync`, `PostAsync`, `PatchAsync`, `DeleteAsync`). The typed `Query<T>()` builder is not used anywhere. |
+| Companies | Single (`KRAL AG`). `ForCompany` / `GetCompaniesAsync` unused. |
+| Observers | **None.** `IBusinessCentralObserver` is not implemented anywhere. |
+| Adapters | 6 classes wrapping the client across 4 bounded contexts |
+| Resilience | `Microsoft.Extensions.Http.Resilience` `AddStandardResilienceHandler` applied globally via .NET Aspire `ConfigureHttpClientDefaults` |
+
+The migration result is the key datum for this document:
+
+> **18 compile errors. All 18 were in two hand-written `IBusinessCentralClient` test fakes.
+> Zero production code required changes to compile.**
+
+The package's breaking-change surface, in practice, was entirely a *testing* surface.
+
+---
+
+## Summary
+
+| ID | Proposal | Priority | Est. effort |
+| --- | --- | --- | --- |
+| P1 | Default interface methods on `IBusinessCentralClient` | **High** | Low |
+| P2 | Ship a `Dynamics365.BusinessCentral.Testing` package | **High** | Medium |
+| P3 | Auto-chunked `In` / key-set fetch | **High** | Medium |
+| P4 | Native OpenTelemetry (`ActivitySource` + `Meter`) | Medium | Medium |
+| P5 | Make the HTTP client names public | Medium | Trivial |
+| P6 | Single-entity fetch on the path-based API | Medium | Low |
+| P7 | Predicate helpers on `BusinessCentralException` | Medium | Trivial |
+| P8 | Public field-name resolution + selector-based `$select` on the path API | **High** | Low |
+
+If only one is implemented, implement **P2** (with **P1** as its prerequisite). That is the
+one place where the package currently *creates* recurring work for consumers rather than
+absorbing it.
+
+---
+
+## P1 — Default interface methods on `IBusinessCentralClient`
+
+**Priority: High · Effort: Low · Breaking: No**
+
+### Problem
+
+Every addition to `IBusinessCentralClient` is a source-breaking change for any consumer that
+hand-writes a test double. 2.0 added nine members, and that alone accounted for 100% of the
+build breakage in a ~200k-line consumer.
+
+Mocking libraries absorb this. Hand-written fakes do not — and consumers write hand-written
+fakes when the behaviour they need is stateful enough that `Moq` setups become unreadable
+(see P2 for why they get unreadable here specifically).
+
+### Evidence
+
+The nine members added in 2.0, each of which had to be stubbed by hand in two Bastion test
+classes purely to restore compilation:
+
+```
+Company, ForCompany, Query<TEntity>(), Query<TEntity>(string), GetCompaniesAsync,
+QueryStreamAsync, PostAsync<TPayload,TResult>, PatchAsync<TPayload,TResult>,
+PutAsync<TPayload,TResult>
+```
+
+None of them were called by the code under test. All were stubbed as
+`throw new NotSupportedException()`.
+
+### Proposal
+
+Give every member a default implementation of `=> throw new NotSupportedException(...)`.
+
+This precedent already exists in the package and is documented in the 2.0 changelog:
+
+> `OnTokenServedFromCache` and `OnRequestRetrying` observer events, **both default interface
+> methods so existing observers keep compiling**.
+
+Apply the same reasoning to the client interface. The members a fake cannot meaningfully
+implement are exactly the members it does not want to implement.
+
+Note the C# detail for the two-generic overloads: an unconstrained `TResult` in a default
+implementation of an interface member that returns `TResult?` needs `where TResult : default`
+on the implementing signature.
+
+### Acceptance criteria
+
+- [ ] Every member of `IBusinessCentralClient` has a default implementation that throws
+      `NotSupportedException` with a message naming the member.
+- [ ] A test fixture implementing *only* `QueryAsync<T>` compiles and runs.
+- [ ] A regression test asserts that a minimal implementer compiles (e.g. a fake in the test
+      project that implements one member and nothing else).
+- [ ] MIGRATION.md's "hand-written test fake will not compile" warning can be deleted.
+
+---
+
+## P2 — Ship a `Dynamics365.BusinessCentral.Testing` package
+
+**Priority: High · Effort: Medium · Breaking: No**
+
+### Problem
+
+Two distinct costs, both borne by every consumer:
+
+1. **Fakes must be hand-written**, so interface growth breaks builds (P1 mitigates, does not
+   eliminate).
+2. **The generated OData is unassertable.** A consumer can verify *that* a query happened but
+   not *what it asked for*. Filter construction, `$select` field names, casing and paging are
+   the highest-risk part of using an OData client, and they are the part consumers cannot
+   test.
+
+### Evidence
+
+Bastion's mock setups, repeated roughly forty times in a single test file:
+
+```csharp
+clientMock.Setup(c => c.QueryAsync<ProductionOrderEntity>(
+    It.IsAny<string>(),
+    It.IsAny<ODataFilter?>(),
+    It.IsAny<Action<QueryOptions>?>(),
+    It.IsAny<IEnumerable<string>?>(),
+    It.IsAny<CancellationToken>()))
+    .ReturnsAsync([...]);
+```
+
+Five `It.IsAny` lines to express "any query at all". The strongest available assertion about
+the query that was actually built is:
+
+```csharp
+client.LastQueryFilter.ShouldNotBeNull();
+```
+
+That this matters is demonstrable, not theoretical. Bastion's BC field-name strings have
+already drifted in casing across adapters:
+
+```
+Filter.Equals("no",  ...)   and   Filter.Equals("No",  ...)
+Filter.Equals("positive", ...)   and   Filter.Equals("Positive", ...)
+```
+
+No test in the consumer could have caught that, because no test can see the emitted URL.
+
+The package already contains the necessary machinery — `test/…/Utils/FakeHttpHandler.cs` —
+it is simply not shipped.
+
+### Proposal
+
+Publish a companion package containing:
+
+1. **`FakeBusinessCentralHandler`** — the existing `FakeHttpHandler`, promoted to public API,
+   so consumers can build a *real* `BusinessCentralClient` over a scripted transport. This is
+   the highest-fidelity option: it exercises URL building, paging, retry and deserialization.
+2. **`InMemoryBusinessCentralClient`** — seed entities, query them, and record every request.
+   Cheaper than (1) for consumers who only want their own mapping logic under test.
+3. **Request capture** on both, exposing the generated relative URL:
+
+```csharp
+var client = new InMemoryBusinessCentralClient()
+    .Seed("items", new Item { No = "X", Description = "Pump" });
+
+var result = await client.QueryAsync<Item>("items", Filter.Equals("no", "X"),
+                                           select: ["no", "description"]);
+
+client.Requests.Single().Url
+      .ShouldBe("items?$filter=no eq 'X'&$select=no,description");
+```
+
+### Acceptance criteria
+
+- [ ] New project `src/Dynamics365.BusinessCentral.Testing`, published as its own NuGet package.
+- [ ] Consumers can assert the exact relative URL produced by a query, including `$filter`,
+      `$select`, `$expand`, `$top`, `$skip` and `$orderby`.
+- [ ] A fake can be constructed with zero arguments and used without implementing any interface
+      member.
+- [ ] Multi-page responses can be scripted, including server-driven `@odata.nextLink`, so
+      consumers can test their own paging assumptions.
+- [ ] Failures can be scripted by status code, so consumers can test their `catch` branches
+      without constructing exception types by hand.
+- [ ] README section: "Testing against Business Central".
+
+> The last criterion is worth calling out. Bastion currently has comments in two test files
+> reading *"BusinessCentralServerException-specific 404 / status-code tests are covered via
+> integration tests where we can construct the SDK exception through the real client."* Those
+> integration tests do not exist. The branches are untested because constructing the exception
+> types by hand is impractical.
+
+---
+
+## P3 — Auto-chunked `In` / key-set fetch
+
+**Priority: High · Effort: Medium · Breaking: No**
+
+### Problem
+
+`Filter.In` exists but goes unused, because using it *correctly* requires knowledge the
+consumer does not have: Business Central's URL length limit, and how to chunk, parallelise
+and merge around it. Consumers therefore fan out one request per key — against an API this
+package's own README describes as throttling aggressively.
+
+### Evidence
+
+`Filter.In` appears **zero times** across the entire Bastion codebase. Meanwhile, its
+nameplate adapter issues one HTTP request per item number:
+
+```csharp
+var distinct = itemNumbers.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+var tasks = distinct.Select(n => _client.QueryAsync<Item>(
+    Item.ItemPath,
+    Filter.Equals(ItemFields.ItemNumber, n),
+    select: [ /* six fields */ ],
+    cancellationToken: ct));
+
+var results = await Task.WhenAll(tasks);
+```
+
+Unbounded parallelism, N round trips, one 429 away from a partial failure — for what is
+semantically a single `no in (...)` query.
+
+### Proposal
+
+Put the chunking in the client, where the URL limit and throttling behaviour are already
+known:
+
+```csharp
+await client.Query<Item>()
+            .WhereIn(i => i.No, itemNumbers)   // chunks, bounds concurrency, merges
+            .ToAllAsync(ct);
+```
+
+with a path-based equivalent for consumers who have not adopted the builder.
+
+Behaviour to specify: chunk by encoded URL length rather than element count; bound concurrency
+(default small, e.g. 4); preserve `$select`/`$expand` across chunks; deduplicate merged
+results; and surface a partial-failure policy rather than letting one chunk's 429 discard the
+whole set.
+
+### Acceptance criteria
+
+- [ ] `WhereIn` on the builder and an `InChunked`-style helper on the path-based API.
+- [ ] Chunk boundaries derived from encoded URL length, with the limit configurable.
+- [ ] Concurrency bounded and configurable.
+- [ ] Test: 500 keys produce > 1 request, all keys appear exactly once in the merged result.
+- [ ] Test: an empty key collection issues **zero** requests and returns empty — consistent
+      with the existing `Filter.In` empty-collection semantics.
+- [ ] README section, cross-linked from `Filter.In`, since discoverability is the actual
+      failure here.
+
+---
+
+## P4 — Native OpenTelemetry
+
+**Priority: Medium · Effort: Medium · Breaking: No**
+
+### Problem
+
+`IBusinessCentralObserver` is the only way to get insight into the client, and it requires
+consumers to write and register an implementation. Consumers with an existing OTel pipeline
+get nothing automatically — the package is an unlabelled HTTP span.
+
+### Evidence
+
+Bastion implements **zero** observers, despite running OpenTelemetry with Seq and Application
+Insights sinks, and despite having a module whose whole purpose is querying that telemetry.
+`AddHttpClientInstrumentation` yields a span that says an HTTPS request occurred, with no
+entity set, no operation, no company, no retry context.
+
+The friction is that writing an observer is work whose payoff is not obvious up front, so it
+never reaches the top of a backlog.
+
+### Proposal
+
+Emit `System.Diagnostics.ActivitySource` spans and `System.Diagnostics.Metrics.Meter`
+instruments directly. Both are BCL types — this adds **no** package dependency, which keeps
+the existing "no logging dependency" design intent intact.
+
+Suggested span attributes: entity set / path, OData operation, company, HTTP method, status
+code, attempt number, whether the token was served from cache.
+
+Suggested instruments: request duration histogram; counters for throttled responses, retries,
+token refreshes and cache hits.
+
+Keep `IBusinessCentralObserver` for callback-style consumers; make OTel the default so
+upgrading is all that is required to benefit.
+
+### Acceptance criteria
+
+- [ ] A documented `ActivitySource` name, stable across versions.
+- [ ] A documented `Meter` name and instrument list.
+- [ ] Spans correctly parent under an ambient `Activity`.
+- [ ] Retries appear as distinct, correlated attempts rather than one opaque span.
+- [ ] No new package dependency.
+- [ ] README section: "Observability", with the one-liner needed to wire it into OTel.
+
+---
+
+## P5 — Make the HTTP client names public
+
+**Priority: Medium · Effort: Trivial · Breaking: No**
+
+### Problem
+
+```csharp
+internal const string TokenHttpClientName  = "Dynamics365.BusinessCentral.Token";
+internal const string ClientHttpClientName = "Dynamics365.BusinessCentral.Client";
+```
+
+Because these are `internal`, a consumer cannot address the package's HTTP clients by name.
+The practical consequence: a consumer with a global `ConfigureHttpClientDefaults` policy
+cannot exempt the Business Central clients from it.
+
+### Evidence
+
+Bastion (via .NET Aspire's standard `ServiceDefaults`) applies
+`AddStandardResilienceHandler` to **every** `IHttpClientFactory` client, including this
+package's two. With the package's own retry also enabled, the two compose multiplicatively —
+roughly nine HTTP requests per logical call — and the package's backoff sleeps consume the
+outer handler's 3-minute total-request timeout.
+
+The correct resolution is to disable the *outer* handler for the BC clients and keep the
+package's retry, which is strictly better: it honours `Retry-After` and refuses to replay a
+`POST` on ambiguous transients. That resolution is unavailable, because the client names are
+internal.
+
+Bastion therefore had to take the inferior option — `options.Retry.Enabled = false` — keeping
+an outer handler that **retries `POST` by default**, and so can duplicate rows in an entity
+set with no uniqueness enforcement. The package's own POST-safety logic is bypassed entirely,
+because the outer handler retries before the package ever observes a failure.
+
+### Proposal
+
+Promote both constants to public API on a stable type:
+
+```csharp
+public static class BusinessCentralHttpClients
+{
+    public const string Token  = "Dynamics365.BusinessCentral.Token";
+    public const string Client = "Dynamics365.BusinessCentral.Client";
+}
+```
+
+Optionally add a convenience opt-out — e.g. `AddBusinessCentral(..., configureHttpClient:)`
+or a documented `RemoveAllResilienceHandlers()` recipe.
+
+### Acceptance criteria
+
+- [ ] Both names exposed as public constants.
+- [ ] README section: "Composing with an existing resilience pipeline", covering both the
+      "disable ours" and "disable theirs" options and stating why the latter is preferable.
+- [ ] MIGRATION.md's retry-composition note links to it.
+
+---
+
+## P6 — Single-entity fetch on the path-based API
+
+**Priority: Medium · Effort: Low · Breaking: No**
+
+### Problem
+
+`FirstOrDefaultAsync` exists on the typed builder, but there is no path-based equivalent.
+Consumers who have not adopted the builder — which, for an existing 1.x codebase, is most of
+them — write the same three-line dance at every call site.
+
+### Evidence
+
+This shape recurs throughout Bastion (order lookup, status probe, service-item lookup by key):
+
+```csharp
+var orders = await _client.QueryAsync<ProductionOrderEntity>(
+    path, Filter.Equals("no", productionOrderNumber), select: [...], cancellationToken: ct);
+
+if (orders.Count == 0)
+    return new BcOrderStatusResult.NotFound();
+
+var status = orders[0].Status;
+```
+
+### Proposal
+
+```csharp
+Task<TEntity?> GetAsync<TEntity>(string path, string key, IEnumerable<string>? select = null,
+                                 CancellationToken cancellationToken = default);
+
+Task<TEntity?> FirstOrDefaultAsync<TEntity>(string path, ODataFilter? filter = null,
+                                            IEnumerable<string>? select = null,
+                                            CancellationToken cancellationToken = default);
+```
+
+`GetAsync` should return `null` on `404` rather than throwing — "does this entity exist" is a
+question, not an error. Add it as a default interface method (see P1) so it is non-breaking.
+
+### Acceptance criteria
+
+- [ ] Both methods on `IBusinessCentralClient`, as default interface methods.
+- [ ] `GetAsync` returns `null` on `404`; all other failures still throw.
+- [ ] `FirstOrDefaultAsync` sends `$top=1`.
+- [ ] Alternate keys (`No='1000'`) work, consistent with the existing key handling.
+
+---
+
+## P7 — Predicate helpers on `BusinessCentralException`
+
+**Priority: Medium · Effort: Trivial · Breaking: No**
+
+### Problem
+
+The exception types are **sealed siblings**, not a hierarchy. This is a defensible design, but
+it invites a specific bug that the compiler cannot catch and that MIGRATION.md already warns
+about — which is itself evidence that the shape is a trap.
+
+### Evidence
+
+This clause shipped in Bastion's production code and was **unreachable for the entire 1.0
+lifetime**:
+
+```csharp
+catch (BusinessCentralServerException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+{
+    // Already gone — idempotent success
+    return Result.Success();
+}
+```
+
+`404` is `BusinessCentralNotFoundException`, a sealed sibling, so the guard could never match.
+The intended idempotent-delete behaviour silently never happened; the call returned a failure
+instead. It compiles, reads correctly, passes review, and is wrong.
+
+MIGRATION.md documents this well. But documentation is the weakest available fix for a
+mistake the type system permits.
+
+### Proposal
+
+Add predicate properties to the base type so consumers stop pattern-matching on subtypes:
+
+```csharp
+public bool IsNotFound   => StatusCode == HttpStatusCode.NotFound;
+public bool IsThrottled  => StatusCode == HttpStatusCode.TooManyRequests;
+public bool IsValidation => StatusCode == HttpStatusCode.BadRequest;
+public bool IsAuth       => StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden;
+```
+
+Then the safe form is also the obvious one:
+
+```csharp
+catch (BusinessCentralException ex) when (ex.IsNotFound) { ... }
+```
+
+Consider additionally a Roslyn analyzer flagging `catch (BusinessCentral*Exception) when
+(ex.StatusCode == ...)` where the pairing is unsatisfiable. That would have caught the bug
+above at compile time.
+
+### Acceptance criteria
+
+- [ ] Predicate properties on `BusinessCentralException`, alongside the existing `IsTransient`.
+- [ ] README error table shows the `when (ex.IsNotFound)` form as the recommended pattern.
+- [ ] Optional: analyzer for unsatisfiable status-code guards.
+
+---
+
+## P8 — Public field-name resolution + selector-based `$select` on the path API
+
+**Priority: High · Effort: Low · Breaking: No**
+
+### Problem
+
+Consumers on the path-based API hand-maintain constants classes that duplicate wire names the
+entity model **already declares**. The package can resolve those names — `PropertyPath` does
+exactly this, honouring `[JsonPropertyName]` before the naming policy — but the capability is
+`internal`, and the path-based `select:` parameter accepts only `IEnumerable<string>`.
+
+So a consumer who has not adopted the `Query<T>()` builder has no way to express a field name
+in terms of the model, and falls back to string constants maintained by hand.
+
+### Evidence
+
+A representative entity from Bastion. The wire names are declared authoritatively via
+`[JsonPropertyName]` — and then copied by hand, immediately below, into a parallel constants
+class:
+
+```csharp
+public sealed class ProductionOrderLine : DynamicsEntity
+{
+    public const string ProductionOrderLinesPath = "LDATProdOrderLine";
+
+    [JsonPropertyName("prodOrderNo")]        public string ProductionOrderNumber { get; set; } = default!;
+    [JsonPropertyName("itemNo")]             public string ItemNumber { get; set; } = default!;
+    [JsonPropertyName("lineNo")]             public int    LineNumber { get; set; }
+    [JsonPropertyName("ccoItemCategoryCode")] public string ItemCategoryCode { get; set; } = default!;
+    [JsonPropertyName("quantity")]           public decimal Quantity { get; set; } = default!;
+    [JsonPropertyName("planningLevelCode")]  public int    PlanningLevelCode { get; set; }
+}
+
+public static class ProductionOrderLineFields
+{
+    public const string ProdOrderNo         = "prodOrderNo";
+    public const string ItemNumber          = "itemNo";
+    public const string LineNumber          = "lineNo";
+    public const string ItemCategoryCode    = "ccoItemCategoryCode";
+    public const string Quantity            = "quantity";
+    public const string PlanningLevelCode   = "planningLevelCode";
+}
+```
+
+Six properties, six manually duplicated constants — and the duplication has already drifted
+in vocabulary: every constant is named after its C# property **except** `ProdOrderNo`, which
+is named after the wire field while the property is `ProductionOrderNumber`. A caller reading
+`ProductionOrderLineFields.ProdOrderNo` must know it refers to `ProductionOrderNumber`. This
+pattern is repeated across roughly a dozen entity types in the consumer.
+
+Note also that `ProductionOrderLinesPath` is a hand-rolled `[BusinessCentralEntity]`.
+
+**Half of this is already solvable today.** Because `PropertyPath` honours
+`[JsonPropertyName]`, the typed filter overloads already emit the correct wire name with no
+package change:
+
+```csharp
+Filter.Equals<ProductionOrderLine>(l => l.ProductionOrderNumber, poNumber)  // → prodOrderNo
+```
+
+The constants survive **only** because of `$select`, which on the path-based API has no
+selector-based form.
+
+### Proposal
+
+Two small additions that let consumers delete these classes entirely without adopting the
+builder wholesale:
+
+**(a) Make field-name resolution public.** Expose a thin facade over `PropertyPath`:
+
+```csharp
+public static class BusinessCentralField
+{
+    public static string Of<TEntity>(Expression<Func<TEntity, object?>> selector);
+}
+```
+
+This alone lets a consumer replace a constants class with call-site resolution, and is a
+one-line change to visibility plus a public wrapper.
+
+**(b) Add selector overloads for `select:` on the path-based API**, mirroring the builder's
+`Select(params Expression<Func<TEntity, object?>>[])`:
+
+```csharp
+var lines = await client.QueryAsync<ProductionOrderLine>(
+    ProductionOrderLine.Path,
+    Filter.Equals<ProductionOrderLine>(l => l.ProductionOrderNumber, poNumber),
+    select: [l => l.ItemNumber, l => l.Quantity]);
+```
+
+Optionally **(c)**: make `EntityPath.For<T>()` public too, so a consumer that annotates its
+entities can drop hand-rolled path constants without being forced onto `Query<T>()`.
+
+Together these remove the last reason to hand-maintain wire names, and they are a fraction of
+the cost of the source generator originally considered for this slot.
+
+### Acceptance criteria
+
+- [ ] Public API for resolving a property selector to an OData field name, sharing
+      `PropertyPath`'s implementation (not a reimplementation).
+- [ ] `QueryAsync` / `QueryAllAsync` / `QueryStreamAsync` accept selector-based `select`
+      alongside the existing string form.
+- [ ] `EntityPath.For<T>()` exposed publicly.
+- [ ] Test: a selector-resolved name for a property carrying `[JsonPropertyName]` returns the
+      attribute value, not the camelCase policy result.
+- [ ] README section aimed at path-based consumers: "Using field selectors without the query
+      builder" — this is the discoverability gap, since the typed `Filter` overloads already
+      work today and consumers are not finding them.
+
+---
+
+## Appendix: provenance and confidence
+
+**Method.** Migrated Bastion from `1.0.0` to `2.0.0-alpha`: read `CHANGELOG.md`,
+`MIGRATION.md`, `README.md` and the package source; mapped every consumer call site; built;
+fixed; ran the full test suite (1,159 unit tests, ~460 integration tests, all green).
+
+**Read closely:** `Client/IBusinessCentralClient.cs`, `Client/BusinessCentralClient.cs`,
+`ServiceCollectionExtensions.cs`, `Options/BusinessCentralOptions.cs`,
+`Errors/BusinessCentralException.cs`, `OData/PropertyPath.cs`, `OData/EntityPath.cs`,
+`Options/BusinessCentralJson.cs`, and the public signatures of `OData/Filter.cs` and
+`OData/IBusinessCentralQuery.cs`.
+
+**Skimmed only:** `OData/BusinessCentralQuery.cs`, `Client/BusinessCentralUrlBuilder.cs`,
+`Client/BusinessCentralTokenProvider.cs`.
+
+P3 touches the skimmed files. If chunked `In` already exists in some form, discount it
+accordingly.
+
+**Version note.** Findings are against tag `v2.0.0-alpha` (commit `1d6dc8f`). At the time of
+writing, `master`'s `[Unreleased]` section contains `BusinessCentralConnectionException`,
+network-failure retry and the `DateOnly`/`TimeOnly` filter-literal fix — none of which are in
+the published alpha, and none of which affect the proposals above.
+
+**Not included.** Defects found during migration are absent from this document because there
+were none. Every 2.0 behavioural change encountered was correct, deliberate and documented in
+MIGRATION.md; the two latent bugs surfaced (the unreachable `catch`, and the truncating
+`QueryAllAsync` reconciliation) were consumer-side, and one of them was *fixed* by upgrading.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -81,6 +81,15 @@ always safe; the others are ambiguous, so a `POST` is *not* retried on them:
 | `PATCH` | retried | retried — this client sends absolute values, so replay converges |
 | `POST` | retried | **not** retried |
 
+Connection-level failures — a reset connection, a DNS error, the `HttpClient` timeout —
+follow the same rules as the ambiguous statuses: idempotent methods are retried, `POST` is
+not. They also now surface as `BusinessCentralConnectionException` (`StatusCode` is `0` —
+no response was received) instead of a raw `HttpRequestException` or
+`TaskCanceledException`. **A `catch (HttpRequestException)` around client calls no longer
+fires**; catch `BusinessCentralConnectionException` or the base type, and find the original
+exception on `InnerException`. Cancelling through your own `CancellationToken` still throws
+`OperationCanceledException`, unwrapped.
+
 If you already have an outer retry policy (Polly, Wolverine, a message broker), the two now
 compose multiplicatively. Consider lowering `Retry.MaxAttempts`, or disabling it:
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -103,6 +103,21 @@ It now follows `@odata.nextLink`. Where Business Central applied a server-side p
 below the requested `$top`, 1.0 stopped early and silently truncated. Reconciliation logic
 that assumed the old result size should be re-checked.
 
+### `QueryAllAsync` with `WithTop` may return far fewer rows
+
+The opposite direction: `WithTop(n)` was 1.0's page size and did not limit results; it is
+now a result cap, as documented. A call like `QueryAllAsync(..., o => o.WithTop(500))`
+that used to fetch *everything* in pages of 500 now returns at most 500 rows. Replace it
+with `WithPageSize(500)` to keep the old behaviour — see §3.
+
+### Kindless `DateTime` filters are no longer shifted by the machine's timezone
+
+1.0 passed every `DateTime` through `ToUniversalTime()`, which treats
+`DateTimeKind.Unspecified` — anything parsed from config or loaded from a database — as
+*local* time. The same filter matched different rows depending on the server's timezone.
+2.0 takes Unspecified as already UTC. If you relied on the local-time interpretation,
+apply `DateTime.SpecifyKind(value, DateTimeKind.Local)` before filtering.
+
 ### `Exception.Message` is now a single line
 
 1.0 baked the status, URL and **entire response body** into `Message`. 2.0 keeps it to one
@@ -133,9 +148,15 @@ If you built workarounds for either, remove them.
 
 ### `WithTop` vs `WithPageSize`
 
-In `QueryAllAsync`, `WithTop(n)` meant *page size*, not a result limit. `WithPageSize(n)`
-now says that explicitly. `WithTop` still works there (`PageSize ?? Top ?? 1000`), but
-prefer the clearer name.
+In 1.0's `QueryAllAsync`, `WithTop(n)` meant *page size*, not a result limit — it paged
+through the entire collection `n` rows at a time. In 2.0 `WithTop` is what it says: a
+result cap, everywhere. `QueryAllAsync(..., o => o.WithTop(10))` now returns at most 10
+rows. Use `WithPageSize(n)` for the old meaning:
+
+```csharp
+// 1.0: WithTop(500) fetched everything, 500 rows per round trip. 2.0 equivalent:
+await client.QueryAllAsync<SalesOrder>("salesOrders", options: o => o.WithPageSize(500));
+```
 
 ### Chained ordering
 
@@ -240,5 +261,7 @@ There is no deprecation on the path-based API; migrate at your own pace, or not 
 - [ ] Decide on retry: keep it, tune `MaxAttempts`, or `Retry.Enabled = false`
 - [ ] Re-check any logic that assumed a `204` write failed
 - [ ] Re-check result-size assumptions around `QueryAllAsync`
+- [ ] Replace `WithTop` used as a page size with `WithPageSize`
+- [ ] Check `DateTime` filter values for `Kind=Unspecified` semantics (now read as UTC)
 - [ ] Replace `dynamic` writes with the two-generic overloads
 - [ ] Optionally simplify configuration and drop hand-built `BaseUrl`

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -13,9 +13,11 @@ so read that section even if the build is green.
 New members: `Company`, `ForCompany`, `Query<T>()` (two overloads), `QueryStreamAsync<T>`,
 `GetCompaniesAsync`, and two-generic `PostAsync`/`PatchAsync`/`PutAsync`.
 
-Mocking libraries (Moq, NSubstitute, FakeItEasy) absorb this automatically. **A
-hand-written test fake implementing the interface will not compile** until the new members
-are added.
+Mocking libraries (Moq, NSubstitute, FakeItEasy) absorb this automatically. Hand-written
+test fakes keep compiling too: **every interface member has a default implementation**, so
+a fake only implements the members it actually exercises. An unimplemented member throws
+`NotSupportedException` naming itself, and `FirstOrDefaultAsync` composes over `QueryAsync`
+so fakes get it for free.
 
 ### Nothing else, in practice
 
@@ -64,7 +66,9 @@ catch (BusinessCentralException ex) { … }          // sees everything
 > did: `BusinessCentralServerException` never caught `400`, `401`, `403` or `404` either —
 > those are `Validation`, `Auth`, `Auth` and `NotFound`, all sealed siblings. A guard like
 > `catch (BusinessCentralServerException ex) when (ex.StatusCode == HttpStatusCode.NotFound)`
-> can never match. Catch `BusinessCentralNotFoundException`, or the base type.
+> can never match. Catch `BusinessCentralNotFoundException`, or use the predicates on the
+> base type — `catch (BusinessCentralException ex) when (ex.IsNotFound)` — which exist
+> precisely because this trap compiles.
 
 ### Transient failures are retried automatically
 
@@ -91,10 +95,13 @@ exception on `InnerException`. Cancelling through your own `CancellationToken` s
 `OperationCanceledException`, unwrapped.
 
 If you already have an outer retry policy (Polly, Wolverine, a message broker), the two now
-compose multiplicatively. Consider lowering `Retry.MaxAttempts`, or disabling it:
+compose multiplicatively. The package's HTTP clients are addressable by name
+(`BusinessCentralHttpClients.Client` / `.Token`), so the preferred fix is exempting them
+from the outer handler and keeping this retry — see the README section *"Composing with an
+existing resilience pipeline"*. Alternatively, lower `Retry.MaxAttempts` or disable it:
 
 ```csharp
-options.Retry.Enabled = false;   // 1.0 behaviour
+options.Retry.Enabled = false;   // 1.0 behaviour — but a generic outer handler replays POST
 ```
 
 ### `QueryAllAsync` may return more rows than before
@@ -256,7 +263,8 @@ There is no deprecation on the path-based API; migrate at your own pace, or not 
 
 ## 5. Checklist
 
-- [ ] Update hand-written `IBusinessCentralClient` fakes, if any
+- [ ] Hand-written `IBusinessCentralClient` fakes keep compiling (default interface
+      methods); implement any newly-exercised member, delete `NotSupportedException` stubs
 - [ ] Audit `catch (BusinessCentralServerException)` — it does not see `400`/`401`/`403`/`404`/`429`
 - [ ] Decide on retry: keep it, tune `MaxAttempts`, or `Retry.Enabled = false`
 - [ ] Re-check any logic that assumed a `204` write failed

--- a/README.md
+++ b/README.md
@@ -265,6 +265,10 @@ Without this, a `504` on a `POST` could duplicate a record that Business Central
 created. If your endpoint deduplicates server-side, or duplicates are acceptable, opt back
 in with `options.Retry.RetryPostOnTransientFailures = true`.
 
+Connection failures and client-side timeouts — no response received at all — are just as
+ambiguous as a `504` and follow the same column: idempotent methods are retried, `POST` is
+not. They surface as `BusinessCentralConnectionException`.
+
 # ⚠️ Errors
 
 All failures derive from `BusinessCentralException`. `Message` is a single line suitable
@@ -276,6 +280,7 @@ for logging; the detail lives on properties, and `ToString()` renders everything
 | `BusinessCentralAuthException` | `401`, `403` |
 | `BusinessCentralNotFoundException` | `404` |
 | `BusinessCentralThrottledException` | `429` |
+| `BusinessCentralConnectionException` | no response — connection failure or client-side timeout; `StatusCode` is `0` |
 | `BusinessCentralServerException` | everything else, and deserialization failures |
 
 ```csharp

--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ var orders = await client.QueryAsync<SalesOrder>("salesOrders", Filter.Equals("s
 var all    = await client.QueryAllAsync<SalesOrder>("salesOrders");
 var raw    = await client.QueryRawAsync<JsonElement>("salesOrders?$top=5");
 
+// Single-entity reads. GetAsync returns null on 404 — "does it exist" is a question,
+// not an error. Keys may be a systemId or an alternate key.
+var one   = await client.GetAsync<SalesOrder>("salesOrders", "No='1000'");
+var first = await client.FirstOrDefaultAsync<SalesOrder>("salesOrders", Filter.Equals("status", "Open"));
+
 await foreach (var o in client.QueryStreamAsync<SalesOrder>("salesOrders")) { }
 ```
 
@@ -231,6 +236,22 @@ var filter = Filter.Equals<SalesOrder>(o => o.Status, "Open")
 `Filter.In` with an empty collection yields a filter matching nothing, rather than the
 invalid OData expression `field in ()`.
 
+## Field names without the builder
+
+Path-based calls take field names as strings, which invites hand-maintained constants
+classes that drift from the model. `BusinessCentralField.Of` resolves a selector exactly
+the way deserialization does — `[JsonPropertyName]` first, then the camelCase policy — so
+wire names live in one place, the entity. `EntityPath.For<T>()` does the same for the
+entity set path:
+
+```csharp
+var lines = await client.QueryAsync<ProdOrderLine>(
+    EntityPath.For<ProdOrderLine>(),                       // path from [BusinessCentralEntity]
+    Filter.Equals<ProdOrderLine>(l => l.OrderNo, orderNo), // typed filters resolve the same way
+    select: [BusinessCentralField.Of<ProdOrderLine>(l => l.ItemNo),
+             BusinessCentralField.Of<ProdOrderLine>(l => l.Quantity)]);
+```
+
 # ♻️ Throttling and retries
 
 Business Central throttles aggressively. Throttled (`429`) and transient (`408`, `502`,
@@ -269,6 +290,27 @@ Connection failures and client-side timeouts — no response received at all —
 ambiguous as a `504` and follow the same column: idempotent methods are retried, `POST` is
 not. They surface as `BusinessCentralConnectionException`.
 
+## Composing with an existing resilience pipeline
+
+If a global handler wraps every `HttpClient` — e.g. .NET Aspire's
+`ConfigureHttpClientDefaults` with `AddStandardResilienceHandler` — the outer retry and
+this package's retry compose multiplicatively. Worse, the standard handler replays `POST`
+on ambiguous failures, which this package deliberately refuses to do; with both active,
+the outer handler retries before the package ever sees the failure.
+
+Prefer exempting the package's clients and keeping the built-in retry, which honours
+`Retry-After` and knows which requests are safe to replay. Both clients are addressable
+by name:
+
+```csharp
+services.AddHttpClient(BusinessCentralHttpClients.Client).RemoveAllResilienceHandlers();
+services.AddHttpClient(BusinessCentralHttpClients.Token).RemoveAllResilienceHandlers();
+```
+
+Disabling the package's retry instead (`options.Retry.Enabled = false`) also resolves the
+composition, but leaves the generic outer handler in charge — including its unsafe `POST`
+replay.
+
 # ⚠️ Errors
 
 All failures derive from `BusinessCentralException`. `Message` is a single line suitable
@@ -292,6 +334,21 @@ catch (BusinessCentralException ex)
     if (ex.IsTransient) { /* safe to try again */ }
 }
 ```
+
+The subtypes are sealed **siblings**, not a hierarchy — a guard like
+`catch (BusinessCentralServerException ex) when (ex.StatusCode == HttpStatusCode.NotFound)`
+compiles but can never match, because a `404` is a `BusinessCentralNotFoundException`.
+Prefer the predicates on the base type, which make the safe form the obvious one:
+
+```csharp
+catch (BusinessCentralException ex) when (ex.IsNotFound)
+{
+    // already gone — treat the delete as idempotent success
+}
+```
+
+`IsNotFound`, `IsThrottled`, `IsValidation`, `IsAuth`, `IsConnectionFailure` and
+`IsTransient` cover the same distinctions as the subtypes, without the trap.
 
 # 📊 Diagnostics
 

--- a/src/Dynamics365.BusinessCentral/BusinessCentralHttpClients.cs
+++ b/src/Dynamics365.BusinessCentral/BusinessCentralHttpClients.cs
@@ -1,0 +1,22 @@
+namespace Dynamics365.BusinessCentral;
+
+/// <summary>
+/// Names of the <see cref="System.Net.Http.IHttpClientFactory"/> clients this package
+/// registers, so consumers can address them from their own HTTP configuration — most
+/// commonly to exempt them from a global resilience handler.
+/// </summary>
+/// <remarks>
+/// The package's built-in retry honours <c>Retry-After</c> and refuses to replay a
+/// <c>POST</c> on ambiguous transient failures. A generic outer handler (e.g.
+/// <c>AddStandardResilienceHandler</c> applied via <c>ConfigureHttpClientDefaults</c>)
+/// does neither, and the two compose multiplicatively. Prefer disabling the outer handler
+/// for these two clients over disabling <c>Retry</c> here.
+/// </remarks>
+public static class BusinessCentralHttpClients
+{
+    /// <summary>Name of the client used for OAuth2 token acquisition.</summary>
+    public const string Token = "Dynamics365.BusinessCentral.Token";
+
+    /// <summary>Name of the client used for data requests.</summary>
+    public const string Client = "Dynamics365.BusinessCentral.Client";
+}

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -120,6 +120,45 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     }
 
     /// <inheritdoc />
+    public async Task<TEntity?> GetAsync<TEntity>(
+        string path,
+        string key,
+        IEnumerable<string>? select = null,
+        CancellationToken cancellationToken = default)
+    {
+        var url = _urlBuilder.BuildEntityUrl(path, key, select);
+
+        try
+        {
+            using var res = await SendWithAuthRetryAsync(
+                () => CreateJsonRequest(HttpMethod.Get, url), cancellationToken).ConfigureAwait(false);
+
+            return await DeserializeAsync<TEntity>(
+                res,
+                "Failed to deserialize Business Central response.",
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (BusinessCentralNotFoundException)
+        {
+            // "Does this entity exist" is a question, not an error.
+            return default;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<TEntity?> FirstOrDefaultAsync<TEntity>(
+        string path,
+        ODataFilter? filter = null,
+        IEnumerable<string>? select = null,
+        CancellationToken cancellationToken = default)
+    {
+        var page = await QueryAsync<TEntity>(path, filter, o => o.WithTop(1), select, cancellationToken)
+            .ConfigureAwait(false);
+
+        return page.Count == 0 ? default : page[0];
+    }
+
+    /// <inheritdoc />
     public Task<List<TEntity>> QueryAsync<TEntity>(
         string path,
         ODataFilter? filter = null,

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -24,6 +24,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     private readonly string _company;
 
     private const string BearerScheme = "Bearer";
+    private const string IfMatchHeader = "If-Match";
 
     /// <summary>Default page size used when auto-paging.</summary>
     private const int DefaultPageSize = 1000;
@@ -234,7 +235,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             {
                 serverDriven = true;
 
-                page = await FetchNextPageAsync<TEntity>(page.NextLink!, cancellationToken)
+                page = await FetchNextPageAsync<TEntity>(page.NextLink, cancellationToken)
                     .ConfigureAwait(false);
 
                 continue;
@@ -348,7 +349,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             () =>
             {
                 var req = CreateJsonRequest(HttpMethod.Patch, url, payload);
-                req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+                req.Headers.TryAddWithoutValidation(IfMatchHeader, ifMatch);
                 req.AddReturnRepresentationPreference();
                 return req;
             },
@@ -417,7 +418,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             () =>
             {
                 var req = CreateJsonRequest(HttpMethod.Patch, url, payload);
-                req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+                req.Headers.TryAddWithoutValidation(IfMatchHeader, ifMatch);
                 req.AddReturnRepresentationPreference();
                 return req;
             },
@@ -442,7 +443,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             () =>
             {
                 var req = CreateJsonRequest(HttpMethod.Put, url, payload);
-                req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+                req.Headers.TryAddWithoutValidation(IfMatchHeader, ifMatch);
                 req.AddReturnRepresentationPreference();
                 return req;
             },
@@ -467,7 +468,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             () =>
             {
                 var req = CreateJsonRequest(HttpMethod.Put, url, payload);
-                req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+                req.Headers.TryAddWithoutValidation(IfMatchHeader, ifMatch);
                 req.AddReturnRepresentationPreference();
                 return req;
             },
@@ -490,7 +491,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             () =>
             {
                 var req = CreateJsonRequest(HttpMethod.Delete, url);
-                req.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+                req.Headers.TryAddWithoutValidation(IfMatchHeader, ifMatch);
                 return req;
             },
             cancellationToken).ConfigureAwait(false);
@@ -792,8 +793,13 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     private static TimeSpan Floor(TimeSpan value) =>
         value < TimeSpan.Zero ? TimeSpan.Zero : value;
 
-    private static TimeSpan Clamp(TimeSpan value, TimeSpan max) =>
-        value < TimeSpan.Zero ? TimeSpan.Zero : value > max ? max : value;
+    private static TimeSpan Clamp(TimeSpan value, TimeSpan max)
+    {
+        if (value < TimeSpan.Zero)
+            return TimeSpan.Zero;
+
+        return value > max ? max : value;
+    }
 
     private static async Task<string?> ReadBodySafeAsync(
         HttpResponseMessage res,

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -602,7 +602,63 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
 
                 var stopwatch = Stopwatch.StartNew();
 
-                var res = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                HttpResponseMessage res;
+
+                try
+                {
+                    res = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (IsNetworkFailure(ex, cancellationToken))
+                {
+                    stopwatch.Stop();
+
+                    // No response was received, so there is no status code to map; wrap so
+                    // the caller still only has BusinessCentralException to catch. Whether
+                    // the request reached the server is as ambiguous as a 502/504, so the
+                    // same replay rules apply (IsSafeToReplay holds a POST back).
+                    var failure = new BusinessCentralConnectionException(
+                        NetworkFailureMessage(ex), method.Method, url, ex);
+
+                    _observer.OnRequestFailed(new BusinessCentralErrorInfo
+                    {
+                        Method = method.Method,
+                        Url = url,
+                        Duration = stopwatch.Elapsed,
+                        Exception = failure
+                    });
+
+                    if (transientAttempt + 1 < maxAttempts &&
+                        IsSafeToReplay(failure, method, retry))
+                    {
+                        transientAttempt++;
+
+                        var delay = ComputeDelay(retry, null, transientAttempt);
+
+                        _observer.OnRequestRetrying(new BusinessCentralRetryInfo
+                        {
+                            Method = method.Method,
+                            Url = url,
+                            Attempt = transientAttempt,
+                            Delay = delay,
+                            FromRetryAfter = false
+                        });
+
+                        request.Dispose();
+
+                        if (delay > TimeSpan.Zero)
+                            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+
+                        request = createRequest();
+                        continue;
+                    }
+
+                    failureReported = true;
+
+                    request.Dispose();
+
+                    throw failure;
+                }
+
                 res.RequestMessage ??= request;
 
                 stopwatch.Stop();
@@ -723,6 +779,20 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
 
         return createRequest();
     }
+
+    /// <summary>
+    /// Whether the send failed without any response arriving: a connection-level error, or
+    /// the <see cref="HttpClient"/> timeout. A cancellation requested through the caller's
+    /// token is not a network failure and propagates as-is.
+    /// </summary>
+    private static bool IsNetworkFailure(Exception ex, CancellationToken cancellationToken) =>
+        ex is HttpRequestException ||
+        (ex is TaskCanceledException && !cancellationToken.IsCancellationRequested);
+
+    private static string NetworkFailureMessage(Exception ex) =>
+        ex is TaskCanceledException
+            ? "The request timed out before Business Central responded."
+            : $"The connection to Business Central failed: {ex.Message}";
 
     /// <summary>
     /// Whether this failure may be retried by replaying the same request.

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -193,13 +193,16 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
         var baseOptions = new QueryOptions();
         options?.Invoke(baseOptions);
 
+        // Top is a result cap, exactly as documented on WithTop; PageSize sizes the round
+        // trips. This mirrors BusinessCentralQuery<T>.StreamAsync — the two implementations
+        // must stay in agreement.
+        var limit = baseOptions.Top;
+
         // $top=0 is a request for no rows at all.
-        if (baseOptions.Top == 0)
+        if (limit == 0)
             yield break;
 
-        // Top has historically doubled as the page size here; PageSize now says it plainly
-        // and wins when both are set.
-        var pageSize = baseOptions.PageSize ?? baseOptions.Top ?? DefaultPageSize;
+        var pageSize = baseOptions.PageSize ?? DefaultPageSize;
 
         // Guards the loop below: with a non-positive page size the "short page" termination
         // check can never fire, so it would request the same empty page forever. The public
@@ -212,9 +215,12 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
         // Honour a caller-supplied $skip as the starting offset instead of silently
         // restarting from the first page.
         var skip = baseOptions.Skip ?? 0;
+        var emitted = 0;
+
+        var requested = NextTop(pageSize, limit, emitted);
 
         var page = await FetchPageAsync<TEntity>(
-                path, filterValue, PageOptions(baseOptions, pageSize, skip), select, cancellationToken)
+                path, filterValue, PageOptions(baseOptions, requested, skip), select, cancellationToken)
             .ConfigureAwait(false);
 
         var serverDriven = false;
@@ -226,7 +232,12 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             foreach (var entity in page.Value)
             {
                 yield return entity;
+
+                emitted++;
                 inPage++;
+
+                if (limit is { } cap && emitted >= cap)
+                    yield break;
             }
 
             // Server-driven paging wins: when Business Central sends @odata.nextLink it
@@ -245,22 +256,33 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
                 yield break;
 
             // No nextLink and a short page means the collection is exhausted.
-            if (inPage < pageSize)
+            if (inPage < requested)
                 yield break;
 
             skip += inPage;
+            requested = NextTop(pageSize, limit, emitted);
 
             page = await FetchPageAsync<TEntity>(
-                    path, filterValue, PageOptions(baseOptions, pageSize, skip), select, cancellationToken)
+                    path, filterValue, PageOptions(baseOptions, requested, skip), select, cancellationToken)
                 .ConfigureAwait(false);
         }
     }
 
-    private static QueryOptions PageOptions(QueryOptions baseOptions, int pageSize, int skip)
+    /// <summary>Page size for the next request, never overshooting a caller-set <c>$top</c>.</summary>
+    private static int NextTop(int pageSize, int? limit, int emitted)
+    {
+        if (limit is not { } cap)
+            return pageSize;
+
+        var remaining = cap - emitted;
+        return remaining < pageSize ? remaining : pageSize;
+    }
+
+    private static QueryOptions PageOptions(QueryOptions baseOptions, int top, int skip)
     {
         var options = new QueryOptions
         {
-            Top = pageSize,
+            Top = top,
             Skip = skip,
             IncludeCount = baseOptions.IncludeCount
         };

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralUrlBuilder.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralUrlBuilder.cs
@@ -24,6 +24,20 @@ internal sealed class BusinessCentralUrlBuilder
         return $"{BuildCompanyBase()}/{EncodePath(path)}({EncodeKey(key)})";
     }
 
+    public string BuildEntityUrl(string path, string key, IEnumerable<string>? select)
+    {
+        var url = BuildEntityUrl(path, key);
+
+        var fields = select?
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .ToList();
+
+        if (fields is { Count: > 0 })
+            url += "?$select=" + string.Join(",", fields.Select(Uri.EscapeDataString));
+
+        return url;
+    }
+
     /// <summary>
     /// Builds a URL against the service root, i.e. without the <c>Company('...')</c>
     /// segment. Used for tenant-level entity sets such as the company list itself.

--- a/src/Dynamics365.BusinessCentral/Client/HttpRequestExtensions.cs
+++ b/src/Dynamics365.BusinessCentral/Client/HttpRequestExtensions.cs
@@ -20,7 +20,7 @@ internal static class HttpRequestExtensions
         request.Headers.Accept.Add(
             new MediaTypeWithQualityHeaderValue("application/json"));
 
-        if (!request.Headers.UserAgent.Any())
+        if (request.Headers.UserAgent.Count == 0)
             request.Headers.UserAgent.ParseAdd(UserAgent);
     }
 

--- a/src/Dynamics365.BusinessCentral/Client/IBusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/IBusinessCentralClient.cs
@@ -6,21 +6,37 @@ namespace Dynamics365.BusinessCentral.Client;
 /// Client abstraction for querying and modifying data in Microsoft Dynamics 365 Business Central via OData.
 /// </summary>
 /// <remarks>
+/// <para>
 /// <see cref="Query{TEntity}()"/> is the recommended entry point — it is strongly typed and
 /// covers filtering, ordering, projection, expansion, paging and counting. The
 /// <c>QueryAsync</c>/<c>PostAsync</c> family remains for direct, path-based access.
+/// </para>
+/// <para>
+/// Every member has a default implementation, so a hand-written test fake only implements
+/// the members it actually exercises — additions to this interface never break it. An
+/// unimplemented member throws <see cref="NotSupportedException"/> naming itself.
+/// <see cref="FirstOrDefaultAsync{TEntity}"/> composes over
+/// <see cref="QueryAsync{TEntity}(string, ODataFilter?, Action{QueryOptions}?, IEnumerable{string}?, CancellationToken)"/>,
+/// so a fake implementing that overload gets it for free.
+/// </para>
 /// </remarks>
 public interface IBusinessCentralClient
 {
+    private static NotSupportedException NotImplemented(string member) =>
+        new($"{nameof(IBusinessCentralClient)}.{member} is not implemented by this type. " +
+            "Interface members have default implementations so partial test fakes keep " +
+            "compiling; implement the member to use it.");
+
     /// <summary>Company this client is scoped to.</summary>
-    string Company { get; }
+    string Company => throw NotImplemented(nameof(Company));
 
     /// <summary>
     /// Returns a client scoped to a different company, sharing the same HTTP client and
     /// access-token cache. Returns <see langword="this"/> when the company is unchanged.
     /// </summary>
     /// <param name="company">Company name, as returned by <see cref="GetCompaniesAsync"/>.</param>
-    IBusinessCentralClient ForCompany(string company);
+    IBusinessCentralClient ForCompany(string company) =>
+        throw NotImplemented(nameof(ForCompany));
 
     /// <summary>
     /// Starts a strongly-typed query. The entity set path comes from
@@ -30,16 +46,19 @@ public interface IBusinessCentralClient
     /// <exception cref="InvalidOperationException">
     /// <typeparamref name="TEntity"/> is not annotated; use <see cref="Query{TEntity}(string)"/>.
     /// </exception>
-    IBusinessCentralQuery<TEntity> Query<TEntity>();
+    IBusinessCentralQuery<TEntity> Query<TEntity>() =>
+        throw NotImplemented(nameof(Query));
 
     /// <summary>Starts a strongly-typed query against an explicit entity set path.</summary>
     /// <typeparam name="TEntity">Entity type to query.</typeparam>
     /// <param name="path">Relative OData entity path, e.g. <c>salesOrders</c>.</param>
-    IBusinessCentralQuery<TEntity> Query<TEntity>(string path);
+    IBusinessCentralQuery<TEntity> Query<TEntity>(string path) =>
+        throw NotImplemented(nameof(Query));
 
     /// <summary>Lists the companies available in the tenant.</summary>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task<List<BusinessCentralCompany>> GetCompaniesAsync(CancellationToken cancellationToken = default);
+    Task<List<BusinessCentralCompany>> GetCompaniesAsync(CancellationToken cancellationToken = default) =>
+        throw NotImplemented(nameof(GetCompaniesAsync));
 
     /// <summary>
     /// Executes an OData query against a Business Central entity and returns the matching entities.
@@ -55,7 +74,8 @@ public interface IBusinessCentralClient
         ODataFilter? filter = null,
         Action<QueryOptions>? options = null,
         IEnumerable<string>? select = null,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default) =>
+        throw NotImplemented(nameof(QueryAsync));
 
     /// <summary>
     /// Executes an OData query using a raw $filter string and returns the matching entities.
@@ -71,7 +91,50 @@ public interface IBusinessCentralClient
         string filter,
         Action<QueryOptions>? options = null,
         IEnumerable<string>? select = null,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default) =>
+        throw NotImplemented(nameof(QueryAsync));
+
+    /// <summary>
+    /// Fetches a single entity by key, returning <see langword="default"/> when it does not
+    /// exist. "Does this entity exist" is a question, not an error — a <c>404</c> yields
+    /// <see langword="default"/>; every other failure still throws.
+    /// </summary>
+    /// <remarks>
+    /// The <c>404</c> is still reported to the diagnostics observer as a failed request,
+    /// because on the wire it is one.
+    /// </remarks>
+    /// <typeparam name="TEntity">The entity type to deserialize the response into.</typeparam>
+    /// <param name="path">Relative OData entity path.</param>
+    /// <param name="key">Entity key: a systemId, or an alternate key such as <c>No='1000'</c>.</param>
+    /// <param name="select">Optional list of fields to select.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<TEntity?> GetAsync<TEntity>(
+        string path,
+        string key,
+        IEnumerable<string>? select = null,
+        CancellationToken cancellationToken = default) =>
+        throw NotImplemented(nameof(GetAsync));
+
+    /// <summary>
+    /// Returns the first entity matching <paramref name="filter"/>, or
+    /// <see langword="default"/> when nothing matches. Sends <c>$top=1</c>.
+    /// </summary>
+    /// <typeparam name="TEntity">The entity type to deserialize the response into.</typeparam>
+    /// <param name="path">Relative OData entity path.</param>
+    /// <param name="filter">Optional strongly-typed OData filter expression.</param>
+    /// <param name="select">Optional list of fields to select.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    async Task<TEntity?> FirstOrDefaultAsync<TEntity>(
+        string path,
+        ODataFilter? filter = null,
+        IEnumerable<string>? select = null,
+        CancellationToken cancellationToken = default)
+    {
+        var page = await QueryAsync<TEntity>(path, filter, o => o.WithTop(1), select, cancellationToken)
+            .ConfigureAwait(false);
+
+        return page.Count == 0 ? default : page[0];
+    }
 
     /// <summary>
     /// Executes an OData query and retrieves all matching entities by automatically paging
@@ -88,7 +151,8 @@ public interface IBusinessCentralClient
         ODataFilter? filter = null,
         Action<QueryOptions>? options = null,
         IEnumerable<string>? select = null,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default) =>
+        throw NotImplemented(nameof(QueryAllAsync));
 
     /// <summary>
     /// Streams every matching entity, fetching pages lazily so the whole result set is
@@ -105,7 +169,8 @@ public interface IBusinessCentralClient
         ODataFilter? filter = null,
         Action<QueryOptions>? options = null,
         IEnumerable<string>? select = null,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default) =>
+        throw NotImplemented(nameof(QueryStreamAsync));
 
     /// <summary>
     /// Executes a raw GET request against the given relative OData URL and deserializes the full response body.
@@ -119,7 +184,8 @@ public interface IBusinessCentralClient
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<TResponse> QueryRawAsync<TResponse>(
         string path,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default) =>
+        throw NotImplemented(nameof(QueryRawAsync));
 
     /// <summary>
     /// Executes a PATCH request to partially update an existing Business Central entity.
@@ -140,7 +206,8 @@ public interface IBusinessCentralClient
         T payload,
         string ifMatch = "*",
         CancellationToken cancellationToken = default)
-        where T : class;
+        where T : class =>
+        throw NotImplemented(nameof(PatchAsync));
 
     /// <summary>
     /// Executes a POST request to create a new entity in Business Central.
@@ -157,7 +224,8 @@ public interface IBusinessCentralClient
         string path,
         T payload,
         CancellationToken cancellationToken = default)
-        where T : class;
+        where T : class =>
+        throw NotImplemented(nameof(PostAsync));
 
     /// <summary>
     /// Creates an entity, deserializing the response into a type different from the payload.
@@ -185,7 +253,8 @@ public interface IBusinessCentralClient
         string path,
         TPayload payload,
         CancellationToken cancellationToken = default)
-        where TPayload : class;
+        where TPayload : class =>
+        throw NotImplemented(nameof(PostAsync));
 
     /// <summary>
     /// Partially updates an entity, deserializing the response into a type different from
@@ -208,7 +277,8 @@ public interface IBusinessCentralClient
         TPayload payload,
         string ifMatch = "*",
         CancellationToken cancellationToken = default)
-        where TPayload : class;
+        where TPayload : class =>
+        throw NotImplemented(nameof(PatchAsync));
 
     /// <summary>
     /// Replaces an entity, deserializing the response into a type different from the payload.
@@ -230,7 +300,8 @@ public interface IBusinessCentralClient
         TPayload payload,
         string ifMatch = "*",
         CancellationToken cancellationToken = default)
-        where TPayload : class;
+        where TPayload : class =>
+        throw NotImplemented(nameof(PutAsync));
 
     /// <summary>
     /// Executes a PUT request to fully replace an existing Business Central entity.
@@ -251,7 +322,8 @@ public interface IBusinessCentralClient
         T payload,
         string ifMatch = "*",
         CancellationToken cancellationToken = default)
-        where T : class;
+        where T : class =>
+        throw NotImplemented(nameof(PutAsync));
 
     /// <summary>
     /// Executes a DELETE request to remove an existing Business Central entity.
@@ -264,5 +336,6 @@ public interface IBusinessCentralClient
         string path,
         string systemId,
         string ifMatch = "*",
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default) =>
+        throw NotImplemented(nameof(DeleteAsync));
 }

--- a/src/Dynamics365.BusinessCentral/Diagnostics/BusinessCentralRetryInfo.cs
+++ b/src/Dynamics365.BusinessCentral/Diagnostics/BusinessCentralRetryInfo.cs
@@ -11,7 +11,10 @@ public sealed class BusinessCentralRetryInfo
     /// <summary>URL of the request being retried.</summary>
     public string Url { get; init; } = string.Empty;
 
-    /// <summary>Status code that triggered the retry.</summary>
+    /// <summary>
+    /// Status code that triggered the retry, or <c>0</c> when no response was received
+    /// (connection failure or client-side timeout).
+    /// </summary>
     public int StatusCode { get; init; }
 
     /// <summary>1-based retry number: <c>1</c> is the first retry after the original attempt.</summary>

--- a/src/Dynamics365.BusinessCentral/Errors/BusinessCentralException.cs
+++ b/src/Dynamics365.BusinessCentral/Errors/BusinessCentralException.cs
@@ -82,7 +82,10 @@ public abstract class BusinessCentralException : Exception
             ? $"Business Central request failed."
             : message.Trim().ReplaceLineEndings(" ");
 
-        return $"{trimmed} ({method} → HTTP {(int)status} {status})";
+        // Status 0 means no response was ever received (connection failure or timeout).
+        return status == 0
+            ? $"{trimmed} ({method} → no response)"
+            : $"{trimmed} ({method} → HTTP {(int)status} {status})";
     }
 
     /// <summary>
@@ -95,7 +98,9 @@ public abstract class BusinessCentralException : Exception
 
         sb.AppendLine();
         sb.AppendLine("--- Business Central details ---");
-        sb.AppendLine($"Status: {(int)StatusCode} {StatusCode}");
+        sb.AppendLine(StatusCode == 0
+            ? "Status: (no response received)"
+            : $"Status: {(int)StatusCode} {StatusCode}");
         sb.AppendLine($"Method: {Method}");
         sb.AppendLine($"URL: {RequestUrl}");
 
@@ -183,6 +188,37 @@ public sealed class BusinessCentralThrottledException : BusinessCentralException
         string? correlationId = null,
         Exception? inner = null)
         : base(message, code, method, url, body, odataErrorCode, correlationId, inner) { }
+
+    /// <inheritdoc />
+    public override bool IsTransient => true;
+}
+
+/// <summary>
+/// No HTTP response was received: the connection failed or the request timed out
+/// client-side before Business Central answered. Always transient.
+/// <see cref="BusinessCentralException.StatusCode"/> is <c>0</c>, because without a
+/// response there is no status code.
+/// </summary>
+/// <remarks>
+/// The underlying <see cref="HttpRequestException"/> or timeout is preserved as
+/// <see cref="Exception.InnerException"/>. Like the ambiguous transient statuses, the
+/// request may have reached the server even though the response never arrived, so
+/// idempotent methods are replayed but a <c>POST</c> is not. Cancellation through the
+/// caller's own <see cref="CancellationToken"/> is never wrapped in this type.
+/// </remarks>
+public sealed class BusinessCentralConnectionException : BusinessCentralException
+{
+    /// <summary>Creates a new <see cref="BusinessCentralConnectionException"/>.</summary>
+    /// <param name="message">Short, single-line description of the failure.</param>
+    /// <param name="method">HTTP method of the failed request.</param>
+    /// <param name="requestUrl">URL of the failed request.</param>
+    /// <param name="inner">The underlying connection or timeout exception.</param>
+    public BusinessCentralConnectionException(
+        string message,
+        string method,
+        string? requestUrl,
+        Exception inner)
+        : base(message, 0, method, requestUrl, null, null, null, inner) { }
 
     /// <inheritdoc />
     public override bool IsTransient => true;

--- a/src/Dynamics365.BusinessCentral/Errors/BusinessCentralException.cs
+++ b/src/Dynamics365.BusinessCentral/Errors/BusinessCentralException.cs
@@ -44,6 +44,28 @@ public abstract class BusinessCentralException : Exception
     /// </summary>
     public virtual bool IsTransient => false;
 
+    /// <summary>The entity or entity set does not exist (<c>404</c>).</summary>
+    /// <remarks>
+    /// The exception subtypes are sealed siblings, so
+    /// <c>catch (BusinessCentralServerException ex) when (ex.StatusCode == HttpStatusCode.NotFound)</c>
+    /// can never match — the 404 is a <see cref="BusinessCentralNotFoundException"/>. These
+    /// predicates make the safe form the obvious one:
+    /// <c>catch (BusinessCentralException ex) when (ex.IsNotFound)</c>.
+    /// </remarks>
+    public bool IsNotFound => StatusCode == HttpStatusCode.NotFound;
+
+    /// <summary>The request was throttled (<c>429</c>).</summary>
+    public bool IsThrottled => StatusCode == HttpStatusCode.TooManyRequests;
+
+    /// <summary>Business Central rejected the request as invalid (<c>400</c>).</summary>
+    public bool IsValidation => StatusCode == HttpStatusCode.BadRequest;
+
+    /// <summary>Authentication or authorisation failed (<c>401</c> / <c>403</c>).</summary>
+    public bool IsAuth => StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden;
+
+    /// <summary>No response was received: connection failure or client-side timeout.</summary>
+    public bool IsConnectionFailure => StatusCode == 0;
+
     /// <summary>Creates a new <see cref="BusinessCentralException"/>.</summary>
     /// <param name="message">Short, single-line description of the failure.</param>
     /// <param name="statusCode">HTTP status code returned by Business Central.</param>

--- a/src/Dynamics365.BusinessCentral/OData/BusinessCentralField.cs
+++ b/src/Dynamics365.BusinessCentral/OData/BusinessCentralField.cs
@@ -1,0 +1,32 @@
+using System.Linq.Expressions;
+
+namespace Dynamics365.BusinessCentral.OData;
+
+/// <summary>
+/// Resolves a property selector to the OData field name Business Central sees on the wire —
+/// for consumers of the path-based API who want typed field names in <c>select:</c> lists
+/// or raw filter strings without adopting the <c>Query&lt;T&gt;()</c> builder.
+/// </summary>
+/// <remarks>
+/// Resolution is identical to the typed <see cref="Filter"/> overloads and to
+/// deserialization: <see cref="System.Text.Json.Serialization.JsonPropertyNameAttribute"/>
+/// first, then the shared naming policy. A hand-maintained constants class duplicating wire
+/// names can be replaced by call-site resolution:
+/// <code>
+/// select: [BusinessCentralField.Of&lt;SalesOrder&gt;(o =&gt; o.No),
+///          BusinessCentralField.Of&lt;SalesOrder&gt;(o =&gt; o.Amount)]
+/// </code>
+/// </remarks>
+public static class BusinessCentralField
+{
+    /// <summary>
+    /// Returns the OData field name for <paramref name="selector"/>. Nested selectors such
+    /// as <c>o =&gt; o.Customer.Name</c> become navigation paths (<c>customer/name</c>).
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="selector"/> is not a plain property access — method calls and
+    /// computed expressions cannot be translated to OData.
+    /// </exception>
+    public static string Of<TEntity>(Expression<Func<TEntity, object?>> selector) =>
+        PropertyPath.Resolve(selector);
+}

--- a/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
+++ b/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
@@ -94,11 +94,8 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
 
     public IBusinessCentralQuery<TEntity> Expand(params string[] fields)
     {
-        foreach (var field in fields)
-        {
-            if (!string.IsNullOrWhiteSpace(field) && !_expand.Contains(field))
-                _expand.Add(field);
-        }
+        foreach (var field in fields.Where(f => !string.IsNullOrWhiteSpace(f) && !_expand.Contains(f)))
+            _expand.Add(field);
 
         return this;
     }
@@ -203,7 +200,7 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
                 serverDriven = true;
 
                 page = await _executor
-                    .FetchNextPageAsync<TEntity>(page.NextLink!, cancellationToken)
+                    .FetchNextPageAsync<TEntity>(page.NextLink, cancellationToken)
                     .ConfigureAwait(false);
 
                 continue;

--- a/src/Dynamics365.BusinessCentral/OData/EntityPath.cs
+++ b/src/Dynamics365.BusinessCentral/OData/EntityPath.cs
@@ -7,7 +7,7 @@ namespace Dynamics365.BusinessCentral.OData;
 /// Resolves the OData entity set path for a CLR type from
 /// <see cref="BusinessCentralEntityAttribute"/>.
 /// </summary>
-internal static class EntityPath
+public static class EntityPath
 {
     private static readonly ConcurrentDictionary<Type, string> _cache = new();
 

--- a/src/Dynamics365.BusinessCentral/OData/Filter.cs
+++ b/src/Dynamics365.BusinessCentral/OData/Filter.cs
@@ -144,7 +144,7 @@ public static class Filter
         {
             null => "null",
             string s => $"'{s.Replace("'", "''")}'",
-            DateTime dt => dt.ToUniversalTime().ToString("O"),
+            DateTime dt => FormatDateTime(dt),
             DateTimeOffset dto => dto.ToUniversalTime().ToString("O"),
             // Edm.Date / Edm.TimeOfDay literals. Without these both fall through to
             // Convert.ToString, whose culture-formatted output ("07/29/2026") Business
@@ -156,4 +156,23 @@ public static class Filter
             Enum e => $"'{e}'",
             _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? "null"
         };
+
+    /// <summary>
+    /// Formats a <see cref="DateTime"/> as a UTC OData literal.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="DateTimeKind.Unspecified"/> is taken to already be UTC rather than local:
+    /// <see cref="DateTime.ToUniversalTime"/> would assume local and shift the value by the
+    /// machine's timezone, making the filter depend on where the code happens to run.
+    /// Business Central stores datetimes in UTC, so a kindless value — parsed from config,
+    /// loaded from a database — almost always is UTC already.
+    /// </remarks>
+    private static string FormatDateTime(DateTime value)
+    {
+        var utc = value.Kind == DateTimeKind.Unspecified
+            ? DateTime.SpecifyKind(value, DateTimeKind.Utc)
+            : value.ToUniversalTime();
+
+        return utc.ToString("O");
+    }
 }

--- a/src/Dynamics365.BusinessCentral/OData/Filter.cs
+++ b/src/Dynamics365.BusinessCentral/OData/Filter.cs
@@ -146,6 +146,11 @@ public static class Filter
             string s => $"'{s.Replace("'", "''")}'",
             DateTime dt => dt.ToUniversalTime().ToString("O"),
             DateTimeOffset dto => dto.ToUniversalTime().ToString("O"),
+            // Edm.Date / Edm.TimeOfDay literals. Without these both fall through to
+            // Convert.ToString, whose culture-formatted output ("07/29/2026") Business
+            // Central rejects.
+            DateOnly d => d.ToString("O", CultureInfo.InvariantCulture),
+            TimeOnly t => t.ToString("O", CultureInfo.InvariantCulture),
             bool b => b.ToString().ToLowerInvariant(),
             Guid g => g.ToString(),
             Enum e => $"'{e}'",

--- a/src/Dynamics365.BusinessCentral/OData/QueryOptions.cs
+++ b/src/Dynamics365.BusinessCentral/OData/QueryOptions.cs
@@ -37,7 +37,7 @@ public sealed class QueryOptions
         {
             _orderBy.Clear();
             if (!string.IsNullOrWhiteSpace(value))
-                _orderBy.Add(value!);
+                _orderBy.Add(value);
         }
     }
 
@@ -87,11 +87,8 @@ public sealed class QueryOptions
     /// <summary>Expands the given navigation properties (<c>$expand</c>).</summary>
     public QueryOptions WithExpand(params string[] fields)
     {
-        foreach (var field in fields)
-        {
-            if (!string.IsNullOrWhiteSpace(field) && !_expand.Contains(field))
-                _expand.Add(field);
-        }
+        foreach (var field in fields.Where(f => !string.IsNullOrWhiteSpace(f) && !_expand.Contains(f)))
+            _expand.Add(field);
 
         return this;
     }

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralRetryOptions.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralRetryOptions.cs
@@ -2,7 +2,8 @@ namespace Dynamics365.BusinessCentral.Options;
 
 /// <summary>
 /// Controls how the client retries throttled (<c>429</c>) and transient (<c>408</c>,
-/// <c>502</c>, <c>503</c>, <c>504</c>) responses.
+/// <c>502</c>, <c>503</c>, <c>504</c>) responses, as well as connection-level failures
+/// and client-side timeouts where no response arrived at all.
 /// </summary>
 /// <remarks>
 /// Business Central throttles aggressively and answers with a <c>Retry-After</c> header;
@@ -46,7 +47,9 @@ public sealed class BusinessCentralRetryOptions
     /// have applied the write before the failure surfaced. Replaying a <c>POST</c> would then
     /// create a duplicate record, so by default it is not retried and the exception is raised
     /// for the caller to handle. Idempotent methods — <c>GET</c>, <c>PUT</c>, <c>DELETE</c> —
-    /// are always retried, because replaying them converges on the same state.
+    /// are always retried, because replaying them converges on the same state. Connection
+    /// failures and client-side timeouts are equally ambiguous — the request may have reached
+    /// the server even though no response arrived — and follow the same rules.
     /// </para>
     /// <para>
     /// Set this to <see langword="true"/> only when the endpoint you POST to deduplicates

--- a/src/Dynamics365.BusinessCentral/README.md
+++ b/src/Dynamics365.BusinessCentral/README.md
@@ -265,6 +265,10 @@ Without this, a `504` on a `POST` could duplicate a record that Business Central
 created. If your endpoint deduplicates server-side, or duplicates are acceptable, opt back
 in with `options.Retry.RetryPostOnTransientFailures = true`.
 
+Connection failures and client-side timeouts — no response received at all — are just as
+ambiguous as a `504` and follow the same column: idempotent methods are retried, `POST` is
+not. They surface as `BusinessCentralConnectionException`.
+
 # ⚠️ Errors
 
 All failures derive from `BusinessCentralException`. `Message` is a single line suitable
@@ -276,6 +280,7 @@ for logging; the detail lives on properties, and `ToString()` renders everything
 | `BusinessCentralAuthException` | `401`, `403` |
 | `BusinessCentralNotFoundException` | `404` |
 | `BusinessCentralThrottledException` | `429` |
+| `BusinessCentralConnectionException` | no response — connection failure or client-side timeout; `StatusCode` is `0` |
 | `BusinessCentralServerException` | everything else, and deserialization failures |
 
 ```csharp

--- a/src/Dynamics365.BusinessCentral/README.md
+++ b/src/Dynamics365.BusinessCentral/README.md
@@ -152,6 +152,11 @@ var orders = await client.QueryAsync<SalesOrder>("salesOrders", Filter.Equals("s
 var all    = await client.QueryAllAsync<SalesOrder>("salesOrders");
 var raw    = await client.QueryRawAsync<JsonElement>("salesOrders?$top=5");
 
+// Single-entity reads. GetAsync returns null on 404 — "does it exist" is a question,
+// not an error. Keys may be a systemId or an alternate key.
+var one   = await client.GetAsync<SalesOrder>("salesOrders", "No='1000'");
+var first = await client.FirstOrDefaultAsync<SalesOrder>("salesOrders", Filter.Equals("status", "Open"));
+
 await foreach (var o in client.QueryStreamAsync<SalesOrder>("salesOrders")) { }
 ```
 
@@ -231,6 +236,22 @@ var filter = Filter.Equals<SalesOrder>(o => o.Status, "Open")
 `Filter.In` with an empty collection yields a filter matching nothing, rather than the
 invalid OData expression `field in ()`.
 
+## Field names without the builder
+
+Path-based calls take field names as strings, which invites hand-maintained constants
+classes that drift from the model. `BusinessCentralField.Of` resolves a selector exactly
+the way deserialization does — `[JsonPropertyName]` first, then the camelCase policy — so
+wire names live in one place, the entity. `EntityPath.For<T>()` does the same for the
+entity set path:
+
+```csharp
+var lines = await client.QueryAsync<ProdOrderLine>(
+    EntityPath.For<ProdOrderLine>(),                       // path from [BusinessCentralEntity]
+    Filter.Equals<ProdOrderLine>(l => l.OrderNo, orderNo), // typed filters resolve the same way
+    select: [BusinessCentralField.Of<ProdOrderLine>(l => l.ItemNo),
+             BusinessCentralField.Of<ProdOrderLine>(l => l.Quantity)]);
+```
+
 # ♻️ Throttling and retries
 
 Business Central throttles aggressively. Throttled (`429`) and transient (`408`, `502`,
@@ -269,6 +290,27 @@ Connection failures and client-side timeouts — no response received at all —
 ambiguous as a `504` and follow the same column: idempotent methods are retried, `POST` is
 not. They surface as `BusinessCentralConnectionException`.
 
+## Composing with an existing resilience pipeline
+
+If a global handler wraps every `HttpClient` — e.g. .NET Aspire's
+`ConfigureHttpClientDefaults` with `AddStandardResilienceHandler` — the outer retry and
+this package's retry compose multiplicatively. Worse, the standard handler replays `POST`
+on ambiguous failures, which this package deliberately refuses to do; with both active,
+the outer handler retries before the package ever sees the failure.
+
+Prefer exempting the package's clients and keeping the built-in retry, which honours
+`Retry-After` and knows which requests are safe to replay. Both clients are addressable
+by name:
+
+```csharp
+services.AddHttpClient(BusinessCentralHttpClients.Client).RemoveAllResilienceHandlers();
+services.AddHttpClient(BusinessCentralHttpClients.Token).RemoveAllResilienceHandlers();
+```
+
+Disabling the package's retry instead (`options.Retry.Enabled = false`) also resolves the
+composition, but leaves the generic outer handler in charge — including its unsafe `POST`
+replay.
+
 # ⚠️ Errors
 
 All failures derive from `BusinessCentralException`. `Message` is a single line suitable
@@ -292,6 +334,21 @@ catch (BusinessCentralException ex)
     if (ex.IsTransient) { /* safe to try again */ }
 }
 ```
+
+The subtypes are sealed **siblings**, not a hierarchy — a guard like
+`catch (BusinessCentralServerException ex) when (ex.StatusCode == HttpStatusCode.NotFound)`
+compiles but can never match, because a `404` is a `BusinessCentralNotFoundException`.
+Prefer the predicates on the base type, which make the safe form the obvious one:
+
+```csharp
+catch (BusinessCentralException ex) when (ex.IsNotFound)
+{
+    // already gone — treat the delete as idempotent success
+}
+```
+
+`IsNotFound`, `IsThrottled`, `IsValidation`, `IsAuth`, `IsConnectionFailure` and
+`IsTransient` cover the same distinctions as the subtypes, without the trap.
 
 # 📊 Diagnostics
 

--- a/src/Dynamics365.BusinessCentral/ServiceCollectionExtensions.cs
+++ b/src/Dynamics365.BusinessCentral/ServiceCollectionExtensions.cs
@@ -14,10 +14,10 @@ namespace Dynamics365.BusinessCentral;
 public static class ServiceCollectionExtensions
 {
     /// <summary>Name of the internal HttpClient used for token acquisition.</summary>
-    internal const string TokenHttpClientName = "Dynamics365.BusinessCentral.Token";
+    internal const string TokenHttpClientName = BusinessCentralHttpClients.Token;
 
     /// <summary>Name of the HttpClient used for data requests.</summary>
-    internal const string ClientHttpClientName = "Dynamics365.BusinessCentral.Client";
+    internal const string ClientHttpClientName = BusinessCentralHttpClients.Client;
 
     /// <summary>
     /// Registers <see cref="IBusinessCentralClient"/> configured in code.

--- a/test/Dynamics365.BusinessCentral.Tests/BusinessCentralFieldTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/BusinessCentralFieldTests.cs
@@ -1,0 +1,44 @@
+using Dynamics365.BusinessCentral.OData;
+using Dynamics365.BusinessCentral.Tests.Utils;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+/// <summary>
+/// <see cref="BusinessCentralField"/> and the now-public <see cref="EntityPath"/> let
+/// path-based consumers derive wire names from the entity model instead of hand-maintained
+/// constants classes. Resolution must match deserialization exactly.
+/// </summary>
+public class BusinessCentralFieldTests
+{
+    [Fact]
+    public void JsonPropertyName_Wins_Over_The_Naming_Policy()
+    {
+        Assert.Equal("Sell_to_Customer_No", BusinessCentralField.Of<SalesOrder>(o => o.CustomerNo));
+    }
+
+    [Fact]
+    public void Unannotated_Properties_Follow_The_CamelCase_Policy()
+    {
+        Assert.Equal("no", BusinessCentralField.Of<SalesOrder>(o => o.No));
+        Assert.Equal("amount", BusinessCentralField.Of<SalesOrder>(o => o.Amount));
+    }
+
+    [Fact]
+    public void Nested_Selectors_Become_Navigation_Paths()
+    {
+        Assert.Equal("customer/name", BusinessCentralField.Of<SalesOrder>(o => o.Customer!.Name));
+    }
+
+    [Fact]
+    public void Computed_Expressions_Are_Rejected()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            BusinessCentralField.Of<SalesOrder>(o => o.No.ToUpperInvariant()));
+    }
+
+    [Fact]
+    public void EntityPath_Is_Publicly_Resolvable()
+    {
+        Assert.Equal("salesOrders", EntityPath.For<SalesOrder>());
+    }
+}

--- a/test/Dynamics365.BusinessCentral.Tests/ClientTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ClientTests.cs
@@ -2070,10 +2070,54 @@ public partial class ClientTests
             };
         });
 
-        var result = await client.QueryAllAsync<TestEntity>("orders", options: o => o.WithTop(2));
+        var result = await client.QueryAllAsync<TestEntity>("orders", options: o => o.WithPageSize(2));
 
         Assert.Equal(5, result.Count);
         Assert.Equal(3, dataCalls);
+    }
+
+    // Top is a result cap here, exactly as its documentation says — the same contract as
+    // the fluent builder's Top(). It used to be silently repurposed as the page size.
+    [Fact]
+    public async Task QueryAll_Honours_Top_As_A_Result_Cap()
+    {
+        var dataCalls = 0;
+        var requests = new List<string>();
+
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
+        {
+            dataCalls++;
+            requests.Add(req.RequestUri!.ToString());
+
+            return TestBase.Json("{\"value\":[{\"id\":1},{\"id\":2}]}");
+        }));
+
+        var result = await client.QueryAllAsync<TestEntity>(
+            "orders", options: o => o.WithTop(3).WithPageSize(2));
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal(2, dataCalls);
+
+        // The second request never overshoots the cap: only one row is still wanted.
+        Assert.Contains("$top=2", requests[0]);
+        Assert.Contains("$top=1", requests[1]);
+    }
+
+    [Fact]
+    public async Task QueryAll_Top_Alone_Stops_After_Top_Rows()
+    {
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            dataCalls++;
+            return TestBase.Json("{\"value\":[{\"id\":1},{\"id\":2}]}");
+        }));
+
+        var result = await client.QueryAllAsync<TestEntity>("orders", options: o => o.WithTop(2));
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1, dataCalls);
     }
 
     #endregion

--- a/test/Dynamics365.BusinessCentral.Tests/ClientTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ClientTests.cs
@@ -2122,6 +2122,103 @@ public partial class ClientTests
 
     #endregion
 
+    #region Get Tests
+
+    [Fact]
+    public async Task Get_Builds_Key_Url_And_Deserializes_The_Entity()
+    {
+        string? capturedUrl = null;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
+        {
+            capturedUrl = req.RequestUri!.ToString();
+            return TestBase.Json("{\"id\":7,\"name\":\"pump\"}");
+        }));
+
+        var entity = await client.GetAsync<TestEntity>("orders", "7");
+
+        Assert.NotNull(entity);
+        Assert.Equal(7, entity.Id);
+        Assert.Equal("https://test/Company('Test')/orders(7)", capturedUrl);
+    }
+
+    [Fact]
+    public async Task Get_Appends_Select_And_Preserves_Alternate_Keys()
+    {
+        string? capturedUrl = null;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
+        {
+            capturedUrl = req.RequestUri!.ToString();
+            return TestBase.Json("{\"id\":7}");
+        }));
+
+        await client.GetAsync<TestEntity>("orders", "No='1000'", select: ["id", "name"]);
+
+        Assert.Equal("https://test/Company('Test')/orders(No='1000')?$select=id,name", capturedUrl);
+    }
+
+    // "Does this entity exist" is a question, not an error: 404 yields null. Anything
+    // else is still a real failure and throws.
+    [Fact]
+    public async Task Get_Returns_Null_On_404()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("{\"error\":{\"code\":\"Not_Found\",\"message\":\"gone\"}}")
+            }));
+
+        var entity = await client.GetAsync<TestEntity>("orders", "7");
+
+        Assert.Null(entity);
+    }
+
+    [Fact]
+    public async Task Get_Still_Throws_On_Other_Failures()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent("boom")
+            }));
+
+        await Assert.ThrowsAsync<BusinessCentralServerException>(() =>
+            client.GetAsync<TestEntity>("orders", "7"));
+    }
+
+    [Fact]
+    public async Task FirstOrDefault_Sends_Top_1_And_Returns_The_First_Row()
+    {
+        string? capturedUrl = null;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
+        {
+            capturedUrl = req.RequestUri!.ToString();
+            return TestBase.Json("{\"value\":[{\"id\":1},{\"id\":2}]}");
+        }));
+
+        var entity = await client.FirstOrDefaultAsync<TestEntity>(
+            "orders", Filter.Equals("status", "active"));
+
+        Assert.NotNull(entity);
+        Assert.Equal(1, entity.Id);
+        Assert.Contains("$top=1", capturedUrl);
+        Assert.Contains("$filter=", capturedUrl);
+    }
+
+    [Fact]
+    public async Task FirstOrDefault_Returns_Null_When_Nothing_Matches()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ => TestBase.Json("{\"value\":[]}")));
+
+        var entity = await client.FirstOrDefaultAsync<TestEntity>("orders");
+
+        Assert.Null(entity);
+    }
+
+    #endregion
+
     #region Observer Reporting Tests
 
     [Fact]

--- a/test/Dynamics365.BusinessCentral.Tests/DefaultInterfaceTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/DefaultInterfaceTests.cs
@@ -1,0 +1,96 @@
+using Dynamics365.BusinessCentral.Client;
+using Dynamics365.BusinessCentral.OData;
+using Dynamics365.BusinessCentral.Tests.Utils;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+/// <summary>
+/// Pins the default-interface-method contract: a hand-written fake implementing a single
+/// member compiles, composed members work through it, and everything else throws
+/// <see cref="NotSupportedException"/> naming the member. Interface growth must never
+/// break a consumer's test fake again.
+/// </summary>
+public class DefaultInterfaceTests
+{
+    /// <summary>Implements exactly one member — the typed-filter QueryAsync overload.</summary>
+    private sealed class MinimalFake : IBusinessCentralClient
+    {
+        public List<TestEntity> Seed { get; init; } = [];
+        public QueryOptions? LastOptions { get; private set; }
+
+        public Task<List<TEntity>> QueryAsync<TEntity>(
+            string path,
+            ODataFilter? filter = null,
+            Action<QueryOptions>? options = null,
+            IEnumerable<string>? select = null,
+            CancellationToken cancellationToken = default)
+        {
+            var opts = new QueryOptions();
+            options?.Invoke(opts);
+            LastOptions = opts;
+
+            return Task.FromResult(Seed.Cast<TEntity>().ToList());
+        }
+    }
+
+    [Fact]
+    public async Task Minimal_Fake_Implements_One_Member_And_Compiles()
+    {
+        IBusinessCentralClient client = new MinimalFake
+        {
+            Seed = [new TestEntity { Id = 1 }]
+        };
+
+        var result = await client.QueryAsync<TestEntity>("orders");
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task FirstOrDefaultAsync_Composes_Over_QueryAsync()
+    {
+        var fake = new MinimalFake
+        {
+            Seed = [new TestEntity { Id = 1 }, new TestEntity { Id = 2 }]
+        };
+
+        IBusinessCentralClient client = fake;
+
+        var first = await client.FirstOrDefaultAsync<TestEntity>("orders");
+
+        Assert.NotNull(first);
+        Assert.Equal(1, first.Id);
+        Assert.Equal(1, fake.LastOptions?.Top);
+    }
+
+    [Fact]
+    public async Task FirstOrDefaultAsync_Returns_Default_When_Nothing_Matches()
+    {
+        IBusinessCentralClient client = new MinimalFake();
+
+        var first = await client.FirstOrDefaultAsync<TestEntity>("orders");
+
+        Assert.Null(first);
+    }
+
+    [Fact]
+    public async Task Unimplemented_Members_Throw_NotSupported_Naming_The_Member()
+    {
+        IBusinessCentralClient client = new MinimalFake();
+
+        var company = Assert.Throws<NotSupportedException>(() => client.Company);
+        Assert.Contains("Company", company.Message);
+
+        var companies = await Assert.ThrowsAsync<NotSupportedException>(
+            () => client.GetCompaniesAsync());
+        Assert.Contains("GetCompaniesAsync", companies.Message);
+
+        var get = await Assert.ThrowsAsync<NotSupportedException>(
+            () => client.GetAsync<TestEntity>("orders", "1"));
+        Assert.Contains("GetAsync", get.Message);
+
+        var delete = await Assert.ThrowsAsync<NotSupportedException>(
+            () => client.DeleteAsync("orders", "1"));
+        Assert.Contains("DeleteAsync", delete.Message);
+    }
+}

--- a/test/Dynamics365.BusinessCentral.Tests/ExceptionPredicateTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ExceptionPredicateTests.cs
@@ -1,0 +1,78 @@
+using Dynamics365.BusinessCentral.Errors;
+using System.Net;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+/// <summary>
+/// The exception subtypes are sealed siblings, so status-code guards on the wrong subtype
+/// silently never match. The predicates on the base type are the supported alternative;
+/// this pins their truth table.
+/// </summary>
+public class ExceptionPredicateTests
+{
+    [Fact]
+    public void NotFound_Sets_Only_IsNotFound()
+    {
+        var ex = new BusinessCentralNotFoundException("x", HttpStatusCode.NotFound, "GET", null, null);
+
+        Assert.True(ex.IsNotFound);
+        Assert.False(ex.IsThrottled);
+        Assert.False(ex.IsValidation);
+        Assert.False(ex.IsAuth);
+        Assert.False(ex.IsConnectionFailure);
+        Assert.False(ex.IsTransient);
+    }
+
+    [Fact]
+    public void Throttled_Sets_IsThrottled_And_IsTransient()
+    {
+        var ex = new BusinessCentralThrottledException("x", HttpStatusCode.TooManyRequests, "GET", null, null);
+
+        Assert.True(ex.IsThrottled);
+        Assert.True(ex.IsTransient);
+        Assert.False(ex.IsNotFound);
+    }
+
+    [Fact]
+    public void Validation_Sets_IsValidation()
+    {
+        var ex = new BusinessCentralValidationException("x", HttpStatusCode.BadRequest, "POST", null, null);
+
+        Assert.True(ex.IsValidation);
+        Assert.False(ex.IsTransient);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    public void Auth_Failures_Set_IsAuth(HttpStatusCode status)
+    {
+        var ex = new BusinessCentralAuthException("x", status, "GET", null, null);
+
+        Assert.True(ex.IsAuth);
+        Assert.False(ex.IsTransient);
+    }
+
+    [Fact]
+    public void Connection_Failure_Sets_IsConnectionFailure_And_IsTransient()
+    {
+        var ex = new BusinessCentralConnectionException("x", "GET", null, new HttpRequestException());
+
+        Assert.True(ex.IsConnectionFailure);
+        Assert.True(ex.IsTransient);
+        Assert.False(ex.IsNotFound);
+    }
+
+    [Fact]
+    public void Transient_Server_Failure_Matches_No_Specific_Predicate()
+    {
+        var ex = new BusinessCentralServerException("x", HttpStatusCode.ServiceUnavailable, "GET", null, null);
+
+        Assert.True(ex.IsTransient);
+        Assert.False(ex.IsNotFound);
+        Assert.False(ex.IsThrottled);
+        Assert.False(ex.IsValidation);
+        Assert.False(ex.IsAuth);
+        Assert.False(ex.IsConnectionFailure);
+    }
+}

--- a/test/Dynamics365.BusinessCentral.Tests/FilterFormatTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/FilterFormatTests.cs
@@ -39,4 +39,37 @@ public class FilterFormatTests
 
         Assert.Equal("postingDate in (2026-07-01,2026-07-02)", filter.Value);
     }
+
+    // A kindless DateTime (parsed from config, loaded from a database) used to be run
+    // through ToUniversalTime, which assumes local — so the literal depended on the
+    // machine's timezone. It is now taken to already be UTC.
+    [Fact]
+    public void Unspecified_DateTime_Is_Treated_As_Utc_Not_Shifted()
+    {
+        var value = new DateTime(2026, 7, 29, 12, 0, 0, DateTimeKind.Unspecified);
+
+        var filter = Filter.GreaterOrEqual("lastModifiedDateTime", value);
+
+        Assert.Equal("lastModifiedDateTime ge 2026-07-29T12:00:00.0000000Z", filter.Value);
+    }
+
+    [Fact]
+    public void Utc_DateTime_Is_Formatted_Unchanged()
+    {
+        var value = new DateTime(2026, 7, 29, 12, 0, 0, DateTimeKind.Utc);
+
+        var filter = Filter.Equals("lastModifiedDateTime", value);
+
+        Assert.Equal("lastModifiedDateTime eq 2026-07-29T12:00:00.0000000Z", filter.Value);
+    }
+
+    [Fact]
+    public void Local_DateTime_Is_Still_Converted_To_Utc()
+    {
+        var value = new DateTime(2026, 7, 29, 12, 0, 0, DateTimeKind.Local);
+
+        var filter = Filter.Equals("lastModifiedDateTime", value);
+
+        Assert.Equal($"lastModifiedDateTime eq {value.ToUniversalTime():O}", filter.Value);
+    }
 }

--- a/test/Dynamics365.BusinessCentral.Tests/FilterFormatTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/FilterFormatTests.cs
@@ -1,0 +1,42 @@
+using Dynamics365.BusinessCentral.OData;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+public class FilterFormatTests
+{
+    // Business Central date fields (postingDate, documentDate, …) are Edm.Date. Before
+    // these types were handled, they fell through to Convert.ToString and produced a
+    // culture-formatted literal ("07/29/2026") that the server rejects with a 400.
+    [Fact]
+    public void DateOnly_Is_Formatted_As_An_OData_Date_Literal()
+    {
+        var filter = Filter.Equals("postingDate", new DateOnly(2026, 7, 29));
+
+        Assert.Equal("postingDate eq 2026-07-29", filter.Value);
+    }
+
+    [Fact]
+    public void TimeOnly_Is_Formatted_As_An_OData_TimeOfDay_Literal()
+    {
+        var filter = Filter.Equals("startTime", new TimeOnly(13, 45, 30));
+
+        Assert.Equal("startTime eq 13:45:30.0000000", filter.Value);
+    }
+
+    [Fact]
+    public void DateOnly_Works_In_Range_Filters()
+    {
+        var filter = Filter.GreaterOrEqual("postingDate", new DateOnly(2026, 1, 1))
+            .And(Filter.LessThan("postingDate", new DateOnly(2027, 1, 1)));
+
+        Assert.Equal("(postingDate ge 2026-01-01) and (postingDate lt 2027-01-01)", filter.Value);
+    }
+
+    [Fact]
+    public void DateOnly_Works_In_In_Filters()
+    {
+        var filter = Filter.In("postingDate", new DateOnly(2026, 7, 1), new DateOnly(2026, 7, 2));
+
+        Assert.Equal("postingDate in (2026-07-01,2026-07-02)", filter.Value);
+    }
+}

--- a/test/Dynamics365.BusinessCentral.Tests/PagingGuardTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/PagingGuardTests.cs
@@ -62,8 +62,11 @@ public class PagingGuardTests
     {
         var (client, _) = Bounded();
 
-        client.Query<SalesOrder>().Top(0);
-        new QueryOptions().WithTop(0);
+        var query = client.Query<SalesOrder>().Top(0);
+        var options = new QueryOptions().WithTop(0);
+
+        Assert.NotNull(query);
+        Assert.Equal(0, options.Top);
     }
 
     #endregion

--- a/test/Dynamics365.BusinessCentral.Tests/RetryTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/RetryTests.cs
@@ -334,6 +334,146 @@ public class RetryTests
         Assert.Equal(3, patches);
     }
 
+    #region Network failures
+
+    // No response at all — connection reset, DNS failure, client-side timeout — is as
+    // ambiguous as a 502/504: the request may have reached the server. Idempotent methods
+    // are retried; failures surface as BusinessCentralConnectionException so the
+    // "everything derives from BusinessCentralException" contract holds.
+    [Fact]
+    public async Task Get_Is_Retried_On_Connection_Failure()
+    {
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            dataCalls++;
+
+            if (dataCalls == 1)
+                throw new HttpRequestException("connection reset");
+
+            return TestBase.Json("{\"value\":[]}");
+        }));
+
+        var result = await client.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.Empty(result);
+        Assert.Equal(2, dataCalls);
+    }
+
+    [Fact]
+    public async Task Connection_Failure_Surfaces_As_ConnectionException_After_MaxAttempts()
+    {
+        var observer = new RecordingObserver();
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ =>
+            {
+                dataCalls++;
+                throw new HttpRequestException("connection reset");
+            }),
+            observer);
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralConnectionException>(() =>
+            client.QueryAsync<TestEntity>("orders", "true"));
+
+        Assert.Equal(3, dataCalls);
+        Assert.True(ex.IsTransient);
+        Assert.Equal(0, (int)ex.StatusCode);
+        Assert.IsType<HttpRequestException>(ex.InnerException);
+
+        Assert.Equal(2, observer.Retries.Count);
+        Assert.All(observer.Retries, r => Assert.Equal(0, r.StatusCode));
+    }
+
+    [Fact]
+    public async Task Client_Timeout_Is_Treated_As_Transient()
+    {
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            dataCalls++;
+
+            // What HttpClient throws when its Timeout elapses: a TaskCanceledException
+            // while the caller's token is NOT cancelled.
+            if (dataCalls == 1)
+                throw new TaskCanceledException("timed out", new TimeoutException());
+
+            return TestBase.Json("{\"value\":[]}");
+        }));
+
+        var result = await client.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.Empty(result);
+        Assert.Equal(2, dataCalls);
+    }
+
+    [Fact]
+    public async Task Post_Is_Not_Replayed_On_Connection_Failure()
+    {
+        var posts = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            posts++;
+            throw new HttpRequestException("connection reset");
+        }));
+
+        await Assert.ThrowsAsync<BusinessCentralConnectionException>(() =>
+            client.PostAsync("ldatSummary", new TestPatchEntity()));
+
+        Assert.Equal(1, posts);
+    }
+
+    [Fact]
+    public async Task Post_Replay_On_Connection_Failure_Can_Be_Opted_Into()
+    {
+        var posts = 0;
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ =>
+            {
+                posts++;
+                throw new HttpRequestException("connection reset");
+            }),
+            configure: o => o.Retry = new BusinessCentralRetryOptions
+            {
+                MaxAttempts = 3,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero,
+                RetryPostOnTransientFailures = true
+            });
+
+        await Assert.ThrowsAsync<BusinessCentralConnectionException>(() =>
+            client.PostAsync("ldatSummary", new TestPatchEntity()));
+
+        Assert.Equal(3, posts);
+    }
+
+    // Cancellation requested by the caller must propagate as-is: no wrapping, no retry.
+    [Fact]
+    public async Task User_Cancellation_Is_Not_Wrapped_Or_Retried()
+    {
+        using var cts = new CancellationTokenSource();
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            dataCalls++;
+            cts.Cancel();
+            throw new TaskCanceledException();
+        }));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            client.QueryAsync<TestEntity>("orders", "true", cancellationToken: cts.Token));
+
+        Assert.Equal(1, dataCalls);
+    }
+
+    #endregion
+
     #region Backoff bounds
 
     // A large BaseDelay with a high attempt count overflows TimeSpan, and

--- a/test/Dynamics365.BusinessCentral.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ServiceCollectionExtensionsTests.cs
@@ -155,7 +155,7 @@ public class ServiceCollectionExtensionsTests
         // Configure the named handlers rather than re-registering the typed client,
         // which would replace the registration under test.
         services
-            .AddHttpClient(ServiceCollectionExtensions.TokenHttpClientName)
+            .AddHttpClient(BusinessCentralHttpClients.Token)
             .ConfigurePrimaryHttpMessageHandler(() => new FakeHttpHandler(_ =>
             {
                 Interlocked.Increment(ref tokenCalls);
@@ -166,7 +166,7 @@ public class ServiceCollectionExtensionsTests
             }));
 
         services
-            .AddHttpClient(ServiceCollectionExtensions.ClientHttpClientName)
+            .AddHttpClient(BusinessCentralHttpClients.Client)
             .ConfigurePrimaryHttpMessageHandler(() => new FakeHttpHandler(_ =>
                 new HttpResponseMessage(HttpStatusCode.OK)
                 {


### PR DESCRIPTION
Two defect fixes targeted at 2.0.0 stable, plus the SonarCloud cleanup commit already on this branch.

## Fixed: `DateOnly`/`TimeOnly` produced invalid OData filter literals

`Filter.Format` had no case for either type, so both fell through to `Convert.ToString` and emitted culture-formatted text — `Filter.Equals("postingDate", new DateOnly(2026, 7, 29))` built `postingDate eq 07/29/2026`, which Business Central rejects with a 400. Since BC date fields (`postingDate`, `documentDate`, `dueDate`, …) are Edm.Date, this broke the natural typed filter. Both now emit round-trip invariant literals (`2026-07-29`, `13:45:30.0000000`), pinned by the new `FilterFormatTests` suite.

## Fixed: network-level failures bypassed retry and escaped the exception contract

The transient-retry budget only engaged on HTTP status codes. A connection reset, DNS failure, or the `HttpClient` timeout failed on the first attempt — even for a GET — and surfaced as a raw `HttpRequestException`/`TaskCanceledException`, contradicting the documented "all failures derive from `BusinessCentralException`" contract.

Now:

- New `BusinessCentralConnectionException` (`StatusCode` 0 — no response; original exception preserved as `InnerException`; `IsTransient` true).
- Routed through the existing transient budget under the same replay rules as `408`/`502`/`503`/`504`: idempotent methods replay, POST is held back unless `Retry.RetryPostOnTransientFailures` is set — no response is exactly as ambiguous as a 502.
- Caller-initiated cancellation is never wrapped or retried (pinned by test).
- Observer events fire the same as for status-code failures; retry `StatusCode` is 0.

**Behavioural note for the migration guide (included):** `catch (HttpRequestException)` around client calls no longer fires — catch `BusinessCentralConnectionException` or the base type.

## Also on this branch

- SonarCloud cleanups with no behavioural risk (d1d4bc7): a non-asserting test now asserts, plus mechanical refactors.
- Removed a stray "Kral" line accidentally committed into MIGRATION.md's heading area (was in the working tree).

## Docs & tests

- CHANGELOG `[Unreleased]` entries (Added/Changed/Fixed) ready to fold into the 2.0.0 stable section at release.
- MIGRATION.md retry section extended; both READMEs updated in sync (exception table + retry paragraph).
- 185 tests green (10 new: 4 filter-format, 6 network-failure/cancellation); all three TFMs build with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second commit: two behavioural traps fixed while still prerelease

**`WithTop` is now a result cap in `QueryAllAsync`/`QueryStreamAsync`** (64f1fed). It was silently repurposed as the page size — `WithTop(10)` fetched the *entire* collection in pages of 10 — and dropped entirely when `WithPageSize` was also set, contradicting both its own docs and the fluent builder. The path-based stream now mirrors `BusinessCentralQuery.StreamAsync` exactly; `$top` shrinks per request so the cap is never overshot. **Breaking vs 1.0/alpha semantics** — MIGRATION.md documents the `WithPageSize` replacement.

**Kindless `DateTime` filter values are no longer shifted by the machine's timezone.** `Kind=Unspecified` went through `ToUniversalTime()`, which assumes local — the same filter matched different rows depending on where the code ran. Unspecified is now read as UTC (what Business Central stores); `Utc`/`Local` are unchanged.

Now 190 tests (15 new across both commits); MIGRATION.md, CHANGELOG and CLAUDE.md updated.

---

## Third commit: pre-stable consumer-feedback set (e9288b6)

Implements P1, P5, P6, P7 and P8a/c from `the round-one consumer feedback` (included in the repo), all API-contract items best landed before 2.0.0 stable:

- **P1** — every `IBusinessCentralClient` member has a default implementation; hand-written fakes implement only what they exercise, and interface growth stops breaking consumer builds. `FirstOrDefaultAsync` composes over `QueryAsync` so fakes inherit it.
- **P6** — `GetAsync<T>(path, key, select?)` (null on 404) and `FirstOrDefaultAsync<T>` on the path-based API.
- **P5** — `BusinessCentralHttpClients.Token`/`.Client` public, plus a README section on exempting them from global resilience handlers (whose default `POST` replay bypasses the package's duplicate-write protection).
- **P7** — predicates on the exception base (`IsNotFound`, `IsThrottled`, `IsValidation`, `IsAuth`, `IsConnectionFailure`) so unsatisfiable status-code guards on sealed siblings stop being the natural pattern.
- **P8a/c** — `BusinessCentralField.Of<T>(selector)` and public `EntityPath`, letting path-based consumers delete hand-maintained wire-name constants.

**Deferred to 2.1:** P8b (selector `select:` overloads would make existing calls ambiguous — needs a different shape), P2 (testing package), P3 (chunked `In`), P4 (OpenTelemetry).

Now 212 tests (22 new in this commit).