### PR TITLE
Release 2.0.0-alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0-alpha.3] - 2026-07-30
+
+**Prerelease.** The final validation build before 2.0.0 stable: robustness fixes from a
+second production-consumer review of the client internals, plus the companion testing
+package. Still to be confirmed against a live tenant before stable: the *Unverified* list
+under [2.0.0-alpha], plus a smoke test of a date filter.
+
 ### Added
 
 - **`Dynamics365.BusinessCentral.Testing`**, a companion NuGet package. `FakeBusinessCentral`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ dotnet test Dynamics365.BusinessCentral.slnx -f net10.0
 dotnet test -f net10.0 --filter "FullyQualifiedName~ClientTests.QueryAll_Pages_Until_Short_Page"
 dotnet test -f net10.0 --filter "FullyQualifiedName~ObserverTests"
 
-dotnet pack -c Release          # produces .nupkg + .snupkg
+dotnet pack -c Release          # packs BOTH packages (main + Testing), .nupkg + .snupkg each
 ```
 
 CI: `.github/workflows/sonar.yml` builds + tests on net8.0 and runs SonarCloud on every push/PR to `master`. `.github/workflows/nuget.yml` packs and pushes to NuGet on published GitHub releases — bump `<Version>` in the csproj before tagging.
@@ -118,7 +118,7 @@ The typed client uses the explicit-factory overload of `AddHttpClient`, not `Act
 
 ## Tests
 
