### PR TITLE
Robustness fixes from the pre-stable review (N1, N2, N3, N5, N6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`Retry.JitterFactor`** (default `0.2`): every retry delay — computed backoff *and*
+  honoured `Retry-After` — is spread by `random(0, delay × factor)`, capped by `MaxDelay`,
+  so concurrent callers throttled at the same moment stop retrying in lockstep and
+  re-throttling each other. The spread is additive only, because a `Retry-After` is a
+  minimum wait. Set `0` for deterministic delays.
+
+### Fixed
+
+- **Token acquisition is retried.** The token request previously had no transient handling
+  at all — a blip at `login.microsoftonline.com` failed every in-flight request at once,
+  and following the README's resilience-composition recipe removed the only outer safety
+  net. Token requests now honour the same `Retry` options as data requests (the
+  `client_credentials` grant has no side effects, so replay is unconditionally safe),
+  report `OnRequestRetrying`, and wrap network failures as
+  `BusinessCentralConnectionException`. Credential failures (`400`/`401`) are not retried.
+- **Concurrent `401`s no longer cascade token refreshes.** Invalidation is now
+  compare-and-swap: a request that observed a stale token cannot clear a token that was
+  already refreshed behind it.
+- **`$expand` encoding handles unsafe characters.** Only spaces were escaped before, so an
+  `&`, `#` or `+` inside a nested expand clause (e.g. `lines($filter=code eq 'A&B')`)
+  silently truncated the query string. Structural expand syntax is preserved; everything
+  else is percent-encoded.
+
+### Changed
+
+- The auto-paging state machine now exists once (shared by `QueryStreamAsync` and the
+  fluent `StreamAsync`) instead of as two hand-synchronised copies. No behavioural change;
+  both entry points are covered by the existing paging tests.
+
 ## [2.0.0-alpha.2] - 2026-07-29
 
 **Prerelease.** The release candidate for 2.0.0 stable: everything below was driven by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ CI: `.github/workflows/sonar.yml` builds + tests on net8.0 and runs SonarCloud o
 Everything funnels through `BusinessCentralClient.SendWithAuthRetryAsync`, a single loop with **two independent retry budgets**:
 
 - **auth** — one retry, tracked by `authRetried`. A `401` invalidates the token and retries once.
-- **transient** — `BusinessCentralRetryOptions.MaxAttempts`, tracked by `transientAttempt`. Gated by `IsSafeToReplay`, not by `IsTransient` alone. `ComputeDelay` prefers the server's `Retry-After`, else doubles `BaseDelay`; both capped by `MaxDelay`.
+- **transient** — `BusinessCentralRetryOptions.MaxAttempts`, tracked by `transientAttempt`. Gated by `IsSafeToReplay`, not by `IsTransient` alone. `RetryHelper.ComputeDelay` (shared with the token provider) prefers the server's `Retry-After`, else doubles `BaseDelay`; both are jittered additively by `JitterFactor` (never below a `Retry-After` — it's a minimum wait) and capped by `MaxDelay`.
 
 `IsSafeToReplay` encodes a deliberate asymmetry: a `429` is rejected *before* processing so it is always replayable, but `408/502/503/504` are ambiguous — the write may already have landed. A `POST` is therefore not replayed on those unless `Retry.RetryPostOnTransientFailures` is set, because a duplicate row is worse than a surfaced error. `GET`/`PUT`/`DELETE` are idempotent and always retried. Don't "simplify" this back to a plain `IsTransient` check.
 
@@ -60,6 +60,8 @@ The client never mutates the injected `HttpClient` (it may be pooled). Accept/Us
 ### Token acquisition
 
 `BusinessCentralTokenProvider` owns the token cache: lock-free fast path, then a `SemaphoreSlim` with double-check before the client-credentials POST. Tokens are cached with a 60-second safety margin subtracted from `expires_in`. It uses `options.ResolvedTokenEndpoint` — never re-implement placeholder substitution locally.
+
+The token POST retries transient failures under the same `Retry` options as data requests, **inside the lock** — every waiter needs the same token, so backoff for one is backoff for all. Replay is unconditionally safe (`client_credentials` has no side effects), so it gates on `IsTransient` alone, not `IsSafeToReplay`; credential failures (`400`/`401`) throw immediately. `InvalidateAsync(staleToken, …)` is compare-and-swap: it only clears the cache when the rejected token is still the cached one, so concurrent `401`s cannot cascade refreshes.
 
 **It is registered as a singleton on purpose.** Typed HTTP clients are transient, so a cache living on `BusinessCentralClient` would re-authenticate on every injection. It gets its own named `HttpClient` (`TokenHttpClientName`) via `IHttpClientFactory`. If you ever move token state back onto the client, you reintroduce that bug — `Token_Cache_Is_Shared_Across_Resolved_Clients` guards it.
 
@@ -85,13 +87,13 @@ Note the quirk in `BuildQueryUrl`: a filter string of `"true"` is treated as "no
 
 ### Paging
 
-Two paging implementations exist and must stay in agreement: `BusinessCentralClient.QueryStreamAsync` (path-based) and `BusinessCentralQuery<T>.StreamAsync` (fluent). Both use the same three-tier termination:
+The auto-paging state machine lives **once**, in `QueryPager` (internal, `OData/`); both public entry points — `BusinessCentralClient.QueryStreamAsync` (path-based) and `BusinessCentralQuery<T>.StreamAsync` (fluent) — delegate to it and differ only in their fetch delegates. Termination is three-tier:
 
 1. Follow `@odata.nextLink` whenever present, and set `serverDriven`.
 2. Once `serverDriven`, a missing nextLink means the collection is exhausted — the `$top` short-page rule no longer applies.
 3. Otherwise stop on the first page shorter than the requested size.
 
-`QueryOptions.PageSize` is rows-per-round-trip; `Top` is a result cap — in both implementations. Each computes the next request's `$top` via `NextTop(pageSize, limit, emitted)` so a request never overshoots the cap. The old `WithTop`-as-page-size behaviour is gone (2.0); `WithPageSize` is the only way to size round trips.
+`QueryOptions.PageSize` is rows-per-round-trip; `Top` is a result cap. `QueryPager.NextTop(pageSize, limit, emitted)` computes each request's `$top` so a request never overshoots the cap. The old `WithTop`-as-page-size behaviour is gone (2.0); `WithPageSize` is the only way to size round trips.
 
 ### Writes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ The auto-paging state machine lives **once**, in `QueryPager` (internal, `OData/
 2. Once `serverDriven`, a missing nextLink means the collection is exhausted — the `$top` short-page rule no longer applies.
 3. Otherwise stop on the first page shorter than the requested size.
 
-`QueryOptions.PageSize` is rows-per-round-trip; `Top` is a result cap. `QueryPager.NextTop(pageSize, limit, emitted)` computes each request's `$top` so a request never overshoots the cap. The old `WithTop`-as-page-size behaviour is gone (2.0); `WithPageSize` is the only way to size round trips.
+`QueryOptions.PageSize` is rows-per-round-trip; `Top` is a result cap. `QueryPager` sizes each request's `$top` from the remaining cap, so a request never overshoots it. The old `WithTop`-as-page-size behaviour is gone (2.0); `WithPageSize` is the only way to size round trips.
 
 ### Writes
 

