### PR TITLE
Release 2.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0-alpha.2] - 2026-07-29
+
+**Prerelease.** The release candidate for 2.0.0 stable: everything below was driven by
+reviewing the alpha and by feedback from a production consumer migrating to it. Still to
+be confirmed against a live tenant before stable: the *Unverified* list under
+[2.0.0-alpha], plus a smoke test of a date filter.
+
 ### Added
 
 - **Default implementations on every `IBusinessCentralClient` member.** Hand-written test

--- a/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
+++ b/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>Dynamics365.BusinessCentral</PackageId>
-        <Version>2.0.0-alpha</Version>
+        <Version>2.0.0-alpha.2</Version>
         <Authors>Daniel Rückenbach</Authors>
         <Company>KRAL GmbH</Company>
 
@@ -35,12 +35,16 @@
         <!-- Shown on the nuget.org package page. Kept short and pointed at CHANGELOG.md
              rather than duplicated, since nuget.org renders this as plain text. -->
         <PackageReleaseNotes>
-            PRERELEASE — 2.0.0-alpha is published for validation against real Business
-            Central environments. Not recommended for production until 2.0.0 stable.
+            PRERELEASE — 2.0.0-alpha.2 is the release candidate for 2.0.0 stable, published
+            for validation against real Business Central environments.
 
-            2.0.0 fixes six defects and reworks the API: typed queries via client.Query&lt;T&gt;(),
-            Retry-After aware throttling handling, streaming, $expand/$count, multi-company
-            support, and XML docs now shipped in the package.
+            On top of 2.0.0-alpha: date/time filter literals fixed (DateOnly, TimeOnly,
+            kindless DateTime), network failures retried and surfaced as
+            BusinessCentralConnectionException, WithTop honoured as a result cap when
+            auto-paging, single-entity GetAsync/FirstOrDefaultAsync, default interface
+            methods so test fakes keep compiling, public HttpClient names for resilience
+            composition, exception predicates (IsNotFound etc.), and typed field-name
+            resolution for the path-based API.
 
             Breaking changes — see the migration guide before upgrading:
             https://github.com/KralGmbh/Dynamics365-BusinessCentral/blob/master/MIGRATION.md


### PR DESCRIPTION
Release prep for the 2.0.0-alpha.2 prerelease — the validation build for Bastion carrying everything merged in #41 (four filter/paging/retry fixes plus the pre-stable consumer-feedback API additions).

- `<Version>` → `2.0.0-alpha.2`
- CHANGELOG: `[Unreleased]` moved to `[2.0.0-alpha.2] - 2026-07-29`
- `<PackageReleaseNotes>` refreshed for nuget.org

After merging: publish a GitHub release tagged `v2.0.0-alpha.2` (mark as pre-release) — `nuget.yml` packs and pushes to NuGet automatically.