-`test/Dynamics365.BusinessCentral.Tests/` — 121 xUnit facts, no mocking library. The csproj has `InternalsVisibleTo`, so internal types are directly testable. Suites: `ClientTests` (path-based API), `QueryBuilderTests` (fluent/typed), `RetryTests`, `OptionsTests`, `ObserverTests`, `ServiceCollectionExtensionsTests`.
+`test/Dynamics365.BusinessCentral.Tests/` — ~240 xUnit facts, no mocking library. The csproj has `InternalsVisibleTo`, so internal types are directly testable. Suites: `ClientTests` (path-based API, `partial`, split by `#region`), `QueryBuilderTests` (fluent/typed), `RetryTests` (incl. token acquisition and network failures), `RetryDelayTests` (jitter contract), `TokenProviderTests` (CAS invalidation), `FilterFormatTests` (OData literals), `DefaultInterfaceTests` (the fakes-keep-compiling contract), `ExceptionPredicateTests`, `BusinessCentralFieldTests`, `FakeBusinessCentralTests` (the Testing package's contract), plus `OptionsTests`, `ObserverTests`, `PagingGuardTests`, `RequestReplayTests`, `WriteOverloadTests`, `ServiceCollectionExtensionsTests`.
 
 Pattern: `TestBase.CreateClient(handler, observer?, configure?)` builds a real `BusinessCentralClient` over `FakeHttpHandler`, a `HttpMessageHandler` driven by a `Func<HttpRequestMessage, HttpResponseMessage>`. **Every handler must answer the token request first** — wrap it in `TestBase.WithToken(...)`, which does that for you, rather than repeating the `Contains("auth")` branch. `TestBase.Json(body)` is the 200-response shorthand. Test entity types live in `Utils/`; `SalesOrder` is the annotated one used for typed-query tests.
 
@@ -126,7 +126,9 @@ Pattern: `TestBase.CreateClient(handler, observer?, configure?)` builds a real `
 
 ## Docs
 
-`README.md` and `src/Dynamics365.BusinessCentral/README.md` are identical except for one line: the root file links `MIGRATION.md` relatively, the packed copy uses an absolute GitHub URL because relative links don't resolve on nuget.org. Update both together when public API changes.
+`README.md` and `src/Dynamics365.BusinessCentral/README.md` are identical except for one line: the root file links `MIGRATION.md` relatively, the packed copy uses an absolute GitHub URL because relative links don't resolve on nuget.org. Update both together when public API changes. A third README, `src/Dynamics365.BusinessCentral.Testing/README.md`, ships in the Testing package — update it when the fake's API changes.
+
+Releasing bumps `<Version>` in **both** csprojs — the packages are versioned in lockstep, and the Testing package's dependency on the main package comes from its `ProjectReference`, so a mismatched bump publishes a dangling dependency.
 
 Three release docs, each with a distinct job — don't merge them:
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,13 +11,19 @@ so read that section even if the build is green.
 ### `IBusinessCentralClient` gained members
 
 New members: `Company`, `ForCompany`, `Query<T>()` (two overloads), `QueryStreamAsync<T>`,
-`GetCompaniesAsync`, and two-generic `PostAsync`/`PatchAsync`/`PutAsync`.
+`GetCompaniesAsync`, `GetAsync<T>`, `FirstOrDefaultAsync<T>`, and two-generic
+`PostAsync`/`PatchAsync`/`PutAsync`.
 
 Mocking libraries (Moq, NSubstitute, FakeItEasy) absorb this automatically. Hand-written
 test fakes keep compiling too: **every interface member has a default implementation**, so
 a fake only implements the members it actually exercises. An unimplemented member throws
 `NotSupportedException` naming itself, and `FirstOrDefaultAsync` composes over `QueryAsync`
 so fakes get it for free.
+
+Before extending a hand-written fake, consider the companion package
+`Dynamics365.BusinessCentral.Testing`: its `FakeBusinessCentral` runs a **real** client
+over scripted responses, so tests can assert the exact OData a call produced — the thing
+a fake or mock can never verify. See the README's *Testing* section.
 
 ### Nothing else, in practice
 
@@ -74,7 +80,10 @@ catch (BusinessCentralException ex) { … }          // sees everything
 
 `429`, `408`, `502`, `503` and `504` are now retried (3 attempts by default), honouring
 `Retry-After`. Calls therefore take longer before surfacing a failure, and fewer transient
-errors reach your code.
+errors reach your code. Delays are jittered by default (`Retry.JitterFactor`, `0.2`) so
+concurrent callers do not retry in lockstep — set it to `0` if your tests assert exact
+timings. Token acquisition follows the same retry options; bad credentials (`400`/`401`
+from the token endpoint) are never retried.
 
 **Writes are not blindly replayed.** A `429` is rejected before processing so replay is
 always safe; the others are ambiguous, so a `POST` is *not* retried on them:

--- a/src/Dynamics365.BusinessCentral.Testing/Dynamics365.BusinessCentral.Testing.csproj
+++ b/src/Dynamics365.BusinessCentral.Testing/Dynamics365.BusinessCentral.Testing.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>Dynamics365.BusinessCentral.Testing</PackageId>
-        <Version>2.0.0-alpha.2</Version>
+        <Version>2.0.0-alpha.3</Version>
         <Authors>Daniel Rückenbach</Authors>
         <Company>KRAL GmbH</Company>
 

--- a/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
+++ b/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>Dynamics365.BusinessCentral</PackageId>
-        <Version>2.0.0-alpha.2</Version>
+        <Version>2.0.0-alpha.3</Version>
         <Authors>Daniel Rückenbach</Authors>
         <Company>KRAL GmbH</Company>
 
@@ -35,16 +35,15 @@
         <!-- Shown on the nuget.org package page. Kept short and pointed at CHANGELOG.md
              rather than duplicated, since nuget.org renders this as plain text. -->
         <PackageReleaseNotes>
-            PRERELEASE — 2.0.0-alpha.2 is the release candidate for 2.0.0 stable, published
-            for validation against real Business Central environments.
+            PRERELEASE — 2.0.0-alpha.3 is the final validation build before 2.0.0 stable.
 
-            On top of 2.0.0-alpha: date/time filter literals fixed (DateOnly, TimeOnly,
-            kindless DateTime), network failures retried and surfaced as
-            BusinessCentralConnectionException, WithTop honoured as a result cap when
-            auto-paging, single-entity GetAsync/FirstOrDefaultAsync, default interface
-            methods so test fakes keep compiling, public HttpClient names for resilience
-            composition, exception predicates (IsNotFound etc.), and typed field-name
-            resolution for the path-based API.
+            On top of 2.0.0-alpha.2: token acquisition now retries transient failures under
+            the same rules as data requests, retry delays are jittered (Retry.JitterFactor)
+            so concurrent callers stop retrying in lockstep, concurrent 401s no longer
+            cascade token refreshes, and $expand encoding handles unsafe characters.
+
+            New companion package: Dynamics365.BusinessCentral.Testing — script responses,
+            run a real client, and assert the exact OData your code produces.
 
             Breaking changes — see the migration guide before upgrading:
             https://github.com/KralGmbh/Dynamics365-BusinessCentral/blob/master/MIGRATION.md


### PR DESCRIPTION
Release prep for `2.0.0-alpha.3` — the final validation build before stable, carrying the round-two robustness fixes (#43: token retry, jitter, CAS invalidation, single paging engine, `$expand` encoding) and the new `Dynamics365.BusinessCentral.Testing` package (#44).

- `<Version>` → `2.0.0-alpha.3` in **both** csprojs (lockstep; the Testing package's dependency on the main package follows via `ProjectReference` — verified in the packed nuspec)
- CHANGELOG: `[Unreleased]` → `[2.0.0-alpha.3] - 2026-07-30`
- `<PackageReleaseNotes>` refreshed
- Doc currency pass: MIGRATION.md member list now includes `GetAsync`/`FirstOrDefaultAsync`, the retry section documents jitter + token-acquisition retry, and hand-written-fake authors get pointed at the Testing package; CLAUDE.md test inventory and packaging notes updated for the two-package layout

After merging: publish a GitHub release tagged `v2.0.0-alpha.3` (mark as pre-release) — `nuget.yml` packs the solution and pushes **both** packages.

Validation focus for the Bastion test drive: token retry + jitter under the parallel `Task.WhenAll` adapters, the `RemoveAllResilienceHandlers()` recipe, replacing Moq setups with `FakeBusinessCentral`, and the still-open live-tenant *Unverified* list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)