### PR TITLE
Server-driven paging: no invented page size, Prefer: odata.maxpagesize (round four, N3)

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -11,16 +11,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      # Pinned to full commit SHAs (SonarCloud S7637), same as nuget.yml.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Java for SonarCloud
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'microsoft'
           java-version: '21'
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: 10.0.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,9 +302,12 @@ Known gaps in this prerelease, to be confirmed before 2.0.0 stable
   live SaaS tenant all four properties bind — `Name`, `Display_Name`, `Id` and
   `Evaluation_Company` were all populated. The "best-effort and null" caveat below applies
   only if an endpoint omits them, which the live tenant did not.
-- ⚠️ **Deliberately left unverified**: whether Business Central honours
-  `Prefer: return=representation` on a given endpoint — confirming it requires a real
-  write to a production tenant. Both outcomes (echo and `204`) are handled either way.
+- ✅ **Verified 2026-07-30**: `Prefer: return=representation` on writes. Measured via a
+  no-op `PATCH` against a live tenant: the `ODataV4` page endpoint returned `200` with the
+  full entity **both with and without the header** — these endpoints always echo on
+  `PATCH`, so the header is redundant there (and harmless). The `204` path remains as a
+  safety net; `POST` echo behaviour was left untested by choice (it would require creating
+  a real record).
 - ⚠️ **Inconclusive 2026-07-30**: server-driven `@odata.nextLink` paging. A 118k-row query
   against an `ODataV4` published-page endpoint did not produce server-driven paging;
   those endpoints may not emit `nextLink` at all, unlike `/api/v2.0`. The nextLink

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Auto-paging is server-driven** (`QueryAllAsync`, `QueryStreamAsync`, fluent
+  `StreamAsync`/`ToAllAsync`), based on live-tenant measurement
+  ([NEXTLINK-FINDINGS-BASTION.md](NEXTLINK-FINDINGS-BASTION.md)): by default no page size
+  is sent, Business Central pages at its own configured Max Page Size (20,000 online) and
+  continuation follows `@odata.nextLink` — an opaque `$skiptoken` cursor immune to the
+  row-shift hazards of `$skip` offset paging, which is gone (a caller-set `WithSkip` still
+  applies, to the first request). A full 118k-row sweep drops from 119 round trips to 6.
+  The package no longer ships a page-size constant; `WithPageSize`/fluent `PageSize` now
+  request smaller server pages via `Prefer: odata.maxpagesize` (clamped by the server)
+  instead of issuing `$top` round trips. `WithTop` is unchanged: a pure result cap, sent
+  as `$top` and enforced client-side across continuations. Single-page reads never send
+  the page preference — it would silently truncate them.
+
+### Added
+
+- **`BusinessCentralOptions.MaxPageSize`** (nullable, default null): the registration-level
+  page preference for streaming reads, overridable per query with `WithPageSize`. Null
+  defers entirely to the server's configuration.
+
 ## [2.0.0-alpha.4] - 2026-07-30
 
 **Prerelease.** Incorporates the first live-tenant validation round

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   page preference for streaming reads, overridable per query with `WithPageSize`. Null
   defers entirely to the server's configuration.
 
+### Fixed
+
+- **A throwing observer can no longer break requests.** `IBusinessCentralObserver`
+  callbacks are isolated: diagnostics are best-effort, so a bug in an observer no longer
+  turns a successful request into a failure or masks the real server error.
+- **Caller-requested cancellation is no longer reported to the observer as a request
+  failure** — ordinary shutdowns stop putting noise in error metrics. Timeouts (which are
+  not caller-requested) are still reported.
+- **The manual-construction constructor documents its trade-off**: a privately created,
+  per-instance token cache and shared token/data HTTP traffic — construct once and reuse,
+  or prefer `AddBusinessCentral`.
+
 ## [2.0.0-alpha.4] - 2026-07-30
 
 **Prerelease.** Incorporates the first live-tenant validation round

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,13 +89,9 @@ Note the quirk in `BuildQueryUrl`: a filter string of `"true"` is treated as "no
 
 ### Paging
 
-The auto-paging state machine lives **once**, in `QueryPager` (internal, `OData/`); both public entry points — `BusinessCentralClient.QueryStreamAsync` (path-based) and `BusinessCentralQuery<T>.StreamAsync` (fluent) — delegate to it and differ only in their fetch delegates. Termination is three-tier:
+The auto-paging state machine lives **once**, in `QueryPager` (internal, `OData/`); both public entry points — `BusinessCentralClient.QueryStreamAsync` (path-based) and `BusinessCentralQuery<T>.StreamAsync` (fluent) — delegate to it and differ only in their fetch delegates. Paging is **server-driven** (measured against a live BC SaaS tenant — see `NEXTLINK-FINDINGS-BASTION.md`): the first request carries `$top` only when the caller set a result cap and `$skip` only when they set an offset; the resolved page preference (`QueryOptions.PageSize ?? BusinessCentralOptions.MaxPageSize ?? nothing`) is sent as `Prefer: odata.maxpagesize` on the first request **and every continuation** (the preference is per request, not per cursor); the server pages at its own Max Page Size otherwise. Termination: no `@odata.nextLink` means done — either the server served everything or the `$top` budget is satisfied. There is no `$skip` loop and no package page-size constant; don't reintroduce either. Single-page reads (`QueryAsync`, `ToListAsync`, `GetAsync`, …) pass a null preference on purpose — `odata.maxpagesize` on a one-shot request silently truncates it.
 
-1. Follow `@odata.nextLink` whenever present, and set `serverDriven`.
-2. Once `serverDriven`, a missing nextLink means the collection is exhausted — the `$top` short-page rule no longer applies.
-3. Otherwise stop on the first page shorter than the requested size.
-
-`QueryOptions.PageSize` is rows-per-round-trip; `Top` is a result cap. `QueryPager` sizes each request's `$top` from the remaining cap, so a request never overshoots it. The old `WithTop`-as-page-size behaviour is gone (2.0); `WithPageSize` is the only way to size round trips.
+`QueryOptions.PageSize` is the server-page preference; `Top` is a result cap (sent as `$top`, enforced client-side mid-page). The old `WithTop`-as-page-size behaviour is gone (2.0).
 
 ### Writes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,9 @@ Everything funnels through `BusinessCentralClient.SendWithAuthRetryAsync`, a sin
 
 `IsSafeToReplay` encodes a deliberate asymmetry: a `429` is rejected *before* processing so it is always replayable, but `408/502/503/504` are ambiguous — the write may already have landed. A `POST` is therefore not replayed on those unless `Retry.RetryPostOnTransientFailures` is set, because a duplicate row is worse than a surfaced error. `GET`/`PUT`/`DELETE` are idempotent and always retried. Don't "simplify" this back to a plain `IsTransient` check.
 
