### PR TITLE
Render Filter.In as a same-field or-chain — BC rejects the in operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Filter.In` works against real Business Central tenants.** It rendered the OData `in`
+  operator, which Business Central only accepts with `$schemaversion=2.1` — on a stock
+  endpoint the server answers `BadRequest_MethodNotImplemented` (verified live). It now
+  renders an equivalent same-field `or`-chain (`(f eq v1) or (f eq v2) …`), which is
+  supported on every schema version. Empty-collection semantics are unchanged (`false`);
+  a single value collapses to a plain `eq`.
+- **Documented a Business Central limitation on `.Or(...)`**: `or` between filters on
+  *different* fields has no AL equivalent and is rejected by the server. Same-field `or`
+  and `.And(...)` are unaffected.
+
 ## [2.0.0-alpha.3] - 2026-07-30
 
 **Prerelease.** The final validation build before 2.0.0 stable: robustness fixes from a

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Every method has a string overload and a typed overload.
 | `Filter.Contains` | `contains(field,value)` |
 | `Filter.StartsWith` | `startswith(field,value)` |
 | `Filter.EndsWith` | `endswith(field,value)` |
-| `Filter.In` | `field in (...)` |
+| `Filter.In` | `(field eq v1) or (field eq v2) ...` |
 | `Filter.IsNull` | `field eq null` |
 | `Filter.IsNotNull` | `field ne null` |
 
@@ -233,8 +233,15 @@ var filter = Filter.Equals<SalesOrder>(o => o.Status, "Open")
                    .And(Filter.GreaterThan<SalesOrder>(o => o.Amount, 100));
 ```
 
-`Filter.In` with an empty collection yields a filter matching nothing, rather than the
-invalid OData expression `field in ()`.
+`Filter.In` renders a **same-field `or`-chain**, not the OData `in` operator — Business
+Central rejects `in` without `$schemaversion=2.1` (`BadRequest_MethodNotImplemented`).
+With an empty collection it yields a filter matching nothing, so passing an empty key set
+is safe.
+
+> **Business Central limitation:** `or` only works between filters on the *same* field.
+> Combining filters on different fields with `.Or(...)` — `field1 eq 1 or field2 eq 2` —
+> has no AL filter equivalent and the server rejects it. `.And(...)` has no such
+> restriction.
 
 ## Field names without the builder
 

--- a/src/Dynamics365.BusinessCentral/OData/Filter.cs
+++ b/src/Dynamics365.BusinessCentral/OData/Filter.cs
@@ -90,19 +90,33 @@ public static class Filter
         EndsWith(PropertyPath.Resolve(field), value);
 
     /// <summary>
-    /// Creates a filter of the form: field in (value1,value2,...).
+    /// Creates a filter matching any of <paramref name="values"/>, rendered as a chain of
+    /// same-field equalities: <c>(field eq v1) or (field eq v2) or ...</c>.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// Deliberately <b>not</b> the OData <c>in</c> operator: Business Central only accepts
+    /// <c>field in (...)</c> with <c>$schemaversion=2.1</c> and answers
+    /// <c>BadRequest_MethodNotImplemented</c> without it — verified against a live tenant.
+    /// A same-field <c>or</c>-chain is explicitly supported on every schema version and is
+    /// semantically identical. The URL grows with the value count; chunk large key sets.
+    /// </para>
+    /// <para>
     /// An empty <paramref name="values"/> produces a filter that matches nothing
-    /// (<c>false</c>) rather than the invalid OData expression <c>field in ()</c>. This
-    /// makes <c>Filter.In(field, ids)</c> safe when <c>ids</c> turns out to be empty.
+    /// (<c>false</c>), so <c>Filter.In(field, ids)</c> is safe when <c>ids</c> turns out
+    /// to be empty.
+    /// </para>
     /// </remarks>
     public static ODataFilter In(string field, params object[] values)
     {
         if (values is null || values.Length == 0)
-            return new ODataFilter("false");
+            return None;
 
-        return new ODataFilter($"{field} in ({string.Join(",", values.Select(Format))})");
+        if (values.Length == 1)
+            return Equals(field, values[0]);
+
+        return new ODataFilter(
+            string.Join(" or ", values.Select(v => $"({field} eq {Format(v)})")));
     }
 
     /// <inheritdoc cref="In(string, object[])"/>

--- a/src/Dynamics365.BusinessCentral/OData/FilterExtensions.cs
+++ b/src/Dynamics365.BusinessCentral/OData/FilterExtensions.cs
@@ -10,6 +10,12 @@ public static class FilterExtensions
         new($"({left}) and ({right})");
 
     /// <summary>Combines two filters using logical OR.</summary>
+    /// <remarks>
+    /// Business Central only supports <c>or</c> between filters on the <b>same field</b> —
+    /// an OR across different fields (<c>field1 eq 1 or field2 eq 2</c>) has no AL filter
+    /// equivalent and the server rejects it with <c>BadRequest_MethodNotImplemented</c>.
+    /// This is a Business Central limitation, not something the client can translate away.
+    /// </remarks>
     public static ODataFilter Or(this ODataFilter left, ODataFilter right) =>
         new($"({left}) or ({right})");
 

--- a/src/Dynamics365.BusinessCentral/README.md
+++ b/src/Dynamics365.BusinessCentral/README.md
@@ -222,7 +222,7 @@ Every method has a string overload and a typed overload.
 | `Filter.Contains` | `contains(field,value)` |
 | `Filter.StartsWith` | `startswith(field,value)` |
 | `Filter.EndsWith` | `endswith(field,value)` |