--- a/PRE-STABLE-REVIEW-BASTION.md
+++ b/PRE-STABLE-REVIEW-BASTION.md
@@ -1,0 +1,403 @@
+# Pre-stable review: findings from a production consumer
+
+Second round of feedback on **Dynamics365.BusinessCentral**, written against
+`v2.0.0-alpha.2` (commit `a2e12d3`) after a production consumer (Bastion) upgraded onto it.
+
+Round one is [CONSUMER-FEEDBACK-BASTION.md](CONSUMER-FEEDBACK-BASTION.md) and covered the
+consumer-facing API surface. **This document is different in kind:** it comes from reading
+the client internals — token acquisition, retry backoff, URL construction, paging — rather
+than from using the public API. The findings are defects and robustness gaps, not ergonomics
+requests.
+
+Self-contained: an agent working in this repository needs no access to the consumer
+codebase. All evidence is quoted inline with file references.
+
+---
+
+## Status of round one
+
+Shipped in `2.0.0-alpha.2` — no action needed, listed so this round is not confused with it:
+
+| ID | Proposal | Status |
+| --- | --- | --- |
+| P1 | Default implementations on every `IBusinessCentralClient` member | ✅ |
+| P5 | `BusinessCentralHttpClients` public client names | ✅ |
+| P6 | `GetAsync` / `FirstOrDefaultAsync` on the path-based API | ✅ |
+| P7 | Predicate properties on `BusinessCentralException` | ✅ (plus `IsConnectionFailure`) |
+| P8a/c | `BusinessCentralField.Of`, public `EntityPath` | ✅ |
+| P2 | Testing package | ❌ Not implemented — see *Release readiness* below |
+| P3 | Auto-chunked `In` | ❌ Not implemented |
+| P4 | Native OpenTelemetry | ❌ Not implemented |
+
+Verified against the consumer: the upgrade from `2.0.0-alpha` to `2.0.0-alpha.2` required
+**zero** source changes and left 1,378 unit tests plus 208 integration tests green. P1 works
+as intended — two hand-written fakes shed ~90 lines of stubs and now declare only the members
+they exercise.
+
+---
+
+## Summary of this round
+
+| ID | Finding | Severity | Effort |
+| --- | --- | --- | --- |
+| N1 | Token acquisition has no retry — and the README now steers consumers into removing the only resilience it had | **High** | Low |
+| N2 | No jitter in retry backoff → synchronised retry storms under throttling | **High** | Low |
+| N3 | `InvalidateAsync` can cascade token refreshes under concurrent `401`s | Medium | Low |
+| N4 | No URL-length guard → confusing failures on large `$filter` | Medium | Low |
+| N5 | The paging loop is duplicated verbatim in two files | Medium | Medium |
+| N6 | `$expand` hand-rolled encoding; `"true"` magic-string filter contract | Low | Low |
+
+N1 and N2 are the ones I would not ship stable without.
+
+---
+
+## N1 — Token acquisition has no retry, and the README now makes that dangerous
+
+**Severity: High · Effort: Low**
+
+### Problem
+
+`BusinessCentralTokenProvider.GetTokenAsync` performs a single, bare send. It does not go
+through `SendWithAuthRetryAsync`, so it has no transient handling of any kind — no retry, no
+`Retry-After`, no backoff.
+
+Until `2.0.0-alpha.2` this was masked for most consumers: anyone with a global resilience
+handler (Aspire's `ConfigureHttpClientDefaults` + `AddStandardResilienceHandler` is the common
+case) was getting retries on the token client for free, without knowing it.
+
+The new README section removes exactly that safety net:
+
+```csharp
+services.AddHttpClient(BusinessCentralHttpClients.Client).RemoveAllResilienceHandlers();
+services.AddHttpClient(BusinessCentralHttpClients.Token).RemoveAllResilienceHandlers();
+```
+
+A consumer who follows the documented guidance ends up with **zero** resilience on token
+acquisition. A transient `503` from `login.microsoftonline.com` becomes a hard failure.
+
+### Evidence
+
+`Client/BusinessCentralTokenProvider.cs:83` — the only send in the class:
+
+```csharp
+using var res = await _http.SendAsync(req, cancellationToken).ConfigureAwait(false);
+res.RequestMessage ??= req;
+
+if (!res.IsSuccessStatusCode)
+    throw await BusinessCentralExceptionFactory.CreateAsync(res, cancellationToken).ConfigureAwait(false);
+```
+
+No loop, no `BusinessCentralRetryOptions` reference anywhere in the file.
+
+**Blast radius is larger than the failure rate suggests.** The token is cached for roughly an
+hour, so failures are rare — but `GetTokenAsync` serialises every concurrent caller behind one
+`SemaphoreSlim` (`:52`). When a refresh fails, every in-flight request fails together.
+
+### Proposal
+
+Route token acquisition through the same retry budget as data requests. The
+`client_credentials` grant has no side effects, so replay is unconditionally safe — none of
+the `POST`-ambiguity reasoning in `IsSafeToReplay` applies.
+
+Then drop the `.Token` line from the README's resilience snippet, or replace it with an
+explicit note that the package now handles token resilience itself.
+
+### Acceptance criteria
+
+- [ ] Token acquisition honours `Retry.Enabled`, `MaxAttempts`, `BaseDelay`, `MaxDelay` and
+      `Retry-After`.
+- [ ] Token retries raise `OnRequestRetrying`, consistent with data requests.
+- [ ] Test: a token endpoint returning `503` then `200` yields a token rather than throwing.
+- [ ] Test: a token endpoint returning `401`/`400` (bad credentials) does **not** retry — that
+      is not transient.
+- [ ] README's resilience snippet no longer strips resilience from the token client.
+
+---
+
+## N2 — No jitter in the retry backoff
+
+**Severity: High · Effort: Low**
+
+### Problem
+
+Backoff is purely deterministic. Every client that fails at the same moment retries at the
+same moment.
+
+Against an API the README itself describes as throttling aggressively, this is the textbook
+setup for a synchronised retry storm. It is worse on the `Retry-After` path than on the
+computed path: Business Central hands *every* concurrent caller the same `Retry-After` value,
+so they all resume in lockstep and re-throttle each other.
+
+### Evidence
+
+`Client/BusinessCentralClient.cs:864` — no randomisation, and `Retry-After` is honoured
+verbatim:
+
+```csharp
+private static TimeSpan ComputeDelay(
+    BusinessCentralRetryOptions retry, TimeSpan? retryAfter, int attempt)
+{
+    var max = Floor(retry.MaxDelay);
+
+    if (retry.HonorRetryAfter && retryAfter is { } requested)
+        return Clamp(requested, max);
+
+    var milliseconds = Floor(retry.BaseDelay).TotalMilliseconds * Math.Pow(2, attempt - 1);
+    …
+}
+```
+
+A repository-wide search for `Random` / `Jitter` returns nothing.
+
+Consumers that fan out concurrent Business Central calls amplify this directly — the
+consumer here issues parallel `QueryAsync` calls via `Task.WhenAll` in more than one adapter.
+
+### Proposal
+
+Apply jitter to **both** branches — the computed backoff and the honoured `Retry-After`.
+Decorrelated jitter is the usual choice; at minimum ±20%.
+
+Expose it as `Retry.JitterFactor` (default non-zero) so it can be disabled for deterministic
+tests, and seed from `Random.Shared` to stay allocation-free and thread-safe.
+
+### Acceptance criteria
+
+- [ ] Computed backoff and honoured `Retry-After` are both jittered.
+- [ ] Jitter never produces a negative delay, and never exceeds `MaxDelay`.
+- [ ] Configurable, with a documented default; `0` disables it.
+- [ ] Test: N concurrent retries against one `Retry-After` produce a spread of delays, not one
+      value.
+
+---
+
+## N3 — `InvalidateAsync` can cascade token refreshes under concurrent `401`s
+
+**Severity: Medium · Effort: Low**
+
+### Problem
+
+`InvalidateAsync` clears the cache unconditionally. Under a burst of `401`s — secret rotation,
+token revocation, clock skew — a request that observed the *old* token can clear a *newly
+refreshed* one, forcing another refresh, which the next straggler then clears in turn.
+
+N concurrent `401`s can therefore produce substantially more than one token request, which is
+the opposite of what the singleton cache exists to achieve.
+
+### Evidence
+
+`Client/BusinessCentralTokenProvider.cs:116` — no comparison against what the caller saw:
+
+```csharp
+public async Task InvalidateAsync(CancellationToken cancellationToken)
+{
+    await _tokenLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+    try { _token = null; }
+    finally { _tokenLock.Release(); }
+}
+```
+
+Called from `Client/BusinessCentralClient.cs:702`, once per `401`, with no knowledge of which
+token was rejected:
+
+```csharp
+await _tokenProvider.InvalidateAsync(cancellationToken).ConfigureAwait(false);
+```
+
+### Proposal
+
+Compare-and-swap. The call site already holds the token it used — it set the `Authorization`
+header from it — so pass it back:
+
+```csharp
+public async Task InvalidateAsync(string staleToken, CancellationToken cancellationToken)
+{
+    …
+    if (_token is not null && _token.Token == staleToken)
+        _token = null;
+}
+```
+
+A straggler holding an already-replaced token then becomes a no-op.
+
+### Acceptance criteria
+
+- [ ] Invalidation only clears the cache when the stale token matches the cached one.
+- [ ] Test: 20 concurrent `401`s against one client trigger exactly one token refresh.
+
+---
+
+## N4 — No URL-length guard
+
+**Severity: Medium · Effort: Low**
+
+### Problem
+
+Nothing checks the length of the constructed URL. A large `Filter.In` silently produces a URL
+that Business Central or IIS rejects, and the consumer sees a bare `404`/`414` with no
+indication that length was the cause.
+
+### Evidence
+
+`Client/BusinessCentralUrlBuilder.BuildQueryUrl` assembles and returns the URL with no size
+check. `Filter.In` accepts an unbounded `IEnumerable<object>`.
+
+Evidence that consumers do not anticipate this: in the consumer reviewed here, `Filter.In` is
+used **zero** times — its adapters fan out one request per key instead. Nobody who has not
+already been burned reaches for the bulk form.
+
+### Proposal
+
+Throw a clear `ArgumentException` naming the length and the likely culprit when the encoded
+URL exceeds a configurable threshold (~2000 chars is the safe practical limit).
+
+This is deliberately the cheap 80% of round one's P3 (auto-chunked `In`). Even without
+chunking, converting a mystifying `404` into "this `$filter` produced a 4,210-character URL;
+Business Central will reject it — chunk the `In` values" is most of the value.
+
+### Acceptance criteria
+
+- [ ] Configurable maximum URL length with a documented default.
+- [ ] Exception message states the actual length, the limit, and suggests chunking.
+- [ ] Test: an `In` filter with many values throws before the request is sent.
+
+---
+
+## N5 — The paging loop is duplicated verbatim
+
+**Severity: Medium · Effort: Medium**
+
+### Problem
+
+The auto-paging state machine exists twice, in full, including a private `NextTop` helper
+defined identically in both places. This is the subtlest logic in the package — server-driven
+`nextLink` versus short-page termination, `$top` as a result cap, `$skip` continuation — and
+it is maintained in two copies.
+
+### Evidence
+
+`Client/BusinessCentralClient.cs:259–311` and `OData/BusinessCentralQuery.cs:176–234` carry
+matching `serverDriven` flags, matching `inPage < requested` termination checks, and two
+private `NextTop` methods.
+
+The code already concedes the hazard, at `BusinessCentralClient.cs:196`:
+
+```csharp
+// Top is a result cap, exactly as documented on WithTop; PageSize sizes the round
+// trips. This mirrors BusinessCentralQuery<T>.StreamAsync — the two implementations
+// must stay in agreement.
+```
+
+This is not hypothetical: the `2.0.0-alpha.2` fix making `WithTop` a result cap had to be
+applied in both copies. A comment is the only thing keeping them synchronised.
+
+### Proposal
+
+Extract one paging iterator parameterised over `IBusinessCentralQueryExecutor` — the interface
+already exists and both call sites already have an executor. Both public entry points then
+delegate to it.
+
+Worth doing **before** stable: after 2.0.0 these are two public behaviours that can silently
+diverge, and divergence between `QueryAllAsync` and `Query<T>().ToAllAsync()` would be
+extremely hard for a consumer to diagnose.
+
+### Acceptance criteria
+
+- [ ] One implementation of the paging loop and of `NextTop`.
+- [ ] Both entry points delegate to it.
+- [ ] Existing paging tests pass unchanged for both entry points.
+- [ ] The "must stay in agreement" comment is deleted rather than reworded.
+
+---
+
+## N6 — Two small correctness nits
+
+**Severity: Low · Effort: Low**
+
+### `$expand` is encoded by hand
+
+`Client/BusinessCentralUrlBuilder.cs:119`:
+
+```csharp
+query.Add("$expand=" + string.Join(",", options.Expand).Replace(" ", "%20"));
+```
+
+Everything else in the builder uses `Uri.EscapeDataString`; this escapes spaces only. A `#`,
+`&` or `+` inside an expand clause — e.g. `Expand("lines($filter=code eq 'A&B')")` — breaks the
+URL.
+
+Expand syntax needs `(`, `)`, `$`, `,` and `=` preserved, so it cannot be escaped wholesale —
+it needs the same selective, character-class approach `EncodeKey` already demonstrates a few
+lines below.
+
+### `"true"` is a magic-string contract between `Filter` and the URL builder
+
+`Client/BusinessCentralUrlBuilder.cs:79`:
+
+```csharp
+if (!string.IsNullOrWhiteSpace(filter) && filter != "true")
+```
+
+"No filter" is encoded as the literal string `"true"`, coupling two components through a magic
+value. Any filter whose rendered form is exactly `true` is silently dropped. Representing
+absence as `null` would remove the coupling.
+
+### Acceptance criteria
+
+- [ ] `$expand` uses selective encoding preserving OData expand syntax; test with `&` in a
+      nested filter.
+- [ ] "No filter" is represented structurally rather than by the string `"true"`.
+
+---
+
+## Release readiness for 2.0.0 stable
+
+Recommended gating, in order:
+
+1. **Ship the testing package (round one, P2).** Still the highest-value item, and nothing in
+   `alpha.2` changed that. Every fix in this release — `WithTop` semantics, the kindless
+   `DateTime` shift, the paging rules — is verified only against this repository's own fake
+   handler. **Consumers have no supported way to assert the OData their code generates.**
+   Concretely: when the consumer here converged ten drifted field constants, verifying that
+   deserialization still bound required writing a test from scratch against
+   `BusinessCentralJson.Options` directly, because no package-provided mechanism could do it.
+
+2. **N1 and N2.** Both are robustness-under-load defects, both are small, and N1 is
+   actively steered into by current documentation.
+
+3. **Close the `Unverified` list.** It has now been carried across two prereleases:
+   `GetCompaniesAsync`'s response shape, whether Business Central honours
+   `Prefer: return=representation`, and server-driven `@odata.nextLink` against a real dataset
+   — plus a date-filter smoke test for the `DateOnly`/`TimeOnly` fix. A stable release should
+   either verify these against a live tenant or state the limitation plainly in the README.
+
+4. **N5**, before the paging behaviour is frozen as public API in two places.
+
+5. **N3, N4, N6** — desirable, not blockers.
+
+**Can slip to 2.1:** round one's P3 (auto-chunked `In`) and P4 (native OpenTelemetry). Both are
+purely additive and non-breaking, so neither needs to gate stable. N4 delivers much of P3's
+practical value on its own.
+
+---
+
+## Appendix: provenance and confidence
+
+**Method.** Upgraded a production consumer from `2.0.0-alpha` to `2.0.0-alpha.2`, verified
+each round-one item in the source rather than from the changelog, then read the client
+internals looking for defects. Every claim above was checked against the code at commit
+`a2e12d3`; the quoted line numbers are from that commit.
+
+**Read in full:** `Client/BusinessCentralClient.cs`, `Client/BusinessCentralTokenProvider.cs`,
+`Client/BusinessCentralUrlBuilder.cs`, `Client/IBusinessCentralClient.cs`,
+`Errors/BusinessCentralException.cs`, `Options/*`, `OData/PropertyPath.cs`,
+`OData/EntityPath.cs`, `ServiceCollectionExtensions.cs`, `README.md`, `MIGRATION.md`,
+`CHANGELOG.md`.
+
+**Not read end-to-end:** `OData/BusinessCentralQuery.cs` (grepped for the paging loop only),
+`OData/Filter.cs` (public signatures only). N5 rests on a structural grep of
+`BusinessCentralQuery.cs` rather than a full read — if the duplication is deliberate for a
+reason not visible in that region, discount it accordingly.
+
+**Not claimed.** No live Business Central tenant was involved. Nothing here is a report of
+observed production failure; N1–N3 are latent failure modes identified by reading, and the
+severity ratings reflect blast radius rather than observed frequency.