-Each attempt clones the request (`HttpRequestExtensions.Clone`, because a sent `HttpRequestMessage` can't be reused). A failure is reported to the observer exactly once — the throw site sets `failureReported` so the catch-all doesn't double-report.
+Each attempt builds a fresh request via the `createRequest` factory passed to `SendWithAuthRetryAsync` (a sent `HttpRequestMessage` can't be reused). A failure is reported to the observer exactly once — the throw site sets `failureReported` so the catch-all doesn't double-report — and a caller-requested cancellation is not reported at all. Observers are wrapped in `SafeBusinessCentralObserver` (`Diagnostics/`), which swallows callback exceptions: diagnostics must never break the pipeline, so never call a consumer observer directly.
+
+Responses are **deliberately buffered as strings** before deserialization: the raw body on `BusinessCentralException.ResponseBody` and in `OnDeserializationFailed` is the package's most valuable field diagnostic (a consumer debugged a prod deserialization failure from a single log line). Under server-driven paging the default page can be 20k rows, so this costs memory — `BusinessCentralOptions.MaxPageSize` is the documented knob. Don't switch to stream deserialization without solving the lost-body diagnostics.
 
 Tests must set `Retry.BaseDelay`/`MaxDelay` to zero or they sleep; `TestBase.CreateClient` already does.
 

--- a/FEATURE-REQUESTS-BASTION.md
+++ b/FEATURE-REQUESTS-BASTION.md
@@ -1,0 +1,144 @@
+# Feature requests — typed query ergonomics
+
+Two small additions to the typed query surface, from migrating a production consumer
+(Bastion) off hand-maintained wire-name constants and onto the 2.0 expression-based API.
+
+Unlike the other `*-BASTION.md` documents in this repo, this one reports no defect and no
+tenant observation. Both requests are ergonomic, both are additive, and neither changes
+existing behaviour.
+
+Line references are against `2.0.0-alpha.4`.
+
+---
+
+## Context: the problem 2.0 already solved
+
+Worth stating first, so these requests are not read as asking for something that exists.
+
+The consumer maintained, per entity, a `*Fields` static class of wire-name constants
+referenced from `[JsonPropertyName]` attributes and from every `$filter` and `$select` call
+site — 12 classes, 101 constants, 99 references. 2.0 already makes all of it deletable:
+
+- `BusinessCentralField.Of<T>(x => x.Prop)` resolves a selector to the wire name.
+- Every `Filter` operator has an `Expression<Func<TEntity, object?>>` overload.
+- `Query<T>()` resolves the entity path from `[BusinessCentralEntity]`, so path constants go too.
+- `Select`, `OrderBy` and `Expand` on the fluent builder are already expression-based.
+
+**No change is requested for any of that.** The two requests below are the gaps that remain
+visible once a consumer actually adopts it.
+
+---
+
+## F1 — Let the fluent builder infer the entity type in filters
+
+**Kind: ergonomics · Additive**
+
+`IBusinessCentralQuery<TEntity>` knows its entity type, but `Where` takes an already-built
+`ODataFilter`, and `Filter`'s typed overloads are static — so the type argument has to be
+restated at every operator, inside a query that has already stated it:
+
+```csharp
+await _client.Query<ProdOrderComponent>()
+    .Where(Filter.Equals<ProdOrderComponent>(x => x.ProductionOrderNumber, orderNo)
+      .And(Filter.Equals<ProdOrderComponent>(x => x.ProdOrderLineNumber, lineNo))
+      .And(Filter.StartsWith<ProdOrderComponent>(x => x.ItemNumber, "EB")))
+    .Select(x => x.ItemNumber)
+    .ToListAsync(ct);
+```
+
+Three restatements of `ProdOrderComponent` in one query. It also reads inconsistently against
+the neighbouring `Select(x => x.ItemNumber)`, which infers the same type from the same builder.
+
+### Proposal
+
+A `Where` overload taking a filter builder bound to `TEntity`:
+
+```csharp
+IBusinessCentralQuery<TEntity> Where(Func<IFilterBuilder<TEntity>, ODataFilter> build);
+```
+
+```csharp
+await _client.Query<ProdOrderComponent>()
+    .Where(f => f.Equals(x => x.ProductionOrderNumber, orderNo)
+                 .And(f.Equals(x => x.ProdOrderLineNumber, lineNo))
+                 .And(f.StartsWith(x => x.ItemNumber, "EB")))
+    .Select(x => x.ItemNumber)
+    .ToListAsync(ct);
+```
+
+`IFilterBuilder<TEntity>` mirrors `Filter`'s operator set with the type argument fixed, and
+returns the same `ODataFilter`, so `.And` / `.Or` composition and everything downstream are
+unchanged. It is a thin forwarding layer over the existing typed overloads — no new rendering
+logic, no new resolution rules, nothing to keep in sync beyond the operator list.
+
+The existing `Where(ODataFilter)` and `Where(string)` overloads stay; this is one more way in,
+not a replacement.
+
+### Acceptance criteria
+
+- [ ] `Where(Func<IFilterBuilder<TEntity>, ODataFilter>)` exists on the fluent builder.
+- [ ] `IFilterBuilder<TEntity>` covers every operator `Filter` exposes, including `In`,
+      `IsNull` and `IsNotNull`.
+- [ ] A test asserts a builder-composed filter renders identically to the equivalent
+      `Filter.X<TEntity>(...)` chain.
+- [ ] README shows the builder form as the default for `Query<T>()`.
+
+---
+
+## F2 — Default `$select` to the entity's declared properties
+
+**Kind: correctness + ergonomics · Behaviour change, see the note below**
+
+A query with no `Select(...)` emits no `$select`, so Business Central returns every column of
+the entity set. The consumer then deserializes into a type that declares six of them and
+discards the rest — including, on wide entity sets, columns it has no property for at all.
+
+Where the entity class *is* the projection — which is the normal case, since these classes are
+written per use — the class already states exactly what should be selected. Consumers restate
+it anyway:
+
+```csharp
+select: [ProductionOrderLineFields.ItemNumber, ProductionOrderLineFields.LineNumber]
+```
+
+21 such lists in this consumer, every one of them a subset of properties the class already
+declares, kept in sync by hand.
+
+### Proposal
+
+When no explicit projection is given, derive `$select` from `TEntity`'s declared, serializable
+properties, resolved through the same `PropertyPath` rules as everything else.
+
+Note the direction: this can only ever **narrow** what is requested. Today's default is "all
+columns"; the proposed default is "the columns the type can actually hold". No consumer can
+receive less data than their type declares, so nothing that currently deserializes can stop
+deserializing.
+
+An explicit `Select(...)` still wins, which keeps the wide-shared-entity case working — a
+consumer with one broad `Item` class and narrow per-call projections is unaffected, because
+those calls already pass a projection.
+
+**This is a behaviour change**, so it wants an escape hatch and a changelog line, not a silent
+flip. An opt-out (`.SelectAll()`, or an option on registration) covers the case where an entity
+type is deliberately partial and the caller wants the full row for logging or diagnostics.
+
+### Acceptance criteria
+
+- [ ] With no `Select(...)`, `$select` lists `TEntity`'s serializable properties.
+- [ ] An explicit `Select(...)` overrides it entirely.
+- [ ] An opt-out exists for requesting all columns.
+- [ ] A test asserts the derived `$select` matches the type's `[JsonPropertyName]` values,
+      including nested navigation properties.
+- [ ] Documented in the changelog as a behaviour change, with the narrowing-only argument stated.
+
+---
+
+## Appendix: provenance
+
+Both requests come from converting Bastion's Business Central access layer from 1.0-style
+string constants to the 2.0 typed API — 12 entity types, 99 call sites. F1 is the friction
+that shows up on every multi-operator filter once the typed overloads are adopted. F2 is the
+last piece of duplication that survives the conversion: the projection stated once in the
+class and again at each call site.
+
+Neither is blocking. Both were worth writing down while the conversion was fresh.

--- a/LIVE-TENANT-FINDINGS-BASTION.md
+++ b/LIVE-TENANT-FINDINGS-BASTION.md
@@ -10,6 +10,10 @@ real tenant, and one finding contradicts a proposal I made in round one.
 
 Self-contained: no access to the consumer codebase required.
 
+**Superseded in part.** [NEXTLINK-FINDINGS-BASTION.md](NEXTLINK-FINDINGS-BASTION.md) (round
+four) closes this round's open `@odata.nextLink` item and corrects the conclusion recorded for
+it under *Still open* below.
+
 ---
 
 ## Summary
@@ -42,7 +46,7 @@ Every row below was executed against the live tenant on `LDATItems` unless noted
 | `$orderby` + `$skip` | `OrderBy*`, `WithSkip` | ✅ works |
 | `$select` | `select:` / `.Select(...)` | ✅ works |
 | **`in`** | **`Filter.In`** | ❌ **`BadRequest_MethodNotImplemented`** |
-| Server-driven paging | `QueryAllAsync` nextLink following | ⚠️ inconclusive — see *Still open* |
+| Server-driven paging | `QueryAllAsync` nextLink following | ✅ supported — measured in [round four](NEXTLINK-FINDINGS-BASTION.md), gated on Max Page Size |
 
 `NotEquals`, `GreaterThan`, `LessThan`, `LessOrEqual` and `EndsWith` were not measured, but
 the operators that were all behave as standard OData v4, so `in` looks like the outlier
@@ -296,7 +300,7 @@ No change required. The Unverified entry can be struck.
 
 | Item | Status |
 | --- | --- |
-| Server-driven `@odata.nextLink` paging | **Inconclusive.** An unbounded query over 118,133 rows did not produce the expected paging behaviour; the consumer's read is that these published-page web-service endpoints (`LDAT*`) may not do server-driven paging at all, unlike the `/api/v2.0` endpoints. Needs a precise capture of the response before any conclusion. **This is the item that silently truncated in 1.x and it is still the least-understood behaviour in the package.** |
+| Server-driven `@odata.nextLink` paging | **Closed — superseded by [NEXTLINK-FINDINGS-BASTION.md](NEXTLINK-FINDINGS-BASTION.md) (round four).** The read recorded here — that the `LDAT*` published-page endpoints may not do server-driven paging at all — was **wrong**; they do. The behaviour is gated on Business Central's **Max Page Size** (20,000 on this tenant), and the package's own default `$top` of 1,000 sits below it, so no nextLink was ever offered. See round four for the measurements and the resulting proposal. |
 | `Prefer: return=representation` | Deliberately unverified — confirming it requires a real write to a production tenant. Better documented as unverified than tested by creating a live record. |
 
 **Recommendation:** given L1, treat every `Filter.*` operator as unverified until measured. The

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -119,6 +119,26 @@ It now follows `@odata.nextLink`. Where Business Central applied a server-side p
 below the requested `$top`, 1.0 stopped early and silently truncated. Reconciliation logic
 that assumed the old result size should be re-checked.
 
+### Auto-paging is server-driven
+
+1.0 (and the 2.0 alphas) paced streaming reads by sending `$top`/`$skip` per round trip.
+2.0 stable sends **no page size by default**: Business Central pages at its own configured
+Max Page Size (20,000 online; the `ODataServicesMaxPageSize` server setting on-premises)
+and drives continuation via `@odata.nextLink`, an opaque `$skiptoken` cursor — verified
+against a live SaaS tenant.
+
+What this changes in practice:
+
+- **Fewer, larger responses.** A full sweep of a 118k-row entity set drops from 119
+  round trips (at the old invented default of 1,000) to 6 — but each response is up to
+  20,000 rows. If per-response size matters (memory, timeouts), set
+  `BusinessCentralOptions.MaxPageSize` or a per-query `WithPageSize(n)`; the value is sent
+  as `Prefer: odata.maxpagesize` and clamped by the server.
+- **No more offset paging.** `$skip` no longer advances between pages, so concurrent
+  inserts/deletes can no longer shift rows between requests. A caller-set `WithSkip(n)` is
+  still honoured — as the starting offset of the first request.
+- **`WithTop` is unchanged**: a pure result cap, sent as `$top` and enforced client-side.
+
 ### `QueryAllAsync` with `WithTop` may return far fewer rows
 
 The opposite direction: `WithTop(n)` was 1.0's page size and did not limit results; it is
@@ -167,7 +187,9 @@ If you built workarounds for either, remove them.
 In 1.0's `QueryAllAsync`, `WithTop(n)` meant *page size*, not a result limit — it paged
 through the entire collection `n` rows at a time. In 2.0 `WithTop` is what it says: a
 result cap, everywhere. `QueryAllAsync(..., o => o.WithTop(10))` now returns at most 10
-rows. Use `WithPageSize(n)` for the old meaning:
+rows. Use `WithPageSize(n)` for the old intent — though the mechanism differs: it now
+requests server pages of at most `n` rows via `Prefer: odata.maxpagesize` rather than
+issuing `$top=n` round trips (see *Auto-paging is server-driven* in §2):
 
 ```csharp
 // 1.0: WithTop(500) fetched everything, 500 rows per round trip. 2.0 equivalent:

--- a/NEXTLINK-FINDINGS-BASTION.md
+++ b/NEXTLINK-FINDINGS-BASTION.md
@@ -1,0 +1,297 @@
+# nextLink and paging findings
+
+Fourth round of feedback on **Dynamics365.BusinessCentral**, narrowed to one subject:
+server-driven paging and `@odata.nextLink`.
+
+This closes the item [LIVE-TENANT-FINDINGS-BASTION.md](LIVE-TENANT-FINDINGS-BASTION.md) left
+under *Still open* — "an unbounded query over 118,133 rows did not produce the expected paging
+behaviour … the least-understood behaviour in the package". It is now understood, and the
+round-three read (that these published-page endpoints may not support server-driven paging at
+all) was **wrong**: they do.
+
+Measured against the same live production tenant on 2026-07-30, against `LDATItems`
+(118,133 rows), plus the Microsoft platform documentation that explains the measurements.
+
+Self-contained: no access to the consumer codebase required. Line references point at
+`Dynamics365.BusinessCentral` at `2.0.0-alpha.4`.
+
+---
+
+## Summary
+
+| ID | Finding | Severity | Affects |
+| --- | --- | --- | --- |
+| N1 | The page-size threshold is a **deployment setting**, not a protocol constant — 20,000 online, configurable on-premises | Medium | docs, any hardcoded page bound |
+| N2 | BC emits `@odata.nextLink` only when `$top` **exceeds** that threshold, so at default settings the package's nextLink branch is unreachable and every unbounded query pages by `$skip` | Medium | `QueryPager` tiers 1 and 3 |
+| N3 | The package never sends `Prefer: odata.maxpagesize` — the supported, tenant-independent way to request server-driven paging. Page size should be deferred to the server and overridable in setup, not a hardcoded default | **High** | all read paths |
+| N4 | If `PageSize` is set above the threshold, `QueryPager`'s "server-driven ⇒ exhausted" rule may terminate early and **silently truncate** | **High, unverified** | `QueryPager.cs:79-81` |
+
+N3 is the actionable one: adopting it makes N1, N2 and N4 stop mattering.
+
+---
+
+## What was measured
+
+A `$top` ladder against `LDATItems` (`$select=no`), same tenant, same token:
+
+| Request | Result |
+| --- | --- |
+| `$top=5000` | served in full, **no** nextLink |
+| `$top=10000` | served in full, **no** nextLink |
+| `$top=20000` | served in full, **no** nextLink |
+| `$top=25000` | first page, **plus** a nextLink |
+
+The nextLink returned for the last one:
+
+```
+https://api.businesscentral.dynamics.com/v2.0/{tenant}/Production/ODataV4
+  /Company('KRAL%20AG')/LDATItems?$select=no&$top=5000&aid=FIN&$skiptoken=87432712-5d44-f111-90ed-6045bd9b71d5
+```
+
+Three things to read off it:
+
+1. **`$top=5000` is the unserved remainder**, `25000 − 20000`, not the server's page size. The
+   threshold sits at 20,000 — consistent with every row of the ladder.
+2. The continuation is a **`$skiptoken`**, an opaque cursor, not a `$skip` offset.
+3. BC adds `aid=FIN` itself, and `$select` is preserved.
+
+The first page's rows were not counted directly; that it contained 20,000 is inferred from the
+remainder arithmetic. Anyone reproducing this should count them.
+
+---
+
+## N1 — The threshold is configuration, not a constant
+
+**Severity: Medium · Documented + measured**
+
+Business Central's paging bound is the **Max Page Size** server setting, called
+`ODataServicesMaxPageSize` in `CustomSettings.config`:
+
+> Business Central on-premises and online are set up to use a maximum of **20,000** entities per
+> page by default. With Business Central on-premises, page size is determined by a configuration
+> setting on the Business Central Server, which you can change. With Business Central online, the
+> page size is configured on the service and can't be changed.
+> — [Server-Driven Paging in OData Web Services](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/webservices/server-driven-paging-in-odata-web-services)
+
+So the 20,000 measured above is *this tenant's* value, and it is fixed only because this tenant
+is SaaS. An on-premises consumer whose administrator set Max Page Size to 5,000 — a reasonable
+choice, since the docs warn that a large value "can overload the memory on Business Central
+Server" — gets different behaviour from byte-identical client code.
+
+Page objects do not enter into this. The only page-level interaction the docs describe is
+`TopNumberOfRows` on *query* objects, which does not apply to published page web services.
+
+**Consequence:** the package must not encode 20,000, nor derive the threshold empirically. Any
+paging strategy whose correctness depends on knowing it is not portable across deployments.
+
+---
+
+## N2 — At default settings, the nextLink branch is unreachable
+
+**Severity: Medium**
+
+`QueryPager` has a three-tier termination scheme (`OData/QueryPager.cs:11-21`): follow
+`@odata.nextLink` when present; once server-driven, a missing nextLink means exhausted;
+otherwise stop on the first short page.
+
+Every read path sends an explicit `$top` — `pageSize`, defaulting to 1,000
+(`QueryPager.cs:25`). Per the ladder, any `$top` at or under the threshold is served whole
+with no nextLink. Therefore:
+
+- **Tier 1 never fires** at default settings. The branch at `QueryPager.cs:70` is only
+  reachable if a caller sets `PageSize` above the server's threshold.
+- **Tier 3 is what actually runs** for every unbounded query: full page ⇒ `skip += inPage` ⇒
+  request again.
+
+That is why round three saw no paging behaviour on a 118,133-row sweep. Nothing was broken;
+the observation was taken at a page size that cannot produce a nextLink.
+
+Two costs follow. A full `LDATItems` sweep at `pageSize` 1,000 is **119 round trips** against
+an API that throttles hard. And `$skip` paging over a set with no explicit `$orderby` is only
+as stable as BC's default row order — the classic offset-paging hazard, where a concurrent
+insert or delete shifts the window and rows are duplicated or skipped between requests. A
+`$skiptoken` cursor has neither problem.
+
+---
+
+## N3 — `Prefer: odata.maxpagesize` is never sent
+
+**Severity: High · This is the fix**
+
+Business Central supports a per-request override of server-driven paging:
+
+> To set paging on a request, use the `odata.maxpagesize` preference in the `Prefer` header of
+> the HTTP request: `Prefer: odata.maxpagesize=300`
+>
+> `odata.maxpagesize` can't be greater than the **ODataServicesMaxPageSize** server setting for
+> on-premises and 20000 for online.
+> — [Server-Driven Paging in OData Web Services](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/webservices/server-driven-paging-in-odata-web-services)
+
+The package sends `Prefer: return=representation` on writes
+(`Client/HttpRequestExtensions.cs:31`, applied at `Client/BusinessCentralClient.cs:345` and
+five sibling call sites) and **no `Prefer` header on any read**. Server-driven paging is
+therefore never requested — it is only stumbled into, when a caller's `$top` happens to
+overshoot a threshold the client cannot see.
+
+### Proposal
+
+Stop using `$top` to size round trips on the streaming paths — it stays what `WithTop`
+documents it to be, a result cap — and let page size be **negotiated with the server** instead
+of decided by the client.
+
+The key point is what the *default* should be. `QueryPager.DefaultPageSize = 1000` is a number
+the package invented; it corresponds to nothing about any deployment, and per N1 the package
+cannot know the right value anyway. **The correct default is to send no `$top` and no
+preference at all.** The server then applies its own Max Page Size — the value its
+administrator actually configured — and drives the paging by nextLink. The deployment's
+configuration becomes the default, and the package ships no page-size constant.
+
+Consumers who need something other than the server's value get it through setup, which is also
+the reason Microsoft documents the override — "useful when pages are slow and you're
+experiencing timeouts or out of memory exceptions". Three levels, most specific winning:
+
+1. `BusinessCentralOptions.MaxPageSize` (nullable, **default null**) — set at registration,
+   sent as `Prefer: odata.maxpagesize={value}` on every streaming read. Null means "defer to
+   the server".
+2. `QueryOptions.WithPageSize(n)` — per-query override of the above, for the one sweep that
+   needs different pacing. This already exists; it would now emit the preference rather than
+   `$top`.
+3. No fallback constant. Where `DefaultPageSize` is used today, nothing is sent.
+
+Note the direction of control: the preference can only ask the server for a page **no larger**
+than its own setting — it is clamped, not honoured blindly — so an over-large value cannot
+break a request, and a consumer cannot use this to raise a deployment's ceiling.
+
+Every consequence above then dissolves at once:
+
+- BC emits a nextLink on **every** page on **every** deployment, so tier 1 becomes the live
+  path and tier 3 becomes the fallback it reads like.
+- The package never needs to know the threshold, because it never states one (N1 stops mattering).
+- Continuation is by `$skiptoken`, so the offset-stability hazard in N2 disappears.
+- The N4 hypothesis below becomes moot: the chain is no longer bounded by a caller's `$top` budget.
+- Round trips drop to whatever the server's own page size allows — for a SaaS tenant at 20,000,
+  a full `LDATItems` sweep goes from 119 requests to 6.
+
+Two requests validate the design before any code is written, both on `?$select=no` with **no
+`$top`**: one with no `Prefer` header (expect the server's own page size and a nextLink), one
+with `Prefer: odata.maxpagesize=1000` (expect 1,000 rows and a nextLink).
+
+### Acceptance criteria
+
+- [ ] `BusinessCentralOptions.MaxPageSize` exists, is nullable, and defaults to null.
+- [ ] Streaming reads send `Prefer: odata.maxpagesize={value}` only when a page size was
+      configured — never a package-chosen default.
+- [ ] `QueryPager.DefaultPageSize` is gone; no page-size constant remains in the package.
+- [ ] `pageSize` no longer determines `$top` on streaming reads; `WithTop` remains a pure result cap.
+- [ ] A test asserts no `Prefer: odata.maxpagesize` header when nothing is configured.
+- [ ] A test asserts the header carries the option value, and that `WithPageSize` overrides it.
+- [ ] A test asserts a caller-set `WithTop` still caps emitted rows when the server pages independently.
+- [ ] README documents that page size defaults to the server's configuration, that the option
+      requests a smaller page, and that the server clamps it.
+
+---
+
+## N4 — Possible silent truncation above the threshold
+
+**Severity: High if confirmed · UNVERIFIED — do not act on this without the probe below**
+
+`QueryPager` treats server-driven mode as authoritative about the end of the collection:
+
+```csharp
+// The server was paging and stopped offering a nextLink: nothing left.
+if (serverDriven)
+    yield break;
+```
+`OData/QueryPager.cs:79-81`
+
+Against BC that assumption may be false. The evidence says the nextLink is a **remainder
+continuation of the caller's `$top`** — `25000 − 20000 = 5000` — not an open-ended cursor over
+the collection. If BC stops offering nextLinks once the requested `$top` is satisfied rather
+than when rows run out, then `PageSize = 25000` with no `Top` over `LDATItems` yields
+20,000 + 5,000 rows and returns **25,000 of 118,133 as a successful, complete result**.
+
+That is the same silent-truncation failure class as the 1.x behaviour this machinery was built
+to fix, re-entering through a different door — and only on the code path a consumer reaches by
+tuning for throughput.
+
+**Decisive probe:** follow the captured nextLink once.
+
+- Page 2 returns 5,000 rows and **no** further nextLink ⇒ confirmed. `PageSize` needs a
+  documented ceiling and validation, and tier 2's comment is wrong against BC.
+- Page 2 returns another nextLink ⇒ BC treats `$skiptoken` as an open cursor, `QueryPager` is
+  correct as written, and this finding can be struck.
+
+Adopting N3 removes the exposure either way, since page size would then be negotiated rather
+than smuggled through `$top`.
+
+### Acceptance criteria
+
+- [ ] Run the probe and record the outcome here.
+- [ ] If confirmed: `PageSize` validated against a documented maximum, or the streaming paths
+      switched to `Prefer` (N3) so the case cannot arise.
+
+---
+
+## What is already correct
+
+Worth stating, since the rest of this document is problems.
+
+`FetchNextPageAsync` (`Client/BusinessCentralClient.cs:300`) sends the nextLink verbatim as an
+absolute URL through the normal authenticated send path. That is the right thing to do with a
+continuation link, and it matters here: the real URL arrives pre-encoded
+(`Company('KRAL%20AG')`) and carries an opaque `$skiptoken` plus a server-added `aid=FIN`. Any
+attempt to parse, rebuild or re-encode it would corrupt the cursor. It survives intact and the
+bearer token is attached.
+
+The `Top`-as-cap arithmetic in `QueryPager.NextTop` is also correct across a server-paged
+stream: a caller-set `WithTop` is honoured mid-page and never overshot by a request.
+
+---
+
+## Still open
+
+| Item | Status |
+| --- | --- |
+| N4 truncation hypothesis | Needs the one-request probe above. |
+| Behaviour with **no** `$top` at all | Not yet measured cleanly. This is the shape N3 would produce and the one round three attempted. |
+| `Prefer: return=representation` | Still deliberately unverified — confirming it requires a real write to a production tenant. |
+
+---
+
+## Appendix: provenance
+
+**Method.** A production consumer (Bastion, event-sourced modular monolith, live since
+2026-05-03) running `2.0.0-alpha.3`, pointed at its live BC production environment. The `$top`
+ladder was executed in Postman against `LDATItems` with `$select=no`. N1 and N3 come from the
+Microsoft platform documentation, quoted above; N2 and N4 come from reading `QueryPager` and
+`BusinessCentralClient` against those measurements.
+
+**Confidence.** The ladder is direct observation, one entity set, one tenant. N1 and N3 are
+documented platform behaviour, not inference. N2 follows from the ladder plus the package's
+own default. **N4 is a hypothesis** — it is consistent with every measurement taken, and no
+measurement yet distinguishes it from the alternative.
+
+**Not claimed.** No defect is alleged in the nextLink-following code itself; it handles the
+real wire shape correctly. The findings are about which paging mechanism the package ends up
+using by default, and whether it can tell when a collection has actually ended.
+
+---
+
+## Validation addendum (package side, 2026-07-30)
+
+The two design-validation requests proposed under N3 were executed against the same tenant
+before implementation:
+
+| Probe | Request | Result |
+| --- | --- | --- |
+| Server default | `LDATItems?$select=no`, no `$top`, no `Prefer` | ~20,000 rows **plus** a nextLink — and the continuation carries **no `$top`**: an open-ended `$skiptoken` cursor. |
+| Preference | same, with `Prefer: odata.maxpagesize=1000` | exactly 1,000 rows plus a nextLink. |
+
+N3 is therefore implemented as proposed: no default page size, `Prefer: odata.maxpagesize`
+when configured (registration-level `BusinessCentralOptions.MaxPageSize`, per-query
+`WithPageSize`), `$top` only for caller-set result caps, continuation by nextLink only —
+the `$skip` loop is gone.
+
+**N4 remains unprobed** (following the `$top=25000` remainder link once). Under the
+implemented design it is unreachable — no code path smuggles a page size through `$top`
+anymore — but the probe is still worth one request to settle the record.

--- a/README.md
+++ b/README.md
@@ -121,12 +121,26 @@ var orders = await client.Query<SalesOrder>()
 `StreamAsync` fetches pages as you consume them and stops fetching when you stop reading —
 prefer it over `ToAllAsync` for large sets.
 
+Paging is **server-driven** (verified against a live BC SaaS tenant): by default no page
+size is sent at all, Business Central pages at its own configured Max Page Size (20,000
+online), and continuation follows `@odata.nextLink` — an opaque cursor immune to the
+row-shift hazards of offset paging. To bound per-response size — memory, slow pages,
+timeouts — request smaller pages; the value is sent as `Prefer: odata.maxpagesize` and
+the server clamps it to its own maximum, so it can only ever ask for *less*:
+
 ```csharp
+// per registration — the default for every streaming read
+services.AddBusinessCentral(o => { /* ... */ o.MaxPageSize = 1000; });
+
+// per query — overrides the registration value
 await foreach (var order in client.Query<SalesOrder>().PageSize(500).StreamAsync())
 {
     if (Process(order) is Done) break;   // no further pages are requested
 }
 ```
+
+`Top(n)` remains a pure result cap: it is sent as `$top` so the server never over-serves a
+capped query, and enforced mid-page while continuations are followed.
 
 ## Counting and paging
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ await client.DeleteAsync("salesOrders", systemId);
 ```
 
 Writes send `Prefer: return=representation`. If the server answers `204 No Content`, the
-payload you sent is returned instead of throwing. Keys may be a `systemId` or an alternate
+payload you sent is returned instead of throwing. (Measured live: `ODataV4` page endpoints
+echo the entity on `PATCH` regardless of the header, so the `204` path is a safety net
+rather than the common case.) Keys may be a `systemId` or an alternate
 key such as `No='1000'`.
 
 When the response type differs from the payload — posting an anonymous object and reading

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -175,7 +175,9 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
         var queryOptions = new QueryOptions();
         options?.Invoke(queryOptions);
 
-        var page = await FetchPageAsync<TEntity>(path, filter, queryOptions, select, cancellationToken)
+        // Single page: no odata.maxpagesize preference — it would silently truncate a
+        // one-shot request to the first server page.
+        var page = await FetchPageAsync<TEntity>(path, filter, queryOptions, select, null, cancellationToken)
             .ConfigureAwait(false);
 
         return page.Value;
@@ -231,29 +233,35 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
 
         var filterValue = filter?.Value ?? string.Empty;
 
-        // Top is a result cap, exactly as documented on WithTop; PageSize sizes the round
-        // trips. The paging state machine itself lives in QueryPager, shared with the
-        // fluent builder. baseOptions.Skip is honoured as the starting offset instead of
-        // silently restarting from the first page.
+        // Top is a result cap, exactly as documented on WithTop. Paging is server-driven:
+        // the per-query PageSize (else the registration-level MaxPageSize, else nothing)
+        // is sent as Prefer: odata.maxpagesize, and the server pages via @odata.nextLink.
+        // baseOptions.Skip is honoured as the starting offset of the first request.
+        var maxPageSize = baseOptions.PageSize ?? _options.MaxPageSize;
+
         var stream = QueryPager.StreamAsync(
             baseOptions.Top,
-            baseOptions.PageSize ?? QueryPager.DefaultPageSize,
             baseOptions.Skip ?? 0,
             (top, skip, ct) => FetchPageAsync<TEntity>(
-                path, filterValue, PageOptions(baseOptions, top, skip), select, ct),
-            FetchNextPageAsync<TEntity>,
+                path, filterValue, PageOptions(baseOptions, top, skip), select, maxPageSize, ct),
+            (link, ct) => FetchNextPageAsync<TEntity>(link, maxPageSize, ct),
             cancellationToken);
 
         await foreach (var entity in stream.ConfigureAwait(false))
             yield return entity;
     }
 
