### PR TITLE
Switch NuGet publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -10,6 +10,7 @@ jobs:
 
     permissions:
       contents: write   # needed to upload artifacts to the release
+      id-token: write   # needed for NuGet Trusted Publishing (OIDC)
 
     steps:
       - uses: actions/checkout@v4
@@ -26,11 +27,22 @@ jobs:
 
       - run: dotnet pack -c Release --no-build
 
+      # Trusted Publishing: exchanges this workflow's OIDC token for a short-lived
+      # API key under the nuget.org policy (owner daru → this repo + workflow file).
+      # No long-lived secret to scope, rotate or leak — and new package IDs owned by
+      # the same account publish without key changes, which is exactly what broke
+      # the first two-package release under the old scoped NUGET_API_KEY.
+      - name: NuGet login (Trusted Publishing)
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: daru
+
       - name: Push to NuGet
         run: |
           dotnet nuget push **/*.nupkg \
             --source https://api.nuget.org/v3/index.json \
-            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} \
             --skip-duplicate
 
       - name: Upload nupkg to GitHub Release

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -13,11 +13,13 @@ jobs:
       id-token: write   # needed for NuGet Trusted Publishing (OIDC)
 
     steps:
-      - uses: actions/checkout@v4
+      # All actions pinned to full commit SHAs (SonarCloud S7637): a moved tag on a
+      # compromised action must not be able to inject code into the publish path.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: 10.0.x
 
@@ -34,7 +36,7 @@ jobs:
       # the first two-package release under the old scoped NUGET_API_KEY.
       - name: NuGet login (Trusted Publishing)
         id: nuget-login
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
         with:
           user: daru
 
@@ -46,6 +48,6 @@ jobs:
             --skip-duplicate
 
       - name: Upload nupkg to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: "**/*.nupkg"


### PR DESCRIPTION
The alpha.3 publish failed with a 403 on `Dynamics365.BusinessCentral.Testing`: the stored `NUGET_API_KEY` is scoped to the existing package ID and can't create new ones. Rather than re-scoping a long-lived key, this switches to nuget.org **Trusted Publishing**:

- `id-token: write` permission added; the new `NuGet/login@v1` step exchanges the workflow's OIDC token for a short-lived API key under the nuget.org policy (owner `daru` → `KralGmbh/Dynamics365-BusinessCentral` → `nuget.yml`).
- The push step uses that ephemeral key; `secrets.NUGET_API_KEY` is no longer referenced.
- New package IDs owned by the account publish without any key changes — exactly what broke this release.

**Prerequisites / follow-ups:**
1. The Trusted Publisher policy must exist on nuget.org before the next release (Package Owner `daru`, Repository Owner `KralGmbh`, Repository `Dynamics365-BusinessCentral`, Workflow `nuget.yml`, no environment).
2. After merging, the `v2.0.0-alpha.3` release must be **deleted and recreated** (not re-run): release-triggered workflows execute the workflow file at the tag's commit, and the existing tag predates this fix. `--skip-duplicate` makes the main package's re-push a no-op; the Testing package and the release assets then go through.
3. Once verified, delete the `NUGET_API_KEY` repo secret and revoke the old key on nuget.org.

Note: this changes CI behaviour that can only be verified by an actual release run — reviewed against the nuget.org Trusted Publishing docs, not executed locally.