--- a/README.md
+++ b/README.md
@@ -256,6 +256,9 @@ var lines = await client.QueryAsync<ProdOrderLine>(
 
 Business Central throttles aggressively. Throttled (`429`) and transient (`408`, `502`,
 `503`, `504`) responses are retried automatically, honouring `Retry-After` when present.
+Delays are jittered (`Retry.JitterFactor`, default `0.2`) so concurrent callers do not
+retry in lockstep — the spread is only ever added, never subtracted from a `Retry-After`.
+Token acquisition follows the same retry options; bad credentials are not retried.
 
 ```csharp
 services.AddBusinessCentral(options =>
@@ -306,6 +309,9 @@ by name:
 services.AddHttpClient(BusinessCentralHttpClients.Client).RemoveAllResilienceHandlers();
 services.AddHttpClient(BusinessCentralHttpClients.Token).RemoveAllResilienceHandlers();
 ```
+
+Exempting the token client is safe: token acquisition has its own retry under the same
+`Retry` options, so removing the outer handler does not leave it bare.
 
 Disabling the package's retry instead (`options.Retry.Enabled = false`) also resolves the
 composition, but leaves the generic outer handler in charge — including its unsafe `POST`

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -609,7 +609,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
                     // the request reached the server is as ambiguous as a 502/504, so the
                     // same replay rules apply (IsSafeToReplay holds a POST back).
                     var failure = new BusinessCentralConnectionException(
-                        RetryHelper.NetworkFailureMessage(ex), method.Method, url, ex);
+                        RetryHelper.NetworkFailureMessage(ex, "Business Central"), method.Method, url, ex);
 
                     _observer.OnRequestFailed(new BusinessCentralErrorInfo
                     {

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -26,9 +26,6 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     private const string BearerScheme = "Bearer";
     private const string IfMatchHeader = "If-Match";
 
-    /// <summary>Default page size used when auto-paging.</summary>
-    private const int DefaultPageSize = 1000;
-
     private static readonly JsonSerializerOptions _jsonOptions = BusinessCentralJson.Options;
 
     /// <summary>Creates a client for the company configured in <paramref name="options"/>.</summary>
@@ -232,89 +229,23 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
         var baseOptions = new QueryOptions();
         options?.Invoke(baseOptions);
 
-        // Top is a result cap, exactly as documented on WithTop; PageSize sizes the round
-        // trips. This mirrors BusinessCentralQuery<T>.StreamAsync — the two implementations
-        // must stay in agreement.
-        var limit = baseOptions.Top;
-
-        // $top=0 is a request for no rows at all.
-        if (limit == 0)
-            yield break;
-
-        var pageSize = baseOptions.PageSize ?? DefaultPageSize;
-
-        // Guards the loop below: with a non-positive page size the "short page" termination
-        // check can never fire, so it would request the same empty page forever. The public
-        // setters reject these values; this covers the internal ones.
-        if (pageSize <= 0)
-            yield break;
-
         var filterValue = filter?.Value ?? string.Empty;
 
-        // Honour a caller-supplied $skip as the starting offset instead of silently
-        // restarting from the first page.
-        var skip = baseOptions.Skip ?? 0;
-        var emitted = 0;
+        // Top is a result cap, exactly as documented on WithTop; PageSize sizes the round
+        // trips. The paging state machine itself lives in QueryPager, shared with the
+        // fluent builder. baseOptions.Skip is honoured as the starting offset instead of
+        // silently restarting from the first page.
+        var stream = QueryPager.StreamAsync(
+            baseOptions.Top,
+            baseOptions.PageSize ?? QueryPager.DefaultPageSize,
+            baseOptions.Skip ?? 0,
+            (top, skip, ct) => FetchPageAsync<TEntity>(
+                path, filterValue, PageOptions(baseOptions, top, skip), select, ct),
+            FetchNextPageAsync<TEntity>,
+            cancellationToken);
 
-        var requested = NextTop(pageSize, limit, emitted);
-
-        var page = await FetchPageAsync<TEntity>(
-                path, filterValue, PageOptions(baseOptions, requested, skip), select, cancellationToken)
-            .ConfigureAwait(false);
-
-        var serverDriven = false;
-
-        while (true)
-        {
-            var inPage = 0;
-
-            foreach (var entity in page.Value)
-            {
-                yield return entity;
-
-                emitted++;
-                inPage++;
-
-                if (limit is { } cap && emitted >= cap)
-                    yield break;
-            }
-
-            // Server-driven paging wins: when Business Central sends @odata.nextLink it
-            // decides the page size, so a short page is not the end of the collection.
-            if (!string.IsNullOrWhiteSpace(page.NextLink))
-            {
-                serverDriven = true;
-
-                page = await FetchNextPageAsync<TEntity>(page.NextLink, cancellationToken)
-                    .ConfigureAwait(false);
-
-                continue;
-            }
-
-            if (serverDriven)
-                yield break;
-
-            // No nextLink and a short page means the collection is exhausted.
-            if (inPage < requested)
-                yield break;
-
-            skip += inPage;
-            requested = NextTop(pageSize, limit, emitted);
-
-            page = await FetchPageAsync<TEntity>(
-                    path, filterValue, PageOptions(baseOptions, requested, skip), select, cancellationToken)
-                .ConfigureAwait(false);
-        }
-    }
-
-    /// <summary>Page size for the next request, never overshooting a caller-set <c>$top</c>.</summary>
-    private static int NextTop(int pageSize, int? limit, int emitted)
-    {
-        if (limit is not { } cap)
-            return pageSize;
-
-        var remaining = cap - emitted;
-        return remaining < pageSize ? remaining : pageSize;
+        await foreach (var entity in stream.ConfigureAwait(false))
+            yield return entity;
     }
 
     private static QueryOptions PageOptions(QueryOptions baseOptions, int top, int skip)
@@ -669,7 +600,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
                 {
                     res = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception ex) when (IsNetworkFailure(ex, cancellationToken))
+                catch (Exception ex) when (RetryHelper.IsNetworkFailure(ex, cancellationToken))
                 {
                     stopwatch.Stop();
 
@@ -678,7 +609,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
                     // the request reached the server is as ambiguous as a 502/504, so the
                     // same replay rules apply (IsSafeToReplay holds a POST back).
                     var failure = new BusinessCentralConnectionException(
-                        NetworkFailureMessage(ex), method.Method, url, ex);
+                        RetryHelper.NetworkFailureMessage(ex), method.Method, url, ex);
 
                     _observer.OnRequestFailed(new BusinessCentralErrorInfo
                     {
@@ -693,7 +624,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
                     {
                         transientAttempt++;
 
-                        var delay = ComputeDelay(retry, null, transientAttempt);
+                        var delay = RetryHelper.ComputeDelay(retry, null, transientAttempt);
 
                         _observer.OnRequestRetrying(new BusinessCentralRetryInfo
                         {
@@ -738,7 +669,9 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
                         Exception = new UnauthorizedAccessException("Unauthorized – retrying with refreshed token")
                     });
 
-                    await _tokenProvider.InvalidateAsync(cancellationToken).ConfigureAwait(false);
+                    // Pass the token this attempt actually used: a straggler must not clear
+                    // a token that was already refreshed by someone else.
+                    await _tokenProvider.InvalidateAsync(token, cancellationToken).ConfigureAwait(false);
 
                     request = Replace(res, request, createRequest);
                     continue;
@@ -765,7 +698,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
                         transientAttempt++;
 
                         var fromRetryAfter = retry.HonorRetryAfter && failure.RetryAfter != null;
-                        var delay = ComputeDelay(retry, failure.RetryAfter, transientAttempt);
+                        var delay = RetryHelper.ComputeDelay(retry, failure.RetryAfter, transientAttempt);
 
                         _observer.OnRequestRetrying(new BusinessCentralRetryInfo
                         {
@@ -842,20 +775,6 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     }
 
     /// <summary>
-    /// Whether the send failed without any response arriving: a connection-level error, or
-    /// the <see cref="HttpClient"/> timeout. A cancellation requested through the caller's
-    /// token is not a network failure and propagates as-is.
-    /// </summary>
-    private static bool IsNetworkFailure(Exception ex, CancellationToken cancellationToken) =>
-        ex is HttpRequestException ||
-        (ex is TaskCanceledException && !cancellationToken.IsCancellationRequested);
-
-    private static string NetworkFailureMessage(Exception ex) =>
-        ex is TaskCanceledException
-            ? "The request timed out before Business Central responded."
-            : $"The connection to Business Central failed: {ex.Message}";
-
-    /// <summary>
     /// Whether this failure may be retried by replaying the same request.
     /// </summary>
     /// <remarks>
@@ -894,42 +813,6 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             return false;
 
         return true;
-    }
-
-    /// <summary>
-    /// A server-supplied <c>Retry-After</c> wins over computed backoff; otherwise the delay
-    /// doubles per attempt. Both are capped by <see cref="BusinessCentralRetryOptions.MaxDelay"/>.
-    /// </summary>
-    private static TimeSpan ComputeDelay(
-        BusinessCentralRetryOptions retry,
-        TimeSpan? retryAfter,
-        int attempt)
-    {
-        var max = Floor(retry.MaxDelay);
-
-        if (retry.HonorRetryAfter && retryAfter is { } requested)
-            return Clamp(requested, max);
-
-        var milliseconds = Floor(retry.BaseDelay).TotalMilliseconds * Math.Pow(2, attempt - 1);
-
-        // A large BaseDelay or a high attempt count overflows to a value TimeSpan cannot
-        // represent — or to Infinity — and TimeSpan.FromMilliseconds throws on both. Compare
-        // in double space first so a transient failure never becomes a crash.
-        if (double.IsNaN(milliseconds) || milliseconds >= max.TotalMilliseconds)
-            return max;
-
-        return Clamp(TimeSpan.FromMilliseconds(milliseconds), max);
-    }
-
-    private static TimeSpan Floor(TimeSpan value) =>
-        value < TimeSpan.Zero ? TimeSpan.Zero : value;
-
-    private static TimeSpan Clamp(TimeSpan value, TimeSpan max)
-    {
-        if (value < TimeSpan.Zero)
-            return TimeSpan.Zero;
-
-        return value > max ? max : value;
     }
 
     private static async Task<string?> ReadBodySafeAsync(

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
@@ -129,7 +129,8 @@ internal sealed class BusinessCentralTokenProvider : IDisposable
                 catch (Exception ex) when (RetryHelper.IsNetworkFailure(ex, cancellationToken))
                 {
                     failure = new BusinessCentralConnectionException(
-                        RetryHelper.NetworkFailureMessage(ex), HttpMethod.Post.Method, endpoint, ex);
+                        RetryHelper.NetworkFailureMessage(ex, "the token endpoint"),
+                        HttpMethod.Post.Method, endpoint, ex);
                 }
 
                 // The client_credentials grant has no side effects, so replay is

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
@@ -70,42 +70,93 @@ internal sealed class BusinessCentralTokenProvider : IDisposable
                 ["grant_type"] = "client_credentials"
             };
 
-            var body = new FormUrlEncodedContent(form);
+            var retry = _options.Retry ?? new BusinessCentralRetryOptions();
+            var maxAttempts = retry.Enabled ? Math.Max(1, retry.MaxAttempts) : 1;
+            var transientAttempt = 0;
 
-            _observer.OnTokenRequested();
-
-            // Both are fully consumed here — nothing escapes this method — so they can be
-            // scoped. Disposing the request also releases the FormUrlEncodedContent, which
-            // carries the client secret.
-            using var req = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = body };
-            req.AddJsonHeaders();
-
-            using var res = await _http.SendAsync(req, cancellationToken).ConfigureAwait(false);
-            res.RequestMessage ??= req;
-
-            if (!res.IsSuccessStatusCode)
-                throw await BusinessCentralExceptionFactory.CreateAsync(res, cancellationToken).ConfigureAwait(false);
-
-            var json = await res.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-
-            var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(json, _jsonOptions)
-                                ?? throw new JsonException("Token response was null.");
-
-            var expiresAt = DateTime.UtcNow + CacheLifetime(tokenResponse.ExpiresIn);
-
-            _token = new CachedAccessToken
+            // Retrying inside the lock is deliberate: every concurrent caller needs this
+            // token, so they would all fail with the same transient error anyway. Backoff
+            // here is backoff for all of them.
+            while (true)
             {
-                Token = tokenResponse.AccessToken,
-                ExpiresAt = expiresAt
-            };
+                _observer.OnTokenRequested();
 
-            _observer.OnTokenRefreshed(new BusinessCentralTokenInfo
-            {
-                ExpiresAt = expiresAt,
-                FromCache = false
-            });
+                BusinessCentralException failure;
 
-            return _token.Token;
+                try
+                {
+                    // Both are fully consumed here — nothing escapes this method — so they
+                    // can be scoped. Disposing the request also releases the
+                    // FormUrlEncodedContent, which carries the client secret. The content
+                    // must be rebuilt per attempt: a sent HttpRequestMessage cannot be
+                    // replayed.
+                    using var req = new HttpRequestMessage(HttpMethod.Post, endpoint)
+                    {
+                        Content = new FormUrlEncodedContent(form)
+                    };
+                    req.AddJsonHeaders();
+
+                    using var res = await _http.SendAsync(req, cancellationToken).ConfigureAwait(false);
+                    res.RequestMessage ??= req;
+
+                    if (res.IsSuccessStatusCode)
+                    {
+                        var json = await res.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                        var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(json, _jsonOptions)
+                                            ?? throw new JsonException("Token response was null.");
+
+                        var expiresAt = DateTime.UtcNow + CacheLifetime(tokenResponse.ExpiresIn);
+
+                        _token = new CachedAccessToken
+                        {
+                            Token = tokenResponse.AccessToken,
+                            ExpiresAt = expiresAt
+                        };
+
+                        _observer.OnTokenRefreshed(new BusinessCentralTokenInfo
+                        {
+                            ExpiresAt = expiresAt,
+                            FromCache = false
+                        });
+
+                        return _token.Token;
+                    }
+
+                    failure = await BusinessCentralExceptionFactory
+                        .CreateAsync(res, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (RetryHelper.IsNetworkFailure(ex, cancellationToken))
+                {
+                    failure = new BusinessCentralConnectionException(
+                        RetryHelper.NetworkFailureMessage(ex), HttpMethod.Post.Method, endpoint, ex);
+                }
+
+                // The client_credentials grant has no side effects, so replay is
+                // unconditionally safe — none of the POST-ambiguity reasoning from the data
+                // pipeline applies. Bad credentials (400/401) are not transient and throw
+                // immediately.
+                if (!failure.IsTransient || transientAttempt + 1 >= maxAttempts)
+                    throw failure;
+
+                transientAttempt++;
+
+                var fromRetryAfter = retry.HonorRetryAfter && failure.RetryAfter != null;
+                var delay = RetryHelper.ComputeDelay(retry, failure.RetryAfter, transientAttempt);
+
+                _observer.OnRequestRetrying(new BusinessCentralRetryInfo
+                {
+                    Method = HttpMethod.Post.Method,
+                    Url = endpoint,
+                    StatusCode = (int)failure.StatusCode,
+                    Attempt = transientAttempt,
+                    Delay = delay,
+                    FromRetryAfter = fromRetryAfter
+                });
+
+                if (delay > TimeSpan.Zero)
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
         }
         finally
         {
@@ -113,11 +164,26 @@ internal sealed class BusinessCentralTokenProvider : IDisposable
         }
     }
 
-    public async Task InvalidateAsync(CancellationToken cancellationToken)
+    /// <summary>
+    /// Clears the cached token, but only if it is still the one the caller found rejected.
+    /// A caller racing behind a refresh — its <c>401</c> was for a token that has since been
+    /// replaced — must not throw away the fresh token, or concurrent <c>401</c>s cascade
+    /// into a refresh per caller.
+    /// </summary>
+    /// <param name="staleToken">The token the rejected request actually sent.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task InvalidateAsync(string staleToken, CancellationToken cancellationToken)
     {
         await _tokenLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try { _token = null; }
-        finally { _tokenLock.Release(); }
+        try
+        {
+            if (_token is { } current && current.Token == staleToken)
+                _token = null;
+        }
+        finally
+        {
+            _tokenLock.Release();
+        }
     }
 
     /// <summary>

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralUrlBuilder.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralUrlBuilder.cs
@@ -75,8 +75,8 @@ internal sealed class BusinessCentralUrlBuilder
 
         var query = new List<string>();
 
-        // Filter
-        if (!string.IsNullOrWhiteSpace(filter) && filter != "true")
+        // Filter — ODataFilter.MatchAll ("match every row") is emitted as no $filter at all.
+        if (!string.IsNullOrWhiteSpace(filter) && filter != ODataFilter.MatchAll)
         {
             query.Add("$filter=" + Uri.EscapeDataString(filter));
         }
@@ -112,11 +112,12 @@ internal sealed class BusinessCentralUrlBuilder
             query.Add("$orderby=" + Uri.EscapeDataString(options.OrderBy));
         }
 
-        // Expand — joined verbatim so nested syntax such as
-        // "salesOrderLines($select=lineNo)" survives.
+        // Expand — selectively encoded so nested syntax such as
+        // "salesOrderLines($select=lineNo)" survives while unsafe characters
+        // ('&', '#', '+', space, …) are still escaped.
         if (options.Expand.Count > 0)
         {
-            query.Add("$expand=" + string.Join(",", options.Expand).Replace(" ", "%20"));
+            query.Add("$expand=" + string.Join(",", options.Expand.Select(EncodeExpand)));
         }
 
         // Count
@@ -163,39 +164,59 @@ internal sealed class BusinessCentralUrlBuilder
     /// so alternate keys such as <c>No='1000'</c> survive intact, while spaces and other
     /// unsafe characters are still percent-encoded.
     /// </summary>
-    private static string EncodeKey(string key)
-    {
-        if (string.IsNullOrEmpty(key))
-            return key;
+    private static string EncodeKey(string key) => EncodeSelectively(key, IsKeySafe);
 
-        var result = new StringBuilder(key.Length);
+    /// <summary>
+    /// Encodes an <c>$expand</c> clause. Expand syntax needs its structural characters —
+    /// parentheses, '$', '=', ',', ';', '/', quotes and '*' — preserved, so wholesale
+    /// escaping is impossible; everything else ('&amp;', '#', '+', space, …) is
+    /// percent-encoded so a value inside a nested <c>$filter</c> cannot break the URL.
+    /// </summary>
+    private static string EncodeExpand(string expand) => EncodeSelectively(expand, IsExpandSafe);
+
+    /// <summary>
+    /// Percent-encodes every character <paramref name="isSafe"/> rejects, leaving the rest
+    /// literal. Unsafe characters are escaped a whole run at a time so surrogate pairs are
+    /// never split across two <see cref="Uri.EscapeDataString(string)"/> calls.
+    /// </summary>
+    private static string EncodeSelectively(string value, Func<char, bool> isSafe)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+
+        var result = new StringBuilder(value.Length);
         var i = 0;
 
-        while (i < key.Length)
+        while (i < value.Length)
         {
-            if (IsKeySafe(key[i]))
+            if (isSafe(value[i]))
             {
-                result.Append(key[i]);
+                result.Append(value[i]);
                 i++;
                 continue;
             }
 
-            // Escape a whole run at once so surrogate pairs are never split
-            // across two EscapeDataString calls.
             var start = i;
-            while (i < key.Length && !IsKeySafe(key[i]))
+            while (i < value.Length && !isSafe(value[i]))
                 i++;
 
-            result.Append(Uri.EscapeDataString(key[start..i]));
+            result.Append(Uri.EscapeDataString(value[start..i]));
         }
 
         return result.ToString();
     }
 
     private static bool IsKeySafe(char c) =>
+        IsUnreserved(c) ||
+        c is '\'' or '=' or ',' or '(' or ')';
+
+    private static bool IsExpandSafe(char c) =>
+        IsUnreserved(c) ||
+        c is '\'' or '=' or ',' or '(' or ')' or '$' or ';' or '/' or '*';
+
+    private static bool IsUnreserved(char c) =>
         c is >= 'A' and <= 'Z' ||
         c is >= 'a' and <= 'z' ||
         c is >= '0' and <= '9' ||
-        c is '-' or '.' or '_' or '~' ||
-        c is '\'' or '=' or ',' or '(' or ')';
+        c is '-' or '.' or '_' or '~';
 }