-| `Filter.In` | `field in (...)` |
+| `Filter.In` | `(field eq v1) or (field eq v2) ...` |
 | `Filter.IsNull` | `field eq null` |
 | `Filter.IsNotNull` | `field ne null` |
 
@@ -233,8 +233,15 @@ var filter = Filter.Equals<SalesOrder>(o => o.Status, "Open")
                    .And(Filter.GreaterThan<SalesOrder>(o => o.Amount, 100));
 ```
 
-`Filter.In` with an empty collection yields a filter matching nothing, rather than the
-invalid OData expression `field in ()`.
+`Filter.In` renders a **same-field `or`-chain**, not the OData `in` operator — Business
+Central rejects `in` without `$schemaversion=2.1` (`BadRequest_MethodNotImplemented`).
+With an empty collection it yields a filter matching nothing, so passing an empty key set
+is safe.
+
+> **Business Central limitation:** `or` only works between filters on the *same* field.
+> Combining filters on different fields with `.Or(...)` — `field1 eq 1 or field2 eq 2` —
+> has no AL filter equivalent and the server rejects it. `.And(...)` has no such
+> restriction.
 
 ## Field names without the builder
 

--- a/test/Dynamics365.BusinessCentral.Tests/ClientTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ClientTests.cs
@@ -1519,7 +1519,11 @@ public partial class ClientTests
         // Assert
         var filterValue = ExtractFilter(capturedUrl);
 
-        Assert.Equal("status in ('active','pending','processing')", filterValue);
+        // A same-field or-chain, not the `in` operator — BC rejects `in` without
+        // $schemaversion=2.1.
+        Assert.Equal(
+            "(status eq 'active') or (status eq 'pending') or (status eq 'processing')",
+            filterValue);
     }
 
     [Fact]

--- a/test/Dynamics365.BusinessCentral.Tests/FilterFormatTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/FilterFormatTests.cs
@@ -32,12 +32,38 @@ public class FilterFormatTests
         Assert.Equal("(postingDate ge 2026-01-01) and (postingDate lt 2027-01-01)", filter.Value);
     }
 
+    // Filter.In renders a same-field or-chain, NOT the OData `in` operator: Business
+    // Central rejects `in` without $schemaversion=2.1 (BadRequest_MethodNotImplemented,
+    // verified against a live tenant), while same-field `or` works everywhere.
+    [Fact]
+    public void In_Renders_A_Same_Field_Or_Chain()
+    {
+        var filter = Filter.In("status", "active", "pending");
+
+        Assert.Equal("(status eq 'active') or (status eq 'pending')", filter.Value);
+    }
+
+    [Fact]
+    public void In_With_A_Single_Value_Collapses_To_Eq()
+    {
+        var filter = Filter.In("status", "active");
+
+        Assert.Equal("status eq 'active'", filter.Value);
+    }
+
+    [Fact]
+    public void In_With_No_Values_Matches_Nothing()
+    {
+        Assert.Equal("false", Filter.In("status").Value);
+        Assert.Equal("false", Filter.In("status", Enumerable.Empty<object>()).Value);
+    }
+
     [Fact]
     public void DateOnly_Works_In_In_Filters()
     {
         var filter = Filter.In("postingDate", new DateOnly(2026, 7, 1), new DateOnly(2026, 7, 2));
 
-        Assert.Equal("postingDate in (2026-07-01,2026-07-02)", filter.Value);
+        Assert.Equal("(postingDate eq 2026-07-01) or (postingDate eq 2026-07-02)", filter.Value);
     }
 
     // A kindless DateTime (parsed from config, loaded from a database) used to be run

--- a/test/Dynamics365.BusinessCentral.Tests/OptionsTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/OptionsTests.cs
@@ -207,6 +207,6 @@ public class OptionsTests
     {
         Assert.Equal("false", Dynamics365.BusinessCentral.OData.Filter.In("id").Value);
         Assert.Equal("false", Dynamics365.BusinessCentral.OData.Filter.In("id", Array.Empty<object>()).Value);
-        Assert.Equal("id in ('a','b')", Dynamics365.BusinessCentral.OData.Filter.In("id", "a", "b").Value);
+        Assert.Equal("(id eq 'a') or (id eq 'b')", Dynamics365.BusinessCentral.OData.Filter.In("id", "a", "b").Value);
     }
 }


### PR DESCRIPTION
First live-tenant finding from the alpha.3 validation: `Filter.In` generated the OData `in` operator, which Business Central only accepts with `$schemaversion=2.1` — a stock endpoint answers `BadRequest_MethodNotImplemented` (reproduced in Postman against a real tenant; confirmed by the footnote in [BC's filter docs](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/webservices/use-filter-expressions-in-odata-uris)).

## Fix

`Filter.In` now renders a **same-field `or`-chain** — `(status eq 'active') or (status eq 'pending')` — which the same docs explicitly support on every schema version and which is semantically identical:

- Empty collection still yields `false` (matches nothing) — unchanged.
- Single value collapses to a plain `eq`.
- XML docs explain why the native operator is deliberately not used; a `$schemaversion=2.1` opt-in that restores it can ride the chunked-`In` work in 2.1.

## Also documented (not fixable client-side)

The same docs page states BC rejects `or` across **different** fields (no AL filter equivalent). `FilterExtensions.Or` and the README now carry that warning — same-field `or` and `.And(...)` are unaffected.

## Tests / docs

Rendering pinned in `FilterFormatTests` (or-chain, single-value collapse, empty → `false`, DateOnly values) and the end-to-end URL assert in `ClientTests` updated. Both READMEs and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)