-    private static QueryOptions PageOptions(QueryOptions baseOptions, int top, int skip)
+    /// <summary>
+    /// Options for the first request of a stream: the caller's cap and starting offset,
+    /// plus everything shareable from the base options. Continuations use the server's
+    /// nextLink verbatim instead.
+    /// </summary>
+    private static QueryOptions PageOptions(QueryOptions baseOptions, int? top, int skip)
     {
         var options = new QueryOptions
         {
             Top = top,
-            Skip = skip,
+            Skip = skip == 0 ? null : skip,
             IncludeCount = baseOptions.IncludeCount
         };
 
@@ -266,30 +274,35 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
         return options;
     }
 
+    int? IBusinessCentralQueryExecutor.DefaultMaxPageSize => _options.MaxPageSize;
+
     async Task<ODataResponse<TEntity>> IBusinessCentralQueryExecutor.FetchPageAsync<TEntity>(
         string path,
         string filter,
         QueryOptions options,
         IEnumerable<string>? select,
+        int? maxPageSize,
         CancellationToken cancellationToken)
-        => await FetchPageAsync<TEntity>(path, filter, options, select, cancellationToken).ConfigureAwait(false);
+        => await FetchPageAsync<TEntity>(path, filter, options, select, maxPageSize, cancellationToken).ConfigureAwait(false);
 
     async Task<ODataResponse<TEntity>> IBusinessCentralQueryExecutor.FetchNextPageAsync<TEntity>(
         string absoluteUrl,
+        int? maxPageSize,
         CancellationToken cancellationToken)