--- a/src/Dynamics365.BusinessCentral/Client/RetryHelper.cs
+++ b/src/Dynamics365.BusinessCentral/Client/RetryHelper.cs
@@ -54,10 +54,19 @@ internal static class RetryHelper
     /// </remarks>
     private static TimeSpan AddJitter(TimeSpan delay, double factor, TimeSpan max)
     {
-        if (factor <= 0 || delay <= TimeSpan.Zero)
+        // JitterFactor is public input that may arrive via configuration binding — a NaN
+        // never compares true, so it must be rejected explicitly or it slips past <= 0.
+        if (double.IsNaN(factor) || factor <= 0 || delay <= TimeSpan.Zero)
             return delay;
 
         var extra = delay.TotalMilliseconds * factor * Random.Shared.NextDouble();
+
+        // A huge or infinite factor overflows `extra` to Infinity — or to NaN when the
+        // random draw is exactly 0 — and TimeSpan.FromMilliseconds throws on both. The
+        // jittered delay can never exceed MaxDelay anyway, so compare in double space
+        // first, same as the backoff overflow guard in ComputeDelay.
+        if (double.IsNaN(extra) || delay.TotalMilliseconds + extra >= max.TotalMilliseconds)
+            return max;
 
         return Clamp(delay + TimeSpan.FromMilliseconds(extra), max);
     }

