### PR TITLE
Release 2.0.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0-alpha.5] - 2026-07-30
+
+**Prerelease.** The final validation build before 2.0.0 stable: server-driven paging from
+the round-four live-tenant measurements, the pre-stable hardening batch, and the closure
+of the last *Unverified* item. Every open item from four review rounds is now shipped,
+documented, or explicitly scheduled for 2.1.
+
 ### Changed
 
 - **Auto-paging is server-driven** (`QueryAllAsync`, `QueryStreamAsync`, fluent

--- a/src/Dynamics365.BusinessCentral.Testing/Dynamics365.BusinessCentral.Testing.csproj
+++ b/src/Dynamics365.BusinessCentral.Testing/Dynamics365.BusinessCentral.Testing.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>Dynamics365.BusinessCentral.Testing</PackageId>
-        <Version>2.0.0-alpha.4</Version>
+        <Version>2.0.0-alpha.5</Version>
         <Authors>Daniel Rückenbach</Authors>
         <Company>KRAL GmbH</Company>
 

--- a/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
+++ b/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>Dynamics365.BusinessCentral</PackageId>
-        <Version>2.0.0-alpha.4</Version>
+        <Version>2.0.0-alpha.5</Version>
         <Authors>Daniel Rückenbach</Authors>
         <Company>KRAL GmbH</Company>
 
@@ -35,13 +35,15 @@
         <!-- Shown on the nuget.org package page. Kept short and pointed at CHANGELOG.md
              rather than duplicated, since nuget.org renders this as plain text. -->
         <PackageReleaseNotes>
-            PRERELEASE — 2.0.0-alpha.4 incorporates the first live-tenant validation round.
+            PRERELEASE — 2.0.0-alpha.5 is the final validation build before 2.0.0 stable.
 
-            Filter.In now renders a same-field or-chain instead of the OData `in` operator,
-            which Business Central rejects without $schemaversion=2.1 (verified against a
-            live tenant). Also documented from live findings: `or` across different fields
-            is rejected by BC, `eq null` matches blank text fields, and Edm.Date fields are
-            date-only — model them as DateOnly.
+            Auto-paging is now server-driven, based on live-tenant measurement: no page
+            size is sent by default, Business Central pages at its own configured Max Page
+            Size and continuation follows @odata.nextLink ($skiptoken cursor — the $skip
+            loop is gone). BusinessCentralOptions.MaxPageSize and WithPageSize request
+            smaller pages via Prefer: odata.maxpagesize. Also: observer callbacks are
+            isolated, caller cancellation is no longer reported as a failure, and
+            Prefer: return=representation was verified against a live tenant.
 
             Breaking changes — see the migration guide before upgrading:
             https://github.com/KralGmbh/Dynamics365-BusinessCentral/blob/master/MIGRATION.md


### PR DESCRIPTION
Release prep for `2.0.0-alpha.5` — the final validation build before stable, carrying #50 (server-driven paging, hardening batch, `Prefer` verification).

- `<Version>` → `2.0.0-alpha.5` in both csprojs (lockstep, pack verified)
- CHANGELOG: `[Unreleased]` → `[2.0.0-alpha.5] - 2026-07-30`
- `<PackageReleaseNotes>` refreshed

Single unstacked PR — no post-squash sync dance this time. After merging:

```
gh release create v2.0.0-alpha.5 --prerelease --title "2.0.0-alpha.5"
```

Validation focus for the Bastion round: a big sweep (~6 round trips, `$skiptoken` continuations), memory at 20k-row default pages, one `Top(n)` capped query, one `MaxPageSize`/`WithPageSize` run. Clean round → `v2.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)