-        => await FetchNextPageAsync<TEntity>(absoluteUrl, cancellationToken).ConfigureAwait(false);
+        => await FetchNextPageAsync<TEntity>(absoluteUrl, maxPageSize, cancellationToken).ConfigureAwait(false);
 
     private async Task<ODataResponse<TEntity>> FetchPageAsync<TEntity>(
         string path,
         string filter,
         QueryOptions options,
         IEnumerable<string>? select,
+        int? maxPageSize,
         CancellationToken cancellationToken)
     {
         var url = _urlBuilder.BuildQueryUrl(path, filter, options, select);
 
         using var res = await SendWithAuthRetryAsync(
-            () => CreateJsonRequest(HttpMethod.Get, url), cancellationToken).ConfigureAwait(false);
+            () => CreatePageRequest(url, maxPageSize), cancellationToken).ConfigureAwait(false);
 
         return await DeserializeAsync<ODataResponse<TEntity>>(
             res,
@@ -299,15 +312,31 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
 
     private async Task<ODataResponse<TEntity>> FetchNextPageAsync<TEntity>(
         string absoluteUrl,
+        int? maxPageSize,
         CancellationToken cancellationToken)
     {
+        // The nextLink is sent verbatim — it arrives pre-encoded and carries an opaque
+        // $skiptoken; rebuilding it would corrupt the cursor. The maxpagesize preference
+        // is re-sent because it applies per request, not per cursor.
         using var res = await SendWithAuthRetryAsync(
-            () => CreateJsonRequest(HttpMethod.Get, absoluteUrl), cancellationToken).ConfigureAwait(false);
+            () => CreatePageRequest(absoluteUrl, maxPageSize), cancellationToken).ConfigureAwait(false);
 
         return await DeserializeAsync<ODataResponse<TEntity>>(
             res,
             "Failed to deserialize Business Central response.",
             cancellationToken).ConfigureAwait(false);
+    }
+
+    private static HttpRequestMessage CreatePageRequest(string url, int? maxPageSize)
+    {
+        var req = CreateJsonRequest(HttpMethod.Get, url);
+
+        // The public setters reject non-positive sizes; internal ones fall back to "no
+        // preference" rather than sending the server a nonsense value.
+        if (maxPageSize is { } size && size > 0)
+            req.AddMaxPageSizePreference(size);
+
+        return req;
     }
 
     private static HttpRequestMessage CreateJsonRequest(HttpMethod method, string url, object? payload = null)

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -29,6 +29,13 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     private static readonly JsonSerializerOptions _jsonOptions = BusinessCentralJson.Options;
 
     /// <summary>Creates a client for the company configured in <paramref name="options"/>.</summary>