--- a/src/Dynamics365.BusinessCentral/Client/RetryHelper.cs
+++ b/src/Dynamics365.BusinessCentral/Client/RetryHelper.cs
@@ -1,0 +1,89 @@
+using Dynamics365.BusinessCentral.Options;
+
+namespace Dynamics365.BusinessCentral.Client;
+
+/// <summary>
+/// Retry mechanics shared by the data pipeline (<see cref="BusinessCentralClient"/>) and
+/// token acquisition (<see cref="BusinessCentralTokenProvider"/>): delay computation with
+/// jitter, and classification of network-level failures.
+/// </summary>
+internal static class RetryHelper
+{
+    /// <summary>
+    /// A server-supplied <c>Retry-After</c> wins over computed backoff; otherwise the delay
+    /// doubles per attempt. Both are jittered by <see cref="BusinessCentralRetryOptions.JitterFactor"/>
+    /// and capped by <see cref="BusinessCentralRetryOptions.MaxDelay"/>.
+    /// </summary>
+    public static TimeSpan ComputeDelay(
+        BusinessCentralRetryOptions retry,
+        TimeSpan? retryAfter,
+        int attempt)
+    {
+        var max = Floor(retry.MaxDelay);
+
+        TimeSpan baseline;
+
+        if (retry.HonorRetryAfter && retryAfter is { } requested)
+        {
+            baseline = Clamp(requested, max);
+        }
+        else
+        {
+            var milliseconds = Floor(retry.BaseDelay).TotalMilliseconds * Math.Pow(2, attempt - 1);
+
+            // A large BaseDelay or a high attempt count overflows to a value TimeSpan cannot
+            // represent — or to Infinity — and TimeSpan.FromMilliseconds throws on both. Compare
+            // in double space first so a transient failure never becomes a crash.
+            baseline = double.IsNaN(milliseconds) || milliseconds >= max.TotalMilliseconds
+                ? max
+                : Clamp(TimeSpan.FromMilliseconds(milliseconds), max);
+        }
+
+        return AddJitter(baseline, retry.JitterFactor, max);
+    }
+
+    /// <summary>
+    /// Spreads the delay by a random amount in <c>[0, delay × factor]</c> so concurrent
+    /// failures do not retry in lockstep and re-throttle each other.
+    /// </summary>
+    /// <remarks>
+    /// The jitter is <b>additive only</b>. A <c>Retry-After</c> is a minimum wait — retrying
+    /// earlier than the server asked guarantees another <c>429</c> — so spreading can only
+    /// ever extend the delay. Still capped by <c>MaxDelay</c>, which means a baseline already
+    /// at the cap cannot be spread; that is the cost of keeping <c>MaxDelay</c> a hard bound.
+    /// </remarks>
+    private static TimeSpan AddJitter(TimeSpan delay, double factor, TimeSpan max)
+    {
+        if (factor <= 0 || delay <= TimeSpan.Zero)
+            return delay;
+
+        var extra = delay.TotalMilliseconds * factor * Random.Shared.NextDouble();
+
+        return Clamp(delay + TimeSpan.FromMilliseconds(extra), max);
+    }
+
+    /// <summary>
+    /// Whether the send failed without any response arriving: a connection-level error, or
+    /// the <see cref="HttpClient"/> timeout. A cancellation requested through the caller's
+    /// token is not a network failure and propagates as-is.
+    /// </summary>
+    public static bool IsNetworkFailure(Exception ex, CancellationToken cancellationToken) =>
+        ex is HttpRequestException ||
+        (ex is TaskCanceledException && !cancellationToken.IsCancellationRequested);
+
+    public static string NetworkFailureMessage(Exception ex) =>
+        ex is TaskCanceledException
+            ? "The request timed out before Business Central responded."
+            : $"The connection to Business Central failed: {ex.Message}";
+
+    private static TimeSpan Floor(TimeSpan value) =>
+        value < TimeSpan.Zero ? TimeSpan.Zero : value;
+
+    private static TimeSpan Clamp(TimeSpan value, TimeSpan max)
+    {
+        if (value < TimeSpan.Zero)
+            return TimeSpan.Zero;
+
+        return value > max ? max : value;
+    }
+}

--- a/src/Dynamics365.BusinessCentral/Client/RetryHelper.cs
+++ b/src/Dynamics365.BusinessCentral/Client/RetryHelper.cs
@@ -80,10 +80,16 @@ internal static class RetryHelper
         ex is HttpRequestException ||
         (ex is TaskCanceledException && !cancellationToken.IsCancellationRequested);
 
-    public static string NetworkFailureMessage(Exception ex) =>
+    /// <summary>
+    /// Single-line failure description. <paramref name="target"/> names what was being
+    /// called — "Business Central" for data requests, "the token endpoint" for token
+    /// acquisition — so a connectivity problem at login.microsoftonline.com is not
+    /// misattributed to Business Central itself.
+    /// </summary>
+    public static string NetworkFailureMessage(Exception ex, string target) =>
         ex is TaskCanceledException
-            ? "The request timed out before Business Central responded."
-            : $"The connection to Business Central failed: {ex.Message}";
+            ? $"The request timed out before {target} responded."
+            : $"The connection to {target} failed: {ex.Message}";
 
     private static TimeSpan Floor(TimeSpan value) =>
         value < TimeSpan.Zero ? TimeSpan.Zero : value;

--- a/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
+++ b/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
@@ -13,8 +13,6 @@ namespace Dynamics365.BusinessCentral.OData;
 /// </remarks>
 internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEntity>
 {
-    private const int DefaultPageSize = 1000;
-
     private readonly IBusinessCentralQueryExecutor _executor;
     private readonly string _path;
 
@@ -158,67 +156,18 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
     public async IAsyncEnumerable<TEntity> StreamAsync(
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var limit = _top;
+        // The paging state machine lives in QueryPager, shared with the path-based
+        // QueryStreamAsync; only the fetch delegates differ.
+        var stream = QueryPager.StreamAsync(
+            _top,
+            _pageSize ?? QueryPager.DefaultPageSize,
+            _skip ?? 0,
+            FetchAsync,
+            _executor.FetchNextPageAsync<TEntity>,
+            cancellationToken);
 
-        // Top(0) is a request for no rows. Returning here also keeps the loop below from
-        // requesting $top=0 forever without ever advancing.
-        if (limit == 0)
-            yield break;
-
-        var pageSize = _pageSize ?? DefaultPageSize;
-
-        if (pageSize <= 0)
-            yield break;
-
-        var skip = _skip ?? 0;
-        var emitted = 0;
-
-        var requested = NextTop(pageSize, limit, emitted);
-        var page = await FetchAsync(requested, skip, cancellationToken).ConfigureAwait(false);
-
-        // True once the server started driving paging via @odata.nextLink, at which point
-        // it — not our $top — decides where the collection ends.
-        var serverDriven = false;
-
-        while (true)
-        {
-            var inPage = 0;
-
-            foreach (var entity in page.Value)
-            {
-                yield return entity;
-
-                emitted++;
-                inPage++;
-
-                if (limit is { } cap && emitted >= cap)
-                    yield break;
-            }
-
-            if (!string.IsNullOrWhiteSpace(page.NextLink))
-            {
-                serverDriven = true;
-
-                page = await _executor
-                    .FetchNextPageAsync<TEntity>(page.NextLink, cancellationToken)
-                    .ConfigureAwait(false);
-
-                continue;
-            }
-
-            // The server was paging and stopped offering a nextLink: nothing left.
-            if (serverDriven)
-                yield break;
-
-            // No nextLink and a short page means the collection is exhausted.
-            if (inPage < requested)
-                yield break;
-
-            skip += inPage;
-            requested = NextTop(pageSize, limit, emitted);
-
-            page = await FetchAsync(requested, skip, cancellationToken).ConfigureAwait(false);
-        }
+        await foreach (var entity in stream.ConfigureAwait(false))
+            yield return entity;
     }
 
     private Task<ODataResponse<TEntity>> FetchAsync(int top, int skip, CancellationToken cancellationToken)
@@ -228,16 +177,6 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
         options.Skip = skip;
 
         return _executor.FetchPageAsync<TEntity>(_path, FilterValue, options, SelectOrNull, cancellationToken);
-    }
-
-    /// <summary>Page size for the next request, never overshooting a caller-set <c>$top</c>.</summary>
-    private static int NextTop(int pageSize, int? limit, int emitted)
-    {
-        if (limit is not { } cap)
-            return pageSize;
-
-        var remaining = cap - emitted;
-        return remaining < pageSize ? remaining : pageSize;
     }
 
     public async Task<TEntity?> FirstOrDefaultAsync(CancellationToken cancellationToken = default)

--- a/src/Dynamics365.BusinessCentral/OData/Filter.cs
+++ b/src/Dynamics365.BusinessCentral/OData/Filter.cs
@@ -134,7 +134,7 @@ public static class Filter
         IsNotNull(PropertyPath.Resolve(field));
 
     /// <summary>A filter that matches every row. Emitted as no <c>$filter</c> at all.</summary>
-    public static ODataFilter All => new("true");
+    public static ODataFilter All => new(ODataFilter.MatchAll);
 
     /// <summary>A filter that matches nothing.</summary>
     public static ODataFilter None => new("false");