+    /// <remarks>
+    /// Prefer registration via <c>AddBusinessCentral</c>: with this constructor the client
+    /// creates a <b>private</b> token cache, so every manually constructed instance
+    /// re-authenticates independently — construct once and reuse, don't new one up per
+    /// call. Token requests also share <paramref name="http"/> with data traffic here,
+    /// instead of the separate named client the DI path uses.
+    /// </remarks>
     /// <param name="http">HTTP client used for data requests.</param>
     /// <param name="options">Connection settings.</param>
     /// <param name="observer">Optional diagnostics observer.</param>
@@ -48,7 +55,7 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     {
         _http = http;
         _options = options.Value;
-        _observer = observer ?? new NullBusinessCentralObserver();
+        _observer = SafeBusinessCentralObserver.Wrap(observer);
         _company = _options.Company;
 
         // No mutation of the supplied HttpClient: it may be pooled or shared, and setting
@@ -774,7 +781,12 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
         }
         catch (Exception ex)
         {
-            if (!failureReported)
+            // A cancellation the caller asked for is not a failure — reporting it would
+            // put noise in every consumer's error metrics on ordinary shutdowns.
+            var callerCancelled =
+                ex is OperationCanceledException && cancellationToken.IsCancellationRequested;
+
+            if (!failureReported && !callerCancelled)
             {
                 _observer.OnRequestFailed(new BusinessCentralErrorInfo
                 {

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
@@ -37,7 +37,7 @@ internal sealed class BusinessCentralTokenProvider : IDisposable
     {
         _http = http;
         _options = options.Value;
-        _observer = observer ?? new NullBusinessCentralObserver();
+        _observer = SafeBusinessCentralObserver.Wrap(observer);
     }
 
     public async Task<string> GetTokenAsync(CancellationToken cancellationToken)

--- a/src/Dynamics365.BusinessCentral/Client/HttpRequestExtensions.cs
+++ b/src/Dynamics365.BusinessCentral/Client/HttpRequestExtensions.cs
@@ -32,4 +32,15 @@ internal static class HttpRequestExtensions
     {
         request.Headers.TryAddWithoutValidation("Prefer", "return=representation");
     }
+
+    /// <summary>
+    /// Asks the server to cap pages at <paramref name="maxPageSize"/> rows via
+    /// <c>Prefer: odata.maxpagesize</c>. The server clamps the value to its own configured
+    /// maximum and continues via <c>@odata.nextLink</c> — the supported, deployment-portable
+    /// way to pace a streaming read (verified against a live BC SaaS tenant).
+    /// </summary>
+    public static void AddMaxPageSizePreference(this HttpRequestMessage request, int maxPageSize)
+    {
+        request.Headers.TryAddWithoutValidation("Prefer", $"odata.maxpagesize={maxPageSize}");
+    }
 }

--- a/src/Dynamics365.BusinessCentral/Client/IBusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/IBusinessCentralClient.cs
@@ -143,7 +143,10 @@ public interface IBusinessCentralClient
     /// <typeparam name="TEntity">The entity type to deserialize the OData result into.</typeparam>
     /// <param name="path">Relative OData entity path.</param>
     /// <param name="filter">Optional strongly-typed OData filter expression.</param>
-    /// <param name="options">Optional query options; use <c>WithPageSize</c> to size each round trip.</param>
+    /// <param name="options">
+    /// Optional query options. Paging is server-driven via <c>@odata.nextLink</c>; use
+    /// <c>WithPageSize</c> to request smaller pages (<c>Prefer: odata.maxpagesize</c>).
+    /// </param>
     /// <param name="select">Optional list of fields to select.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<List<TEntity>> QueryAllAsync<TEntity>(
@@ -161,7 +164,10 @@ public interface IBusinessCentralClient
     /// <typeparam name="TEntity">The entity type to deserialize the OData result into.</typeparam>
     /// <param name="path">Relative OData entity path.</param>
     /// <param name="filter">Optional strongly-typed OData filter expression.</param>
-    /// <param name="options">Optional query options; use <c>WithPageSize</c> to size each round trip.</param>
+    /// <param name="options">
+    /// Optional query options. Paging is server-driven via <c>@odata.nextLink</c>; use
+    /// <c>WithPageSize</c> to request smaller pages (<c>Prefer: odata.maxpagesize</c>).
+    /// </param>
     /// <param name="select">Optional list of fields to select.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     IAsyncEnumerable<TEntity> QueryStreamAsync<TEntity>(

--- a/src/Dynamics365.BusinessCentral/Diagnostics/SafeBusinessCentralObserver.cs
+++ b/src/Dynamics365.BusinessCentral/Diagnostics/SafeBusinessCentralObserver.cs
@@ -1,0 +1,66 @@
+namespace Dynamics365.BusinessCentral.Diagnostics;
+
+/// <summary>
+/// Isolates the pipeline from a throwing observer: diagnostics are best-effort, and a bug
+/// in an <see cref="IBusinessCentralObserver"/> implementation must not turn a successful
+/// request into a failure — or worse, break the retry loop mid-flight. Every callback is
+/// swallowed on error, mirroring how the client already treats unreadable response bodies
+/// ("diagnostics must never mask the original failure").
+/// </summary>
+internal sealed class SafeBusinessCentralObserver : IBusinessCentralObserver
+{
+    private readonly IBusinessCentralObserver _inner;
+
+    private SafeBusinessCentralObserver(IBusinessCentralObserver inner) => _inner = inner;
+
+    /// <summary>
+    /// Wraps <paramref name="observer"/>, or returns a null observer when none was given.
+    /// Idempotent: an already-wrapped observer is returned as-is, so the client can hand
+    /// its observer to the token provider without double-wrapping.
+    /// </summary>
+    public static IBusinessCentralObserver Wrap(IBusinessCentralObserver? observer) =>
+        observer switch
+        {
+            null => new NullBusinessCentralObserver(),
+            SafeBusinessCentralObserver safe => safe,
+            NullBusinessCentralObserver @null => @null,
+            _ => new SafeBusinessCentralObserver(observer)
+        };
+
+    public void OnRequestStarting(BusinessCentralRequestInfo request) =>
+        Invoke(() => _inner.OnRequestStarting(request));
+
+    public void OnRequestSucceeded(BusinessCentralRequestInfo request) =>
+        Invoke(() => _inner.OnRequestSucceeded(request));
+
+    public void OnRequestFailed(BusinessCentralErrorInfo error) =>
+        Invoke(() => _inner.OnRequestFailed(error));
+
+    public void OnRequestRetrying(BusinessCentralRetryInfo retry) =>
+        Invoke(() => _inner.OnRequestRetrying(retry));
+
+    public void OnDeserializationFailed(BusinessCentralErrorInfo error) =>
+        Invoke(() => _inner.OnDeserializationFailed(error));
+
+    public void OnTokenRequested() =>
+        Invoke(_inner.OnTokenRequested);
+
+    public void OnTokenRefreshed(BusinessCentralTokenInfo token) =>
+        Invoke(() => _inner.OnTokenRefreshed(token));
+
+    public void OnTokenServedFromCache(BusinessCentralTokenInfo token) =>
+        Invoke(() => _inner.OnTokenServedFromCache(token));
+
+    private static void Invoke(Action callback)
+    {
+        try
+        {
+            callback();
+        }
+        catch
+        {
+            // Observer failures are deliberately silent: there is no safe place to report
+            // a broken reporter.
+        }
+    }
+}

--- a/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
+++ b/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
@@ -125,7 +125,7 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
     public async Task<List<TEntity>> ToListAsync(CancellationToken cancellationToken = default)
     {
         var page = await _executor
-            .FetchPageAsync<TEntity>(_path, FilterValue, BuildOptions(), SelectOrNull, cancellationToken)
+            .FetchPageAsync<TEntity>(_path, FilterValue, BuildOptions(), SelectOrNull, null, cancellationToken)
             .ConfigureAwait(false);
 
         return page.Value;
@@ -137,7 +137,7 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
         options.WithCount();
 
         var page = await _executor
-            .FetchPageAsync<TEntity>(_path, FilterValue, options, SelectOrNull, cancellationToken)
+            .FetchPageAsync<TEntity>(_path, FilterValue, options, SelectOrNull, null, cancellationToken)
             .ConfigureAwait(false);
 
         return new BusinessCentralPage<TEntity>(page.Value, page.Count, page.NextLink);
@@ -157,26 +157,34 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         // The paging state machine lives in QueryPager, shared with the path-based
-        // QueryStreamAsync; only the fetch delegates differ.
+        // QueryStreamAsync; only the fetch delegates differ. Paging is server-driven: the
+        // per-query PageSize (else the registration-level MaxPageSize, else nothing) is
+        // sent as Prefer: odata.maxpagesize and continuation follows @odata.nextLink.
+        var maxPageSize = _pageSize ?? _executor.DefaultMaxPageSize;
+
         var stream = QueryPager.StreamAsync(
             _top,
-            _pageSize ?? QueryPager.DefaultPageSize,
             _skip ?? 0,
-            FetchAsync,
-            _executor.FetchNextPageAsync<TEntity>,
+            (top, skip, ct) => FetchAsync(top, skip, maxPageSize, ct),
+            (link, ct) => _executor.FetchNextPageAsync<TEntity>(link, maxPageSize, ct),
             cancellationToken);
 
         await foreach (var entity in stream.ConfigureAwait(false))
             yield return entity;
     }
 
-    private Task<ODataResponse<TEntity>> FetchAsync(int top, int skip, CancellationToken cancellationToken)
+    private Task<ODataResponse<TEntity>> FetchAsync(
+        int? top,
+        int skip,
+        int? maxPageSize,
+        CancellationToken cancellationToken)
     {
         var options = BuildOptions();
         options.Top = top;
-        options.Skip = skip;
+        options.Skip = skip == 0 ? null : skip;
 
-        return _executor.FetchPageAsync<TEntity>(_path, FilterValue, options, SelectOrNull, cancellationToken);
+        return _executor.FetchPageAsync<TEntity>(
+            _path, FilterValue, options, SelectOrNull, maxPageSize, cancellationToken);
     }
 
     public async Task<TEntity?> FirstOrDefaultAsync(CancellationToken cancellationToken = default)
@@ -185,7 +193,7 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
         options.Top = 1;
 
         var page = await _executor
-            .FetchPageAsync<TEntity>(_path, FilterValue, options, SelectOrNull, cancellationToken)
+            .FetchPageAsync<TEntity>(_path, FilterValue, options, SelectOrNull, null, cancellationToken)
             .ConfigureAwait(false);
 
         return page.Value.Count == 0 ? default : page.Value[0];
@@ -198,7 +206,7 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
         options.Top = 0;
 
         var page = await _executor
-            .FetchPageAsync<TEntity>(_path, FilterValue, options, SelectOrNull, cancellationToken)
+            .FetchPageAsync<TEntity>(_path, FilterValue, options, SelectOrNull, null, cancellationToken)
             .ConfigureAwait(false);
 
         if (page.Count is { } count)

--- a/src/Dynamics365.BusinessCentral/OData/IBusinessCentralQuery.cs
+++ b/src/Dynamics365.BusinessCentral/OData/IBusinessCentralQuery.cs
@@ -55,7 +55,12 @@ public interface IBusinessCentralQuery<TEntity>
     /// <summary>Skips entities (<c>$skip</c>).</summary>
     IBusinessCentralQuery<TEntity> Skip(int count);
 
-    /// <summary>Sets rows fetched per round trip when auto-paging. Not a result limit.</summary>
+    /// <summary>
+    /// Requests at most <paramref name="size"/> rows per page when auto-paging, via
+    /// <c>Prefer: odata.maxpagesize</c>. Not a result limit. When unset, the server pages
+    /// at its own configured Max Page Size (or <c>BusinessCentralOptions.MaxPageSize</c>,
+    /// when that is set); the server clamps the value to its own maximum.
+    /// </summary>
     IBusinessCentralQuery<TEntity> PageSize(int size);
 
     /// <summary>Executes a single request and returns that page's entities.</summary>

--- a/src/Dynamics365.BusinessCentral/OData/ODataResponse.cs
+++ b/src/Dynamics365.BusinessCentral/OData/ODataResponse.cs
@@ -22,14 +22,33 @@ internal sealed class ODataResponse<TEntity>
 /// </summary>
 internal interface IBusinessCentralQueryExecutor
 {
+    /// <summary>
+    /// The registration-level <c>BusinessCentralOptions.MaxPageSize</c>, so the fluent
+    /// builder can fall back to it when no per-query page size was set.
+    /// </summary>
+    int? DefaultMaxPageSize { get; }
+
+    /// <remarks>
+    /// <c>maxPageSize</c>, when set, is sent as <c>Prefer: odata.maxpagesize</c>. Streaming
+    /// reads pass the resolved preference; single-page reads pass <see langword="null"/> —
+    /// a preference on a one-shot request would silently truncate it to the first server
+    /// page.
+    /// </remarks>
     Task<ODataResponse<TEntity>> FetchPageAsync<TEntity>(
         string path,
         string filter,
         QueryOptions options,
         IEnumerable<string>? select,
+        int? maxPageSize,
         CancellationToken cancellationToken);
 
+    /// <remarks>
+    /// <c>maxPageSize</c> must be the same preference as the page that produced the
+    /// nextLink — re-sent on every continuation, because the preference applies per
+    /// request, not per cursor.
+    /// </remarks>
     Task<ODataResponse<TEntity>> FetchNextPageAsync<TEntity>(
         string absoluteUrl,
+        int? maxPageSize,
         CancellationToken cancellationToken);
 }

--- a/src/Dynamics365.BusinessCentral/OData/QueryOptions.cs
+++ b/src/Dynamics365.BusinessCentral/OData/QueryOptions.cs
@@ -16,8 +16,11 @@ public sealed class QueryOptions
     public int? Skip { get; internal set; }
 
     /// <summary>
-    /// Rows fetched per request when auto-paging. This is <b>not</b> a result limit —
-    /// use <see cref="WithTop"/> for that.
+    /// Maximum rows per page when auto-paging, requested from the server via
+    /// <c>Prefer: odata.maxpagesize</c>. This is <b>not</b> a result limit — use
+    /// <see cref="WithTop"/> for that. When unset, the server pages at its own configured
+    /// Max Page Size (or the registration-level <c>BusinessCentralOptions.MaxPageSize</c>,
+    /// when that is set).
     /// </summary>
     public int? PageSize { get; internal set; }
 
@@ -62,12 +65,13 @@ public sealed class QueryOptions
     }
 
     /// <summary>
-    /// Sets how many rows are fetched per request when auto-paging. Affects the number of
-    /// round trips, not how many entities come back.
+    /// Requests at most <paramref name="value"/> rows per page when auto-paging, via
+    /// <c>Prefer: odata.maxpagesize</c>. Affects the number of round trips and per-response
+    /// size, not how many entities come back. The server clamps the value to its own
+    /// configured maximum, so this can only ask for <i>smaller</i> pages.
     /// </summary>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// <paramref name="value"/> is less than 1. A page size of zero would request <c>$top=0</c>
-    /// forever without advancing.
+    /// <paramref name="value"/> is less than 1.
     /// </exception>
     public QueryOptions WithPageSize(int value)
     {

--- a/src/Dynamics365.BusinessCentral/OData/QueryPager.cs
+++ b/src/Dynamics365.BusinessCentral/OData/QueryPager.cs
@@ -9,26 +9,26 @@ namespace Dynamics365.BusinessCentral.OData;
 /// cannot drift apart; only the page-fetching delegates differ per caller.
 /// </summary>
 /// <remarks>
-/// Three-tier termination:
-/// <list type="number">
-/// <item>Follow <c>@odata.nextLink</c> whenever present — the server decides page size.</item>
-/// <item>Once server-driven, a missing nextLink means the collection is exhausted; the
-/// short-page rule no longer applies.</item>
-/// <item>Otherwise stop on the first page shorter than requested.</item>
-/// </list>
-/// <c>limit</c> caps emitted rows (<c>$top</c> semantics), enforced mid-page and never
-/// overshot by a request; <c>pageSize</c> sizes the round trips.
+/// <para>
+/// Paging is <b>server-driven</b> (verified against a live BC SaaS tenant): the first
+/// request carries no <c>$top</c> unless the caller set a result cap, the server pages at
+/// its own Max Page Size — or at the <c>Prefer: odata.maxpagesize</c> preference the fetch
+/// delegates send when one is configured — and continuation follows
+/// <c>@odata.nextLink</c>, an opaque <c>$skiptoken</c> cursor immune to the offset-shift
+/// hazard of <c>$skip</c> paging. No nextLink means the response is complete: either the
+/// server served everything, or the caller's <c>$top</c> budget is satisfied.
+/// </para>
+/// <para>
+/// <c>limit</c> (<c>$top</c> semantics) caps emitted rows, enforced mid-page client-side
+/// and also sent to the server so it never over-serves a capped query.
+/// </para>
 /// </remarks>
 internal static class QueryPager
 {
-    /// <summary>Default rows-per-round-trip when the caller did not set a page size.</summary>
-    public const int DefaultPageSize = 1000;
-
     public static async IAsyncEnumerable<TEntity> StreamAsync<TEntity>(
         int? limit,
-        int pageSize,
         int initialSkip,
-        Func<int, int, CancellationToken, Task<ODataResponse<TEntity>>> fetchPage,
+        Func<int?, int, CancellationToken, Task<ODataResponse<TEntity>>> fetchFirstPage,
         Func<string, CancellationToken, Task<ODataResponse<TEntity>>> fetchNextPage,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
@@ -36,68 +36,28 @@ internal static class QueryPager
         if (limit == 0)
             yield break;
 
-        // Guards the loop below: with a non-positive page size the "short page" termination
-        // check can never fire, so it would request the same empty page forever. The public
-        // setters reject these values; this covers the internal ones.
-        if (pageSize <= 0)
-            yield break;
-
-        var skip = initialSkip;
         var emitted = 0;
 
-        var requested = NextTop(pageSize, limit, emitted);
-        var page = await fetchPage(requested, skip, cancellationToken).ConfigureAwait(false);
-
-        // True once the server started driving paging via @odata.nextLink, at which point
-        // it — not our $top — decides where the collection ends.
-        var serverDriven = false;
+        var page = await fetchFirstPage(limit, initialSkip, cancellationToken).ConfigureAwait(false);
 
         while (true)
         {
-            var inPage = 0;
-
             foreach (var entity in page.Value)
             {
                 yield return entity;
 
                 emitted++;
-                inPage++;
 
                 if (limit is { } cap && emitted >= cap)
                     yield break;
             }
 
-            if (!string.IsNullOrWhiteSpace(page.NextLink))
-            {
-                serverDriven = true;
-
-                page = await fetchNextPage(page.NextLink!, cancellationToken).ConfigureAwait(false);
-
-                continue;
-            }
-
-            // The server was paging and stopped offering a nextLink: nothing left.
-            if (serverDriven)
+            // No continuation means the collection (or the caller's $top budget) is
+            // exhausted — BC offers a nextLink on every page it truncates.
+            if (string.IsNullOrWhiteSpace(page.NextLink))
                 yield break;
 
-            // No nextLink and a short page means the collection is exhausted.
-            if (inPage < requested)
-                yield break;
-
-            skip += inPage;
-            requested = NextTop(pageSize, limit, emitted);
-
-            page = await fetchPage(requested, skip, cancellationToken).ConfigureAwait(false);
+            page = await fetchNextPage(page.NextLink!, cancellationToken).ConfigureAwait(false);
         }
-    }
-
-    /// <summary>Page size for the next request, never overshooting a caller-set <c>$top</c>.</summary>
-    private static int NextTop(int pageSize, int? limit, int emitted)
-    {
-        if (limit is not { } cap)
-            return pageSize;
-
-        var remaining = cap - emitted;
-        return remaining < pageSize ? remaining : pageSize;
     }
 }

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptions.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptions.cs
@@ -49,6 +49,22 @@ public sealed class BusinessCentralOptions
     /// <summary>Controls automatic retrying of throttled and transient failures.</summary>
     public BusinessCentralRetryOptions Retry { get; set; } = new();
 
+    /// <summary>
+    /// Maximum rows per page requested on streaming reads (<c>QueryAllAsync</c>,
+    /// <c>QueryStreamAsync</c>, the fluent <c>StreamAsync</c>/<c>ToAllAsync</c>), sent as
+    /// <c>Prefer: odata.maxpagesize={value}</c>. Defaults to <see langword="null"/> —
+    /// <b>no preference is sent</b>, and Business Central pages at its own configured
+    /// Max Page Size (20,000 online; the server setting on-premises), driving continuation
+    /// via <c>@odata.nextLink</c>.
+    /// </summary>
+    /// <remarks>
+    /// The server clamps the preference to its own maximum, so a large value cannot raise
+    /// a deployment's ceiling — this can only ask for <i>smaller</i> pages, e.g. to bound
+    /// per-response memory or avoid timeouts on slow pages. Override per query with
+    /// <c>QueryOptions.WithPageSize</c> / the fluent <c>PageSize(n)</c>.
+    /// </remarks>
+    public int? MaxPageSize { get; set; }
+
     /// <summary><see cref="BaseUrl"/> with all placeholders substituted.</summary>
     internal string ResolvedBaseUrl => ResolvePlaceholders(BaseUrl);
 

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptionsValidator.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptionsValidator.cs
@@ -28,6 +28,9 @@ internal sealed class BusinessCentralOptionsValidator : IValidateOptions<Busines
         RequireAbsoluteUrl(options.ResolvedBaseUrl, nameof(options.BaseUrl), failures);
         RequireAbsoluteUrl(options.ResolvedTokenEndpoint, nameof(options.TokenEndpoint), failures);
 
+        if (options.MaxPageSize is < 1)
+            failures.Add($"{nameof(BusinessCentralOptions)}.{nameof(options.MaxPageSize)} must be at least 1 when set.");
+
         return failures.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(failures);

--- a/src/Dynamics365.BusinessCentral/README.md
+++ b/src/Dynamics365.BusinessCentral/README.md
@@ -121,12 +121,26 @@ var orders = await client.Query<SalesOrder>()
 `StreamAsync` fetches pages as you consume them and stops fetching when you stop reading —
 prefer it over `ToAllAsync` for large sets.
 
+Paging is **server-driven** (verified against a live BC SaaS tenant): by default no page
+size is sent at all, Business Central pages at its own configured Max Page Size (20,000
+online), and continuation follows `@odata.nextLink` — an opaque cursor immune to the
+row-shift hazards of offset paging. To bound per-response size — memory, slow pages,
+timeouts — request smaller pages; the value is sent as `Prefer: odata.maxpagesize` and
+the server clamps it to its own maximum, so it can only ever ask for *less*:
+
 ```csharp
+// per registration — the default for every streaming read
+services.AddBusinessCentral(o => { /* ... */ o.MaxPageSize = 1000; });
+
+// per query — overrides the registration value
 await foreach (var order in client.Query<SalesOrder>().PageSize(500).StreamAsync())
 {
     if (Process(order) is Done) break;   // no further pages are requested
 }
 ```
+
+`Top(n)` remains a pure result cap: it is sent as `$top` so the server never over-serves a
+capped query, and enforced mid-page while continuations are followed.
 
 ## Counting and paging
 

--- a/src/Dynamics365.BusinessCentral/README.md
+++ b/src/Dynamics365.BusinessCentral/README.md
@@ -197,7 +197,9 @@ await client.DeleteAsync("salesOrders", systemId);
 ```
 
 Writes send `Prefer: return=representation`. If the server answers `204 No Content`, the
-payload you sent is returned instead of throwing. Keys may be a `systemId` or an alternate
+payload you sent is returned instead of throwing. (Measured live: `ODataV4` page endpoints
+echo the entity on `PATCH` regardless of the header, so the `204` path is a safety net
+rather than the common case.) Keys may be a `systemId` or an alternate
 key such as `No='1000'`.
 
 When the response type differs from the payload — posting an anonymous object and reading

--- a/test/Dynamics365.BusinessCentral.Tests/ClientTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ClientTests.cs
@@ -821,32 +821,28 @@ public partial class ClientTests
         Assert.Contains(requests, r => r.Contains("$top=25"));
     }
 
+    // The default is server-driven: no $top, no page preference — the deployment's own
+    // Max Page Size paces the stream and drives continuation via @odata.nextLink
+    // (verified against a live BC SaaS tenant).
     [Fact]
-    public async Task QueryAll_Uses_Default_Page_Size_When_Not_Set()
+    public async Task QueryAll_Sends_No_Top_And_No_Page_Preference_By_Default()
     {
-        // Arrange
         string? capturedUrl = null;
-        var client = TestBase.CreateClient(req =>
+        string? preferHeader = null;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
         {
-            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
-                return new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
-                };
-
             capturedUrl = req.RequestUri!.ToString();
-            return new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("{\"value\":[]}")
-            };
-        });
+            preferHeader = req.Headers.TryGetValues("Prefer", out var v) ? string.Join(",", v) : null;
+            return TestBase.Json("{\"value\":[]}");
+        }));
 
-        // Act
         await client.QueryAllAsync<TestEntity>("orders");
 
-        // Assert
         Assert.NotNull(capturedUrl);
-        Assert.Contains("$top=1000", capturedUrl);
+        Assert.DoesNotContain("$top", capturedUrl);
+        Assert.DoesNotContain("$skip", capturedUrl);
+        Assert.Null(preferHeader);
     }
 
     [Fact]
@@ -2048,40 +2044,40 @@ public partial class ClientTests
         Assert.Equal(1, dataCalls);
     }
 
+    // WithPageSize is a server preference (Prefer: odata.maxpagesize), re-sent on every
+    // continuation because it applies per request, not per cursor.
     [Fact]
-    public async Task QueryAll_Pages_Until_Short_Page()
+    public async Task QueryAll_Requests_Page_Size_Via_Prefer_And_Follows_NextLinks()
     {
         var dataCalls = 0;
+        var preferHeaders = new List<string?>();
 
-        var client = TestBase.CreateClient(req =>
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
         {
-            if (req.RequestUri!.AbsoluteUri.Contains("auth"))
-                return new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent("{\"access_token\":\"abc\",\"expires_in\":3600}")
-                };
-
             dataCalls++;
+            preferHeaders.Add(req.Headers.TryGetValues("Prefer", out var v) ? string.Join(",", v) : null);
 
-            // Two full pages of 2, then a short page.
-            var body = dataCalls <= 2
-                ? "{\"value\":[{\"id\":1},{\"id\":2}]}"
-                : "{\"value\":[{\"id\":3}]}";
-
-            return new HttpResponseMessage(HttpStatusCode.OK)
+            // Two pages with continuations, then a final page without one.
+            var body = dataCalls switch
             {
-                Content = new StringContent(body)
+                1 => "{\"value\":[{\"id\":1},{\"id\":2}],\"@odata.nextLink\":\"https://test/p2\"}",
+                2 => "{\"value\":[{\"id\":3},{\"id\":4}],\"@odata.nextLink\":\"https://test/p3\"}",
+                _ => "{\"value\":[{\"id\":5}]}"
             };
-        });
+
+            return TestBase.Json(body);
+        }));
 
         var result = await client.QueryAllAsync<TestEntity>("orders", options: o => o.WithPageSize(2));
 
         Assert.Equal(5, result.Count);
         Assert.Equal(3, dataCalls);
+        Assert.All(preferHeaders, h => Assert.Equal("odata.maxpagesize=2", h));
     }
 
-    // Top is a result cap here, exactly as its documentation says — the same contract as
-    // the fluent builder's Top(). It used to be silently repurposed as the page size.
+    // Top is a result cap: sent to the server as $top on the first request (so a capped
+    // query is never over-served) and enforced client-side mid-page while nextLinks are
+    // followed.
     [Fact]
     public async Task QueryAll_Honours_Top_As_A_Result_Cap()
     {
@@ -2093,7 +2089,11 @@ public partial class ClientTests
             dataCalls++;
             requests.Add(req.RequestUri!.ToString());
 
-            return TestBase.Json("{\"value\":[{\"id\":1},{\"id\":2}]}");
+            var body = dataCalls == 1
+                ? "{\"value\":[{\"id\":1},{\"id\":2}],\"@odata.nextLink\":\"https://test/p2\"}"
+                : "{\"value\":[{\"id\":3},{\"id\":4}]}";
+
+            return TestBase.Json(body);
         }));
 
         var result = await client.QueryAllAsync<TestEntity>(
@@ -2102,9 +2102,51 @@ public partial class ClientTests
         Assert.Equal(3, result.Count);
         Assert.Equal(2, dataCalls);
 
-        // The second request never overshoots the cap: only one row is still wanted.
-        Assert.Contains("$top=2", requests[0]);
-        Assert.Contains("$top=1", requests[1]);
+        // The cap rides the first request; continuation follows the server's link.
+        Assert.Contains("$top=3", requests[0]);
+        Assert.Equal("https://test/p2", requests[1]);
+    }
+
+    // Single-page reads never send the page preference — it would silently truncate a
+    // one-shot request to the first server page.
+    [Fact]
+    public async Task Single_Page_Query_Never_Sends_The_Page_Preference()
+    {
+        string? preferHeader = null;
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(req =>
+            {
+                preferHeader = req.Headers.TryGetValues("Prefer", out var v) ? string.Join(",", v) : null;
+                return TestBase.Json("{\"value\":[]}");
+            }),
+            configure: o => o.MaxPageSize = 500);
+
+        await client.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.Null(preferHeader);
+    }
+
+    // The registration-level MaxPageSize is the streaming default; a per-query
+    // WithPageSize overrides it.
+    [Fact]
+    public async Task Options_MaxPageSize_Is_The_Streaming_Default_And_PageSize_Overrides_It()
+    {
+        var preferHeaders = new List<string?>();
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(req =>
+            {
+                preferHeaders.Add(req.Headers.TryGetValues("Prefer", out var v) ? string.Join(",", v) : null);
+                return TestBase.Json("{\"value\":[]}");
+            }),
+            configure: o => o.MaxPageSize = 500);
+
+        await client.QueryAllAsync<TestEntity>("orders");
+        await client.QueryAllAsync<TestEntity>("orders", options: o => o.WithPageSize(50));
+
+        Assert.Equal("odata.maxpagesize=500", preferHeaders[0]);
+        Assert.Equal("odata.maxpagesize=50", preferHeaders[1]);
     }
 
     [Fact]

--- a/test/Dynamics365.BusinessCentral.Tests/ObserverTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ObserverTests.cs
@@ -1,4 +1,5 @@
-﻿using Dynamics365.BusinessCentral.Errors;
+﻿using Dynamics365.BusinessCentral.Diagnostics;
+using Dynamics365.BusinessCentral.Errors;
 using Dynamics365.BusinessCentral.Tests.Utils;
 using System.Net;
 
@@ -131,6 +132,66 @@ public class ObserverTests
         Assert.Contains("token-cached", observer.Events);
     }
 
+    /// <summary>Throws from every callback — diagnostics must never break the pipeline.</summary>
+    private sealed class ThrowingObserver : IBusinessCentralObserver
+    {
+        public void OnRequestStarting(BusinessCentralRequestInfo request) => throw new InvalidOperationException("observer bug");
+        public void OnRequestSucceeded(BusinessCentralRequestInfo request) => throw new InvalidOperationException("observer bug");
+        public void OnRequestFailed(BusinessCentralErrorInfo error) => throw new InvalidOperationException("observer bug");
+        public void OnRequestRetrying(BusinessCentralRetryInfo retry) => throw new InvalidOperationException("observer bug");
+        public void OnDeserializationFailed(BusinessCentralErrorInfo error) => throw new InvalidOperationException("observer bug");
+        public void OnTokenRequested() => throw new InvalidOperationException("observer bug");
+        public void OnTokenRefreshed(BusinessCentralTokenInfo token) => throw new InvalidOperationException("observer bug");
+        public void OnTokenServedFromCache(BusinessCentralTokenInfo token) => throw new InvalidOperationException("observer bug");
+    }
 
+    // Observers are best-effort diagnostics: a bug in one must not turn a successful
+    // request into a failure, and a real server failure must surface as the
+    // BusinessCentralException — not as the observer's own exception.
+    [Fact]
+    public async Task Throwing_Observer_Does_Not_Break_Successful_Requests()
+    {
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ => TestBase.Json("{\"value\":[{\"id\":1}]}")),
+            new ThrowingObserver());
 
+        var result = await client.QueryAsync<TestEntity>("orders", "true");
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task Throwing_Observer_Does_Not_Mask_The_Real_Failure()
+    {
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ => new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("nope")
+            }),
+            new ThrowingObserver());
+
+        await Assert.ThrowsAsync<BusinessCentralValidationException>(() =>
+            client.QueryAsync<TestEntity>("orders", "true"));
+    }
+
+    // A cancellation the caller asked for is not a failure and must not be reported as one.
+    [Fact]
+    public async Task Caller_Cancellation_Is_Not_Reported_As_A_Failure()
+    {
+        var observer = new TestObserver();
+        using var cts = new CancellationTokenSource();
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ =>
+            {
+                cts.Cancel();
+                throw new TaskCanceledException();
+            }),
+            observer);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            client.QueryAsync<TestEntity>("orders", "true", cancellationToken: cts.Token));
+
+        Assert.Empty(observer.Failures);
+    }
 }

--- a/test/Dynamics365.BusinessCentral.Tests/PagingGuardTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/PagingGuardTests.cs
@@ -8,10 +8,10 @@ using Dynamics365.BusinessCentral.Errors;
 namespace Dynamics365.BusinessCentral.Tests;
 
 /// <summary>
-/// Regression cover for non-positive paging values, which previously produced a
-/// non-terminating paging loop: with a page size of zero the "short page" termination
-/// check (<c>inPage &lt; pageSize</c>) can never fire, so the same empty page is requested
-/// forever without <c>$skip</c> ever advancing.
+/// Boundary cover for paging values. Paging is server-driven (nextLink continuation), so
+/// a bad page size can no longer cause a non-terminating loop — these pin the boundary
+/// validation and that non-positive internal values degrade to "no preference" rather
+/// than reaching the server.
 /// </summary>
 public class PagingGuardTests
 {
@@ -117,24 +117,25 @@ public class PagingGuardTests
         Assert.Equal(0, requests());
     }
 
-    // The internal setters bypass the public guards, so the loop keeps its own.
+    // The internal setters bypass the public guards; a non-positive value must degrade
+    // to "no preference" instead of sending the server odata.maxpagesize=0.
     [Fact]
-    public async Task Non_Positive_Page_Size_Set_Internally_Still_Terminates()
+    public async Task Non_Positive_Page_Size_Set_Internally_Sends_No_Preference()
     {
-        var (client, requests) = Bounded();
+        string? preferHeader = null;
 
-        var options = new QueryOptions();
-        typeof(QueryOptions).GetProperty(nameof(QueryOptions.PageSize))!
-            .SetValue(options, 0);
-
-        Assert.Equal(0, options.PageSize);
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
+        {
+            preferHeader = req.Headers.TryGetValues("Prefer", out var v) ? string.Join(",", v) : null;
+            return TestBase.Json("{\"value\":[]}");
+        }));
 
         var result = await client.QueryAllAsync<TestEntity>(
             "orders",
             options: o => typeof(QueryOptions).GetProperty(nameof(QueryOptions.PageSize))!.SetValue(o, 0));
 
         Assert.Empty(result);
-        Assert.Equal(0, requests());
+        Assert.Null(preferHeader);
     }
 
     #endregion
@@ -151,7 +152,7 @@ public class PagingGuardTests
             dataCalls++;
 
             return dataCalls <= 2
-                ? TestBase.Json("{\"value\":[{\"no\":\"a\"},{\"no\":\"b\"}]}")
+                ? TestBase.Json($"{{\"value\":[{{\"no\":\"a{dataCalls}\"}},{{\"no\":\"b{dataCalls}\"}}],\"@odata.nextLink\":\"https://test/p{dataCalls + 1}\"}}")
                 : TestBase.Json("{\"value\":[{\"no\":\"c\"}]}");
         }));
 

--- a/test/Dynamics365.BusinessCentral.Tests/QueryBuilderTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/QueryBuilderTests.cs
@@ -235,7 +235,8 @@ public class QueryBuilderTests
         var client = TestBase.CreateClient(TestBase.WithToken(_ =>
         {
             requests++;
-            return TestBase.Json("{\"value\":[{\"no\":\"a\"},{\"no\":\"b\"}]}");
+            return TestBase.Json(
+                $"{{\"value\":[{{\"no\":\"a{requests}\"}},{{\"no\":\"b{requests}\"}}],\"@odata.nextLink\":\"https://test/p{requests + 1}\"}}");
         }));
 
         var seen = new List<string>();
@@ -256,8 +257,15 @@ public class QueryBuilderTests
     [Fact]
     public async Task Top_Caps_Results_Across_Pages()
     {
+        var call = 0;
+
         var client = TestBase.CreateClient(TestBase.WithToken(_ =>
-            TestBase.Json("{\"value\":[{\"no\":\"a\"},{\"no\":\"b\"}]}")));
+        {
+            call++;
+            return TestBase.Json(call == 1
+                ? "{\"value\":[{\"no\":\"a\"},{\"no\":\"b\"}],\"@odata.nextLink\":\"https://test/p2\"}"
+                : "{\"value\":[{\"no\":\"c\"},{\"no\":\"d\"}]}");
+        }));
 
         var all = await client.Query<SalesOrder>().PageSize(2).Top(3).ToAllAsync();
 

--- a/test/Dynamics365.BusinessCentral.Tests/RequestReplayTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/RequestReplayTests.cs
@@ -223,31 +223,30 @@ public class RequestReplayTests
     }
 
     [Fact]
-    public async Task QueryStreamAsync_Continues_Paging_From_The_Supplied_Skip()
+    public async Task QueryStreamAsync_Sends_The_Supplied_Skip_On_The_First_Request_Only()
     {
-        var skips = new List<string>();
+        var urls = new List<string>();
         var dataCalls = 0;
 
         var client = TestBase.CreateClient(TestBase.WithToken(req =>
         {
-            var query = new Uri(req.RequestUri!.AbsoluteUri).Query;
-            skips.Add(Uri.UnescapeDataString(query));
+            urls.Add(Uri.UnescapeDataString(req.RequestUri!.AbsoluteUri));
 
             dataCalls++;
 
             return dataCalls == 1
-                ? TestBase.Json("{\"value\":[{\"id\":1},{\"id\":2}]}")
-                : TestBase.Json("{\"value\":[]}");
+                ? TestBase.Json("{\"value\":[{\"id\":1},{\"id\":2}],\"@odata.nextLink\":\"https://test/p2\"}")
+                : TestBase.Json("{\"value\":[{\"id\":3}]}");
         }));
 
         var all = await client.QueryAllAsync<TestEntity>(
             "orders", options: o => o.WithPageSize(2).WithSkip(10));
 
-        Assert.Equal(2, all.Count);
-        Assert.Contains("$skip=10", skips[0]);
+        Assert.Equal(3, all.Count);
+        Assert.Contains("$skip=10", urls[0]);
 
-        // Second page continues from the offset rather than restarting.
-        Assert.Contains("$skip=12", skips[1]);
+        // Continuation is the server's cursor, not a client-computed offset.
+        Assert.Equal("https://test/p2", urls[1]);
     }
 
     #endregion


### PR DESCRIPTION
Implements N3 from `the nextLink findings (round four)` (round four, included with a validation addendum). Design probed against the live tenant **before** implementation, per the doc's own discipline:

| Probe | Result |
| --- | --- |
| No `$top`, no `Prefer` | ~20,000 rows + nextLink, continuation carries **no `$top`** (open cursor) |
| `Prefer: odata.maxpagesize=1000` | exactly 1,000 rows + nextLink |

## What changes

- **Default**: streaming reads send no page size at all — the deployment's own Max Page Size paces the stream, continuation via `@odata.nextLink` (`$skiptoken` cursor). A 118k-row sweep drops from 119 round trips to 6. `QueryPager.DefaultPageSize` (an invented number) is gone; so is the entire `$skip` loop and its offset-shift hazard.
- **`BusinessCentralOptions.MaxPageSize`** (new, nullable, default null) and `WithPageSize`/fluent `PageSize` now request *smaller* server pages via `Prefer: odata.maxpagesize` — clamped by the server, re-sent on every continuation (the preference is per request, not per cursor).
- **`WithTop` unchanged**: pure result cap, sent as `$top` (the server never over-serves a capped query), enforced client-side across continuations. N4's truncation hypothesis becomes unreachable — no code path smuggles a page size through `$top`.
- **Single-page reads never send the preference** — it would silently truncate them to the first server page. Pinned by test.
- `WithSkip` still honoured, as the first request's offset.

## Trade-off, documented

Default pages on SaaS are up to 20,000 rows per response (~large bodies buffered per page) versus the old 1,000-row pacing — that's the point (6 round trips against an API that throttles hard), and `MaxPageSize` is the knob for memory-constrained consumers. Documented in README + MIGRATION ("Auto-paging is server-driven").

## Tests

244 green: 8 paging tests rewritten from `$skip` scripting to nextLink scripting, plus new pins for the preference contract (no header by default, options-level default with per-query override, single-page exclusion, header re-sent on continuations, internal non-positive sizes degrade to no preference).

N4's one-request probe (follow the `$top=25000` remainder link) remains open for the record; it no longer gates anything.