--- a/src/Dynamics365.BusinessCentral/OData/ODataFilter.cs
+++ b/src/Dynamics365.BusinessCentral/OData/ODataFilter.cs
@@ -7,6 +7,14 @@
 public sealed class ODataFilter
 {
     /// <summary>
+    /// The rendered form of <see cref="Filter.All"/>: a filter matching every row, which the
+    /// URL builder emits as no <c>$filter</c> at all. The single definition of that contract —
+    /// both <see cref="Filter"/> and the URL builder reference this constant. The same value
+    /// passed as a raw filter string keeps the same meaning, which is pinned by tests.
+    /// </summary>
+    internal const string MatchAll = "true";
+
+    /// <summary>
     /// The raw OData filter expression string.
     /// </summary>
     public string Value { get; }

--- a/src/Dynamics365.BusinessCentral/OData/QueryPager.cs
+++ b/src/Dynamics365.BusinessCentral/OData/QueryPager.cs
@@ -1,0 +1,103 @@
+using System.Runtime.CompilerServices;
+
+namespace Dynamics365.BusinessCentral.OData;
+
+/// <summary>
+/// The auto-paging state machine, used by both public entry points —
+/// <c>BusinessCentralClient.QueryStreamAsync</c> (path-based) and
+/// <c>BusinessCentralQuery&lt;T&gt;.StreamAsync</c> (fluent). One implementation so the two
+/// cannot drift apart; only the page-fetching delegates differ per caller.
+/// </summary>
+/// <remarks>
+/// Three-tier termination:
+/// <list type="number">
+/// <item>Follow <c>@odata.nextLink</c> whenever present — the server decides page size.</item>
+/// <item>Once server-driven, a missing nextLink means the collection is exhausted; the
+/// short-page rule no longer applies.</item>
+/// <item>Otherwise stop on the first page shorter than requested.</item>
+/// </list>
+/// <c>limit</c> caps emitted rows (<c>$top</c> semantics), enforced mid-page and never
+/// overshot by a request; <c>pageSize</c> sizes the round trips.
+/// </remarks>
+internal static class QueryPager
+{
+    /// <summary>Default rows-per-round-trip when the caller did not set a page size.</summary>
+    public const int DefaultPageSize = 1000;
+
+    public static async IAsyncEnumerable<TEntity> StreamAsync<TEntity>(
+        int? limit,
+        int pageSize,
+        int initialSkip,
+        Func<int, int, CancellationToken, Task<ODataResponse<TEntity>>> fetchPage,
+        Func<string, CancellationToken, Task<ODataResponse<TEntity>>> fetchNextPage,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // $top=0 is a request for no rows at all.
+        if (limit == 0)
+            yield break;
+
+        // Guards the loop below: with a non-positive page size the "short page" termination
+        // check can never fire, so it would request the same empty page forever. The public
+        // setters reject these values; this covers the internal ones.
+        if (pageSize <= 0)
+            yield break;
+
+        var skip = initialSkip;
+        var emitted = 0;
+
+        var requested = NextTop(pageSize, limit, emitted);
+        var page = await fetchPage(requested, skip, cancellationToken).ConfigureAwait(false);
+
+        // True once the server started driving paging via @odata.nextLink, at which point
+        // it — not our $top — decides where the collection ends.
+        var serverDriven = false;
+
+        while (true)
+        {
+            var inPage = 0;
+
+            foreach (var entity in page.Value)
+            {
+                yield return entity;
+
+                emitted++;
+                inPage++;
+
+                if (limit is { } cap && emitted >= cap)
+                    yield break;
+            }
+
+            if (!string.IsNullOrWhiteSpace(page.NextLink))
+            {
+                serverDriven = true;
+
+                page = await fetchNextPage(page.NextLink!, cancellationToken).ConfigureAwait(false);
+
+                continue;
+            }
+
+            // The server was paging and stopped offering a nextLink: nothing left.
+            if (serverDriven)
+                yield break;
+
+            // No nextLink and a short page means the collection is exhausted.
+            if (inPage < requested)
+                yield break;
+
+            skip += inPage;
+            requested = NextTop(pageSize, limit, emitted);
+
+            page = await fetchPage(requested, skip, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Page size for the next request, never overshooting a caller-set <c>$top</c>.</summary>
+    private static int NextTop(int pageSize, int? limit, int emitted)
+    {
+        if (limit is not { } cap)
+            return pageSize;
+
+        var remaining = cap - emitted;
+        return remaining < pageSize ? remaining : pageSize;
+    }
+}

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralRetryOptions.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralRetryOptions.cs
@@ -34,6 +34,19 @@ public sealed class BusinessCentralRetryOptions
     public bool HonorRetryAfter { get; set; } = true;
 
     /// <summary>
+    /// How much random spread is added to every retry delay, as a fraction of the delay:
+    /// the actual wait is <c>delay + random(0, delay × JitterFactor)</c>, still capped by
+    /// <see cref="MaxDelay"/>. Defaults to <c>0.2</c>; set <c>0</c> for deterministic delays.
+    /// </summary>
+    /// <remarks>
+    /// Without jitter, every caller that is throttled at the same moment retries at the same
+    /// moment — Business Central hands all of them the same <c>Retry-After</c> — and they
+    /// re-throttle each other in lockstep. The spread is <b>added</b>, never subtracted: a
+    /// <c>Retry-After</c> is a minimum wait, and retrying early guarantees another <c>429</c>.
+    /// </remarks>
+    public double JitterFactor { get; set; } = 0.2;
+
+    /// <summary>
     /// Whether a <c>POST</c> may be replayed after a transient failure <i>other than</i>
     /// <c>429</c>. Defaults to <see langword="false"/>.
     /// </summary>

--- a/src/Dynamics365.BusinessCentral/README.md
+++ b/src/Dynamics365.BusinessCentral/README.md
@@ -256,6 +256,9 @@ var lines = await client.QueryAsync<ProdOrderLine>(
 
 Business Central throttles aggressively. Throttled (`429`) and transient (`408`, `502`,
 `503`, `504`) responses are retried automatically, honouring `Retry-After` when present.
+Delays are jittered (`Retry.JitterFactor`, default `0.2`) so concurrent callers do not
+retry in lockstep — the spread is only ever added, never subtracted from a `Retry-After`.
+Token acquisition follows the same retry options; bad credentials are not retried.
 
 ```csharp
 services.AddBusinessCentral(options =>
@@ -306,6 +309,9 @@ by name:
 services.AddHttpClient(BusinessCentralHttpClients.Client).RemoveAllResilienceHandlers();
 services.AddHttpClient(BusinessCentralHttpClients.Token).RemoveAllResilienceHandlers();
 ```
+
+Exempting the token client is safe: token acquisition has its own retry under the same
+`Retry` options, so removing the outer handler does not leave it bare.
 
 Disabling the package's retry instead (`options.Retry.Enabled = false`) also resolves the
 composition, but leaves the generic outer handler in charge — including its unsafe `POST`

--- a/test/Dynamics365.BusinessCentral.Tests/QueryBuilderTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/QueryBuilderTests.cs
@@ -185,6 +185,19 @@ public class QueryBuilderTests
         Assert.Contains("$expand=lines($select=lineNo)", Decode(urls[0]));
     }
 
+    // Expand encoding is selective: structural characters survive, everything unsafe is
+    // escaped. Previously only spaces were handled, so an '&' inside a nested filter
+    // truncated the query string.
+    [Fact]
+    public async Task Expand_Escapes_Unsafe_Characters_Inside_Nested_Filters()
+    {
+        var (client, urls) = Capturing();
+
+        await client.Query<SalesOrder>().Expand("lines($filter=code eq 'A&B')").ToListAsync();
+
+        Assert.Contains("$expand=lines($filter=code%20eq%20'A%26B')", urls[0]);
+    }
+
     [Fact]
     public async Task ToPageAsync_Returns_Items_And_Total()
     {

--- a/test/Dynamics365.BusinessCentral.Tests/RetryDelayTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/RetryDelayTests.cs
@@ -1,0 +1,97 @@
+using Dynamics365.BusinessCentral.Client;
+using Dynamics365.BusinessCentral.Options;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+/// <summary>
+/// Pins the jitter contract on <see cref="RetryHelper.ComputeDelay"/>: additive-only spread
+/// on both the computed-backoff and the <c>Retry-After</c> branch, never negative, never
+/// past <c>MaxDelay</c>, and fully deterministic at <c>JitterFactor = 0</c>.
+/// </summary>
+public class RetryDelayTests
+{
+    [Fact]
+    public void RetryAfter_Is_Jittered_But_Never_Shortened()
+    {
+        var retry = new BusinessCentralRetryOptions
+        {
+            MaxDelay = TimeSpan.FromSeconds(30),
+            JitterFactor = 0.5
+        };
+
+        var retryAfter = TimeSpan.FromSeconds(2);
+
+        var delays = Enumerable.Range(0, 50)
+            .Select(_ => RetryHelper.ComputeDelay(retry, retryAfter, attempt: 1))
+            .ToList();
+
+        // A Retry-After is a minimum wait — jitter must only ever extend it.
+        Assert.All(delays, d => Assert.InRange(d, retryAfter, TimeSpan.FromSeconds(3)));
+
+        // Concurrent callers handed the same Retry-After must not resume in lockstep.
+        Assert.True(delays.Distinct().Count() > 1,
+            "50 jittered delays collapsed to a single value");
+    }
+
+    [Fact]
+    public void Computed_Backoff_Is_Jittered_Within_The_Same_Bounds()
+    {
+        var retry = new BusinessCentralRetryOptions
+        {
+            BaseDelay = TimeSpan.FromSeconds(1),
+            MaxDelay = TimeSpan.FromSeconds(30),
+            JitterFactor = 0.2
+        };
+
+        var delays = Enumerable.Range(0, 50)
+            .Select(_ => RetryHelper.ComputeDelay(retry, retryAfter: null, attempt: 2))
+            .ToList();
+
+        // Attempt 2 doubles BaseDelay: baseline 2s, spread up to 2.4s.
+        Assert.All(delays, d => Assert.InRange(d, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2.4)));
+        Assert.True(delays.Distinct().Count() > 1);
+    }
+
+    [Fact]
+    public void Jitter_Never_Exceeds_MaxDelay()
+    {
+        var retry = new BusinessCentralRetryOptions
+        {
+            MaxDelay = TimeSpan.FromSeconds(5),
+            JitterFactor = 1.0
+        };
+
+        for (var i = 0; i < 50; i++)
+        {
+            var delay = RetryHelper.ComputeDelay(retry, TimeSpan.FromSeconds(5), attempt: 1);
+            Assert.True(delay <= retry.MaxDelay);
+        }
+    }
+
+    [Fact]
+    public void Zero_JitterFactor_Is_Deterministic()
+    {
+        var retry = new BusinessCentralRetryOptions
+        {
+            BaseDelay = TimeSpan.FromSeconds(1),
+            MaxDelay = TimeSpan.FromSeconds(30),
+            JitterFactor = 0
+        };
+
+        Assert.Equal(TimeSpan.FromSeconds(4), RetryHelper.ComputeDelay(retry, null, attempt: 3));
+        Assert.Equal(TimeSpan.FromSeconds(7), RetryHelper.ComputeDelay(retry, TimeSpan.FromSeconds(7), attempt: 1));
+    }
+
+    [Fact]
+    public void Negative_JitterFactor_Is_Treated_As_Disabled()
+    {
+        var retry = new BusinessCentralRetryOptions
+        {
+            BaseDelay = TimeSpan.FromSeconds(1),
+            MaxDelay = TimeSpan.FromSeconds(30),
+            JitterFactor = -1
+        };
+
+        Assert.Equal(TimeSpan.FromSeconds(1), RetryHelper.ComputeDelay(retry, null, attempt: 1));
+    }
+}

--- a/test/Dynamics365.BusinessCentral.Tests/RetryDelayTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/RetryDelayTests.cs
@@ -94,4 +94,39 @@ public class RetryDelayTests
 
         Assert.Equal(TimeSpan.FromSeconds(1), RetryHelper.ComputeDelay(retry, null, attempt: 1));
     }
+
+    // JitterFactor is public input reachable via configuration binding: a non-finite or
+    // absurd value must degrade to a capped delay, never to a TimeSpan overflow crash
+    // that turns a transient failure into an unrelated exception.
+    [Theory]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.MaxValue)]
+    public void NonFinite_Or_Huge_JitterFactor_Caps_At_MaxDelay_Instead_Of_Throwing(double factor)
+    {
+        var retry = new BusinessCentralRetryOptions
+        {
+            BaseDelay = TimeSpan.FromSeconds(1),
+            MaxDelay = TimeSpan.FromSeconds(30),
+            JitterFactor = factor
+        };
+
+        for (var i = 0; i < 50; i++)
+        {
+            var delay = RetryHelper.ComputeDelay(retry, null, attempt: 1);
+            Assert.InRange(delay, TimeSpan.FromSeconds(1), retry.MaxDelay);
+        }
+    }
+
+    [Fact]
+    public void NaN_JitterFactor_Is_Treated_As_Disabled()
+    {
+        var retry = new BusinessCentralRetryOptions
+        {
+            BaseDelay = TimeSpan.FromSeconds(1),
+            MaxDelay = TimeSpan.FromSeconds(30),
+            JitterFactor = double.NaN
+        };
+
+        Assert.Equal(TimeSpan.FromSeconds(1), RetryHelper.ComputeDelay(retry, null, attempt: 1));
+    }
 }

--- a/test/Dynamics365.BusinessCentral.Tests/RetryTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/RetryTests.cs
@@ -174,7 +174,10 @@ public class RetryTests
             {
                 MaxAttempts = 4,
                 BaseDelay = TimeSpan.FromMilliseconds(1),
-                MaxDelay = TimeSpan.FromSeconds(10)
+                MaxDelay = TimeSpan.FromSeconds(10),
+
+                // This test asserts exact delays; jitter would smear them.
+                JitterFactor = 0
             });
 
         await Assert.ThrowsAsync<BusinessCentralThrottledException>(() =>
@@ -333,6 +336,138 @@ public class RetryTests
 
         Assert.Equal(3, patches);
     }
+
+    #region Token acquisition
+
+    // The client_credentials grant has no side effects, so token requests are retried on
+    // transient failures under the same budget as data requests — a blip at
+    // login.microsoftonline.com must not fail every in-flight request at once.
+    [Fact]
+    public async Task Token_Request_Is_Retried_On_Transient_Failure()
+    {
+        var tokenCalls = 0;
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+            {
+                tokenCalls++;
+
+                return tokenCalls == 1
+                    ? new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                    {
+                        Content = new StringContent("AADSTS transient")
+                    }
+                    : new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                    };
+            }
+
+            return TestBase.Json("{\"value\":[]}");
+        });
+
+        var result = await client.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.Empty(result);
+        Assert.Equal(2, tokenCalls);
+    }
+
+    [Fact]
+    public async Task Token_Request_Is_Retried_On_Network_Failure()
+    {
+        var tokenCalls = 0;
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+            {
+                tokenCalls++;
+
+                if (tokenCalls == 1)
+                    throw new HttpRequestException("connection reset");
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                };
+            }
+
+            return TestBase.Json("{\"value\":[]}");
+        });
+
+        await client.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.Equal(2, tokenCalls);
+    }
+
+    // Bad credentials are not transient: retrying a 400/401 from the token endpoint would
+    // just hammer the identity provider with the same wrong secret.
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest, typeof(BusinessCentralValidationException))]
+    [InlineData(HttpStatusCode.Unauthorized, typeof(BusinessCentralAuthException))]
+    public async Task Token_Request_Is_Not_Retried_On_Credential_Failures(
+        HttpStatusCode status, Type expectedException)
+    {
+        var tokenCalls = 0;
+
+        var client = TestBase.CreateClient(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+            {
+                tokenCalls++;
+                return new HttpResponseMessage(status)
+                {
+                    Content = new StringContent("{\"error\":\"invalid_client\"}")
+                };
+            }
+
+            return TestBase.Json("{\"value\":[]}");
+        });
+
+        var ex = await Assert.ThrowsAnyAsync<BusinessCentralException>(() =>
+            client.QueryAsync<TestEntity>("orders", "true"));
+
+        Assert.IsType(expectedException, ex);
+        Assert.Equal(1, tokenCalls);
+    }
+
+    [Fact]
+    public async Task Token_Retries_Are_Reported_To_The_Observer()
+    {
+        var observer = new RecordingObserver();
+        var tokenCalls = 0;
+
+        var client = TestBase.CreateClient(
+            req =>
+            {
+                if (req.RequestUri!.AbsoluteUri.Contains("auth"))
+                {
+                    tokenCalls++;
+
+                    return tokenCalls == 1
+                        ? new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                        {
+                            Content = new StringContent("down")
+                        }
+                        : new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
+                        };
+                }
+
+                return TestBase.Json("{\"value\":[]}");
+            },
+            observer);
+
+        await client.QueryAsync<TestEntity>("orders", "true");
+
+        var retry = Assert.Single(observer.Retries);
+        Assert.Equal(503, retry.StatusCode);
+        Assert.Contains("auth", retry.Url);
+    }
+
+    #endregion
 
     #region Network failures
 

--- a/test/Dynamics365.BusinessCentral.Tests/TokenProviderTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/TokenProviderTests.cs
@@ -1,0 +1,85 @@
+using Dynamics365.BusinessCentral.Client;
+using Dynamics365.BusinessCentral.Options;
+using Dynamics365.BusinessCentral.Tests.Utils;
+using System.Net;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+public class TokenProviderTests
+{
+    private static BusinessCentralTokenProvider CreateProvider(
+        Func<HttpRequestMessage, HttpResponseMessage> handler)
+    {
+        var options = new BusinessCentralOptions
+        {
+            BaseUrl = "https://test",
+            Company = "Test",
+            TenantId = "tenant",
+            ClientId = "client",
+            ClientSecret = "secret",
+            Scope = "scope",
+            TokenEndpoint = "https://auth/{TenantId}",
+            Retry = new BusinessCentralRetryOptions
+            {
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero
+            }
+        };
+
+        return new BusinessCentralTokenProvider(
+            new HttpClient(new FakeHttpHandler(handler)),
+            Microsoft.Extensions.Options.Options.Create(options));
+    }
+
+    private static HttpResponseMessage Token(string value) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent($"{{\"access_token\":\"{value}\",\"expires_in\":3600}}")
+        };
+
+    // A straggler whose 401 was for an already-replaced token must not clear the fresh
+    // one — otherwise N concurrent 401s cascade into N refreshes.
+    [Fact]
+    public async Task Invalidate_With_A_Stale_Token_Keeps_The_Fresh_One()
+    {
+        var tokenRequests = 0;
+
+        var provider = CreateProvider(_ =>
+        {
+            tokenRequests++;
+            return Token($"token-{tokenRequests}");
+        });
+
+        var first = await provider.GetTokenAsync(CancellationToken.None);
+        Assert.Equal("token-1", first);
+
+        // The rejected request used some older token, not the cached one.
+        await provider.InvalidateAsync("some-older-token", CancellationToken.None);
+
+        var second = await provider.GetTokenAsync(CancellationToken.None);
+
+        Assert.Equal("token-1", second);
+        Assert.Equal(1, tokenRequests);
+    }
+
+    [Fact]
+    public async Task Invalidate_With_The_Cached_Token_Clears_It()
+    {
+        var tokenRequests = 0;
+
+        var provider = CreateProvider(_ =>
+        {
+            tokenRequests++;
+            return Token($"token-{tokenRequests}");
+        });
+
+        var first = await provider.GetTokenAsync(CancellationToken.None);
+
+        await provider.InvalidateAsync(first, CancellationToken.None);
+
+        var second = await provider.GetTokenAsync(CancellationToken.None);
+
+        Assert.Equal("token-2", second);
+        Assert.Equal(2, tokenRequests);
+    }
+}


### PR DESCRIPTION
Implements round two of the the consumer feedback (`the pre-stable review (round two)`, included) — the internals findings, minus N4 (URL-length guard), which is deferred to 2.1 alongside chunked `In` because the threshold default needs live-tenant measurement.

## N1 — token acquisition retries transient failures
The token POST previously had no transient handling, and the README's resilience-exemption recipe removed the only outer safety net. Now honours the same `Retry` options as data requests, reports `OnRequestRetrying`, wraps network failures as `BusinessCentralConnectionException`, and throws immediately on credential failures (`400`/`401`). Retry runs inside the token lock deliberately — every waiter needs the same token. README updated: exempting the token client is now explicitly safe.

## N2 — jittered backoff (`Retry.JitterFactor`, default `0.2`)
Additive-only spread `random(0, delay × factor)` capped by `MaxDelay`, applied to **both** the computed backoff and the honoured `Retry-After` — additive because a `Retry-After` is a minimum wait, and retrying earlier guarantees another `429`. `0` disables for deterministic tests. Delay computation now lives in a shared `RetryHelper`.

## N3 — compare-and-swap token invalidation
The 401 path passes the token the rejected request actually sent; the cache is only cleared when it is still the cached one. A straggler racing behind a refresh becomes a no-op instead of cascading refreshes.

## N5 — one paging state machine
`QueryPager` (internal) now owns the auto-paging loop; both `QueryStreamAsync` and the fluent `StreamAsync` delegate to it with their own fetch delegates. The duplicated `NextTop` helpers and the "must stay in agreement" comments are deleted. Existing paging tests pass unchanged on both entry points.

## N6 — encoding nits
`$expand` uses selective run-encoding (structural syntax preserved; `&`/`#`/`+`/space escaped — pinned by a nested-filter-with-`&` test). The "no filter" sentinel is single-sourced as `ODataFilter.MatchAll`; the raw string `"true"` keeps its documented meaning.

## Tests / docs
225 tests (13 new: token retry ×4, jitter ×5, CAS ×2, expand ×1, plus determinism guards). CHANGELOG, both READMEs, and CLAUDE.md updated.