### PR TITLE
2.0.0-alpha.6: builder-inferred filters (F1), derived $select (F2), RequestTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0-alpha.6] - 2026-07-30
+
+**Prerelease.** The consumer-ergonomics round (F1/F2 from
+[FEATURE-REQUESTS-BASTION.md](FEATURE-REQUESTS-BASTION.md)), shipped ahead of the
+consumer's fluent-builder migration.
+
+### Added
+
+- **Builder-inferred filters (F1).** `Query<T>().Where(f => f.Equals(x => x.Status, "Open")
+  .And(f.GreaterThan(x => x.Amount, 100)))` — `IFilterBuilder<T>` mirrors every `Filter`
+  operator with the entity type fixed, forwarding to the existing typed overloads so
+  rendering is identical. The static form remains.
+- **`SelectAll()`** on the fluent builder: requests every column, suppressing the derived
+  projection below.
+- **`BusinessCentralOptions.RequestTimeout`** (nullable, default null = `HttpClient`'s
+  100s): per-attempt timeout for the data client on the DI path — no more re-registering
+  the named client just to set a timeout. Timeouts surface as
+  `BusinessCentralConnectionException` and retry under the normal rules.
+
+### Changed
+
+- **The fluent builder derives `$select` from the entity type (F2)** when neither
+  `Select(...)` nor `SelectAll()` is used: the settable scalar properties — the columns the
+  type can actually hold — resolved through the same rules as filters and deserialization,
+  ordinal-sorted for deterministic URLs. Navigation properties, get-only computed
+  properties, `[JsonIgnore]` and `@`-annotations are excluded; `CountAsync` sends no
+  `$select`. This can only **narrow** what is requested, so existing deserialization keeps
+  working — but note `$select` is case-sensitive server-side: latent `[JsonPropertyName]`
+  casing drift that deserialization tolerated now fails loudly. Path-based `QueryAsync` is
+  unchanged.
+
+### Documentation
+
+- README: builder-form `Where` as the leading example; derived-`$select` explanation; new
+  *"Mapping exceptions in message-level retry policies"* section (Wolverine/MassTransit/
+  Polly must key on `BusinessCentralConnectionException`/`BusinessCentralThrottledException`
+  or `IsTransient` — never `HttpRequestException`, which the client no longer lets escape).
+
 ## [2.0.0-alpha.5] - 2026-07-30
 
 **Prerelease.** The final validation build before 2.0.0 stable: server-driven paging from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,9 +85,9 @@ Note the quirk in `BuildQueryUrl`: a filter string of `"true"` is treated as "no
 
 ### Filters and typed field names
 
-`ODataFilter`'s constructor is `internal` — expressions can only be produced by `Filter` or `FilterExtensions`. New operators belong in those two files, and each needs **both** a string and an `Expression<Func<TEntity, object?>>` overload. `Filter.Format` handles type→OData literal conversion (invariant culture); extend it there when adding value types.
+`ODataFilter`'s constructor is `internal` — expressions can only be produced by `Filter`, `FilterExtensions` or `IFilterBuilder<T>` (the type-inferred form used inside `Query<T>().Where(f => ...)`; `FilterBuilder<T>` is a stateless per-closed-generic singleton that forwards to `Filter`'s typed overloads). New operators belong in `Filter`/`FilterExtensions` and need **three** surfaces kept in sync: a string overload, an `Expression<Func<TEntity, object?>>` overload, and the `IFilterBuilder<T>` member — the parity test in `FluentSelectAndFilterBuilderTests` fails if the builder lags. `Filter.Format` handles type→OData literal conversion (invariant culture); extend it there when adding value types.
 
-`PropertyPath.Resolve` turns a selector into a field name using `JsonPropertyNameAttribute` first, then `BusinessCentralJson.Options.PropertyNamingPolicy`. That coupling is the point: `$filter`/`$select`/`$orderby` names always match deserialization. It strips the compiler's boxing `Convert` and walks nested members into `a/b` navigation paths.
+`PropertyPath.Resolve` turns a selector into a field name using `JsonPropertyNameAttribute` first, then `BusinessCentralJson.Options.PropertyNamingPolicy`. `EntitySelect` derives the fluent builder's default `$select` (settable scalar props, no `[JsonIgnore]`, no `@`-names, ordinal-sorted) through the same `PropertyPath.ResolveName` — never re-implement the name rules. Explicit `Select(...)` wins; `SelectAll()` suppresses; `CountAsync` sends none. That coupling is the point: `$filter`/`$select`/`$orderby` names always match deserialization. It strips the compiler's boxing `Convert` and walks nested members into `a/b` navigation paths.
 
 ### Paging
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -146,6 +146,28 @@ now a result cap, as documented. A call like `QueryAllAsync(..., o => o.WithTop(
 that used to fetch *everything* in pages of 500 now returns at most 500 rows. Replace it
 with `WithPageSize(500)` to keep the old behaviour — see §3.
 
+### The fluent builder derives `$select` from the entity type
+
+A `Query<T>()` call with no explicit `Select(...)` used to request **every column**; it now
+sends a `$select` derived from `T`'s settable scalar properties — the columns the type can
+actually hold. This can only narrow the data requested, so anything that deserialized
+before still deserializes. `.SelectAll()` restores the full row for deliberately partial
+entity types. The path-based `QueryAsync(select:)` is unchanged.
+
+**One migration caveat:** `$select` is case-sensitive on the server while deserialization
+is not. A `[JsonPropertyName]` value whose casing drifts from `$metadata` worked silently
+before and now fails with a loud `400` naming the field — verify your wire names against
+`$metadata` once when adopting the fluent builder.
+
+### Message-level retry policies must re-key their exceptions
+
+An outer retry policy (Wolverine, MassTransit, Polly) keyed on `HttpRequestException`
+**silently stops matching** in 2.0: the client wraps transport failures in
+`BusinessCentralConnectionException`. Match that type (or `ex.IsTransient`), and give
+`BusinessCentralThrottledException` a slower curve — the client has already honoured
+`Retry-After` in-process. See the README's *"Mapping exceptions in message-level retry
+policies"* table.
+
 ### Kindless `DateTime` filters are no longer shifted by the machine's timezone
 
 1.0 passed every `DateTime` through `ToUniversalTime()`, which treats

--- a/README.md
+++ b/README.md
@@ -98,14 +98,26 @@ they survive renames and always match how the entity is deserialized.
 
 ```csharp
 var orders = await client.Query<SalesOrder>()
-    .Where(Filter.Equals<SalesOrder>(o => o.Status, "Open"))
-    .Where(Filter.GreaterThan<SalesOrder>(o => o.Amount, 100))
+    .Where(f => f.Equals(o => o.Status, "Open")
+                 .And(f.GreaterThan(o => o.Amount, 100)))
     .OrderByDescending(o => o.Amount)
     .ThenBy(o => o.No)
-    .Select(o => o.No, o => o.Amount)
     .Top(50)
     .ToListAsync();
 ```
+
+The `Where(f => ...)` builder infers the entity type from the query, so it is never
+restated per operator; the static `Filter.Equals<SalesOrder>(...)` form remains available
+and renders identically.
+
+**`$select` is derived from the entity by default**: the query above sends
+`$select=Sell_to_Customer_No,amount,no,status` — the settable scalar properties of
+`SalesOrder`, resolved exactly like deserialization. The entity class states the
+projection once; call sites stop restating it. An explicit `.Select(...)` narrows it,
+`.SelectAll()` requests every column. Two things to know: navigation properties and
+get-only computed properties are excluded automatically, and `$select` is
+**case-sensitive** on the server even though deserialization is not — a `[JsonPropertyName]`
+whose casing drifts from `$metadata` fails loudly here instead of silently deserializing.
 
 | Operation | Method |
 | --------- | ------ |
@@ -349,7 +361,27 @@ services.AddHttpClient(BusinessCentralHttpClients.Token).RemoveAllResilienceHand
 ```
 
 Exempting the token client is safe: token acquisition has its own retry under the same
-`Retry` options, so removing the outer handler does not leave it bare.
+`Retry` options, so removing the outer handler does not leave it bare. The per-attempt
+timeout of the data client is configurable via `options.RequestTimeout` (default: the
+`HttpClient` 100s) — budget `Retry.MaxAttempts × (RequestTimeout + backoff)` against any
+outer execution timeout.
+
+## Mapping exceptions in message-level retry policies
+
+If a message bus or job runner (Wolverine, MassTransit, Hangfire, Polly) retries around
+client calls, key its policies on this package's exception types — **not** on
+`HttpRequestException`, which the client never lets escape:
+
+| Match | Meaning | Suggested policy |
+| ----- | ------- | ---------------- |
+| `BusinessCentralConnectionException` | no response — connection failure / timeout (already retried in-process) | fast requeue curve |
+| `BusinessCentralThrottledException` | `429` — the client already honoured `Retry-After` | slow requeue curve |
+| `ex.IsTransient` | any retry-worthy failure | generic transient handling |
+| everything else | validation/auth/not-found — retrying cannot help | dead-letter / alert |
+
+A policy keyed on `HttpRequestException` written for 1.x **silently stops matching** on
+2.0 — transport failures surface as `BusinessCentralConnectionException` with the original
+exception as `InnerException`.
 
 Disabling the package's retry instead (`options.Retry.Enabled = false`) also resolves the
 composition, but leaves the generic outer handler in charge — including its unsafe `POST`

--- a/src/Dynamics365.BusinessCentral.Testing/Dynamics365.BusinessCentral.Testing.csproj
+++ b/src/Dynamics365.BusinessCentral.Testing/Dynamics365.BusinessCentral.Testing.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>Dynamics365.BusinessCentral.Testing</PackageId>
-        <Version>2.0.0-alpha.5</Version>
+        <Version>2.0.0-alpha.6</Version>
         <Authors>Daniel Rückenbach</Authors>
         <Company>KRAL GmbH</Company>
 

--- a/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
+++ b/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>Dynamics365.BusinessCentral</PackageId>
-        <Version>2.0.0-alpha.5</Version>
+        <Version>2.0.0-alpha.6</Version>
         <Authors>Daniel Rückenbach</Authors>
         <Company>KRAL GmbH</Company>
 
@@ -35,15 +35,15 @@
         <!-- Shown on the nuget.org package page. Kept short and pointed at CHANGELOG.md
              rather than duplicated, since nuget.org renders this as plain text. -->
         <PackageReleaseNotes>
-            PRERELEASE — 2.0.0-alpha.5 is the final validation build before 2.0.0 stable.
+            PRERELEASE — 2.0.0-alpha.6 adds the consumer-ergonomics round before 2.0.0
+            stable.
 
-            Auto-paging is now server-driven, based on live-tenant measurement: no page
-            size is sent by default, Business Central pages at its own configured Max Page
-            Size and continuation follows @odata.nextLink ($skiptoken cursor — the $skip
-            loop is gone). BusinessCentralOptions.MaxPageSize and WithPageSize request
-            smaller pages via Prefer: odata.maxpagesize. Also: observer callbacks are
-            isolated, caller cancellation is no longer reported as a failure, and
-            Prefer: return=representation was verified against a live tenant.
+            Query&lt;T&gt;().Where(f =&gt; ...) infers the entity type per operator; $select
+            is now derived from the entity's settable scalar properties by default
+            (SelectAll() opts out; explicit Select(...) still wins); and
+            BusinessCentralOptions.RequestTimeout configures the data client's per-attempt
+            timeout. The README documents how message-level retry policies should map this
+            package's exception types.
 
             Breaking changes — see the migration guide before upgrading:
             https://github.com/KralGmbh/Dynamics365-BusinessCentral/blob/master/MIGRATION.md

--- a/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
+++ b/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
@@ -222,7 +222,7 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
         // A count query returns no rows, so it needs no column list — skip the derived
         // $select rather than sending a pointless projection.
         var page = await _executor
-            .FetchPageAsync<TEntity>(_path, FilterValue, options, select: null, null, cancellationToken)
+            .FetchPageAsync<TEntity>(_path, FilterValue, options, select: null, maxPageSize: null, cancellationToken)
             .ConfigureAwait(false);
 
         if (page.Count is { } count)

--- a/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
+++ b/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
@@ -76,6 +76,8 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
 
     public IBusinessCentralQuery<TEntity> Select(params Expression<Func<TEntity, object?>>[] fields)
     {
+        _selectAll = false;
+
         foreach (var field in fields)
         {
             var name = PropertyPath.Resolve(field);
@@ -88,7 +90,10 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
 
     public IBusinessCentralQuery<TEntity> SelectAll()
     {
+        // Mutually exclusive with Select(...): the last call wins, so the builder's state
+        // is always one of explicit / all / derived — never an ambiguous mix.
         _selectAll = true;
+        _select.Clear();
         return this;
     }
 

--- a/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
+++ b/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
@@ -21,6 +21,7 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
     private readonly List<string> _select = [];
 
     private ODataFilter? _filter;
+    private bool _selectAll;
     private int? _top;
     private int? _skip;
     private int? _pageSize;
@@ -41,6 +42,13 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
 
     public IBusinessCentralQuery<TEntity> Where(string filter) =>
         string.IsNullOrWhiteSpace(filter) ? this : Where(new ODataFilter(filter));
+
+    public IBusinessCentralQuery<TEntity> Where(Func<IFilterBuilder<TEntity>, ODataFilter> build)
+    {
+        ArgumentNullException.ThrowIfNull(build);
+
+        return Where(build(FilterBuilder<TEntity>.Instance));
+    }
 
     public IBusinessCentralQuery<TEntity> OrderBy(Expression<Func<TEntity, object?>> field)
     {
@@ -75,6 +83,12 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
                 _select.Add(name);
         }
 
+        return this;
+    }
+
+    public IBusinessCentralQuery<TEntity> SelectAll()
+    {
+        _selectAll = true;
         return this;
     }
 
@@ -205,8 +219,10 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
         options.WithCount();
         options.Top = 0;
 
+        // A count query returns no rows, so it needs no column list — skip the derived
+        // $select rather than sending a pointless projection.
         var page = await _executor
-            .FetchPageAsync<TEntity>(_path, FilterValue, options, SelectOrNull, null, cancellationToken)
+            .FetchPageAsync<TEntity>(_path, FilterValue, options, select: null, null, cancellationToken)
             .ConfigureAwait(false);
 
         if (page.Count is { } count)
@@ -223,7 +239,14 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
 
     private string FilterValue => _filter?.Value ?? string.Empty;
 
-    private IEnumerable<string>? SelectOrNull => _select.Count == 0 ? null : _select;
+    /// <summary>
+    /// Explicit <c>Select(...)</c> wins; <c>SelectAll()</c> suppresses; otherwise the
+    /// projection is derived from the entity type (<see cref="EntitySelect"/>).
+    /// </summary>
+    private IEnumerable<string>? SelectOrNull =>
+        _select.Count > 0 ? _select
+        : _selectAll ? null
+        : EntitySelect.For<TEntity>() is { Length: > 0 } derived ? derived : null;
 
     private QueryOptions BuildOptions()
     {

--- a/src/Dynamics365.BusinessCentral/OData/EntitySelect.cs
+++ b/src/Dynamics365.BusinessCentral/OData/EntitySelect.cs
@@ -19,7 +19,8 @@ namespace Dynamics365.BusinessCentral.OData;
 /// <c>init</c>) — a get-only computed property cannot receive data and is not a column;</item>
 /// <item>scalar types only (value types and <see cref="string"/>, including nullables) —
 /// classes and collections are navigations, which belong in <c>$expand</c>;</item>
-/// <item>not <c>[JsonIgnore]</c>;</item>
+/// <item>not unconditionally <c>[JsonIgnore]</c> — conditional ignores such as
+/// <c>WhenWritingNull</c> still deserialize, so those properties remain columns;</item>
 /// <item>wire name not starting with <c>@</c> — <c>@odata.etag</c> and friends are
 /// annotations the server sends regardless, not selectable columns.</item>
 /// </list>

--- a/src/Dynamics365.BusinessCentral/OData/EntitySelect.cs
+++ b/src/Dynamics365.BusinessCentral/OData/EntitySelect.cs
@@ -1,0 +1,55 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text.Json.Serialization;
+
+namespace Dynamics365.BusinessCentral.OData;
+
+/// <summary>
+/// Derives the default <c>$select</c> list for an entity type: the wire names of the
+/// columns the type can actually hold. Used by the fluent builder when a query specifies
+/// neither <c>Select(...)</c> nor <c>SelectAll()</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Inclusion is deliberately strict — every included name is sent to the server, and a
+/// name that is not a real column fails the query with a <c>400</c>:
+/// </para>
+/// <list type="bullet">
+/// <item>public instance properties, readable <b>and settable</b> (<c>set</c> or
+/// <c>init</c>) — a get-only computed property cannot receive data and is not a column;</item>
+/// <item>scalar types only (value types and <see cref="string"/>, including nullables) —
+/// classes and collections are navigations, which belong in <c>$expand</c>;</item>
+/// <item>not <c>[JsonIgnore]</c>;</item>
+/// <item>wire name not starting with <c>@</c> — <c>@odata.etag</c> and friends are
+/// annotations the server sends regardless, not selectable columns.</item>
+/// </list>
+/// <para>
+/// Names resolve through <see cref="PropertyPath.ResolveName"/> — the same rules as
+/// filters, ordering and deserialization — and are sorted ordinally so the emitted URL is
+/// deterministic. Note that <c>$select</c> is case-<b>sensitive</b> on the server even
+/// though deserialization is not: a <c>[JsonPropertyName]</c> whose casing drifts from
+/// <c>$metadata</c> deserializes fine today but fails loudly here. That is this feature
+/// surfacing latent drift, not creating it.
+/// </para>
+/// </remarks>
+internal static class EntitySelect
+{
+    private static readonly ConcurrentDictionary<Type, string[]> _cache = new();
+
+    public static string[] For<TEntity>() => _cache.GetOrAdd(typeof(TEntity), static type =>
+        type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && p.GetIndexParameters().Length == 0)
+            .Where(p => p.SetMethod is { IsPublic: true })
+            .Where(p => IsScalar(p.PropertyType))
+            .Where(p => p.GetCustomAttribute<JsonIgnoreAttribute>() is not { Condition: JsonIgnoreCondition.Always })
+            .Select(PropertyPath.ResolveName)
+            .Where(name => !name.StartsWith('@'))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray());
+
+    private static bool IsScalar(Type type)
+    {
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+        return underlying.IsValueType || underlying == typeof(string);
+    }
+}

--- a/src/Dynamics365.BusinessCentral/OData/IBusinessCentralQuery.cs
+++ b/src/Dynamics365.BusinessCentral/OData/IBusinessCentralQuery.cs
@@ -62,7 +62,8 @@ public interface IBusinessCentralQuery<TEntity>
     /// <summary>
     /// Requests every column (<b>no</b> <c>$select</c>), suppressing the derived
     /// projection — for deliberately partial entity types where the full row is wanted,
-    /// e.g. for diagnostics.
+    /// e.g. for diagnostics. Mutually exclusive with <see cref="Select"/>: whichever was
+    /// called last wins.
     /// </summary>
     IBusinessCentralQuery<TEntity> SelectAll();
 

--- a/src/Dynamics365.BusinessCentral/OData/IBusinessCentralQuery.cs
+++ b/src/Dynamics365.BusinessCentral/OData/IBusinessCentralQuery.cs
@@ -28,6 +28,16 @@ public interface IBusinessCentralQuery<TEntity>
     /// <summary>Adds a raw OData <c>$filter</c> expression, combined using <c>and</c>.</summary>
     IBusinessCentralQuery<TEntity> Where(string filter);
 
+    /// <summary>
+    /// Adds a filter built with the entity type already inferred — no type argument to
+    /// restate per operator:
+    /// <code>
+    /// .Where(f =&gt; f.Equals(x =&gt; x.Status, "Open").And(f.GreaterThan(x =&gt; x.Amount, 100)))
+    /// </code>
+    /// Combined with any existing filter using <c>and</c>, exactly like the other overloads.
+    /// </summary>
+    IBusinessCentralQuery<TEntity> Where(Func<IFilterBuilder<TEntity>, ODataFilter> build);
+
     /// <summary>Orders ascending, replacing any ordering set so far.</summary>
     IBusinessCentralQuery<TEntity> OrderBy(Expression<Func<TEntity, object?>> field);
 
@@ -40,8 +50,21 @@ public interface IBusinessCentralQuery<TEntity>
     /// <summary>Appends a descending sort key.</summary>
     IBusinessCentralQuery<TEntity> ThenByDescending(Expression<Func<TEntity, object?>> field);
 
-    /// <summary>Restricts the returned fields (<c>$select</c>).</summary>
+    /// <summary>
+    /// Restricts the returned fields (<c>$select</c>). When neither this nor
+    /// <see cref="SelectAll"/> is called, <c>$select</c> is <b>derived from
+    /// <typeparamref name="TEntity"/></b>: its settable scalar properties, resolved to
+    /// wire names the same way filters and deserialization are. The entity class states
+    /// the projection once — call sites stop restating it.
+    /// </summary>
     IBusinessCentralQuery<TEntity> Select(params Expression<Func<TEntity, object?>>[] fields);
+
+    /// <summary>
+    /// Requests every column (<b>no</b> <c>$select</c>), suppressing the derived
+    /// projection — for deliberately partial entity types where the full row is wanted,
+    /// e.g. for diagnostics.
+    /// </summary>
+    IBusinessCentralQuery<TEntity> SelectAll();
 
     /// <summary>Expands navigation properties (<c>$expand</c>).</summary>
     IBusinessCentralQuery<TEntity> Expand(params Expression<Func<TEntity, object?>>[] fields);

--- a/src/Dynamics365.BusinessCentral/OData/IFilterBuilder.cs
+++ b/src/Dynamics365.BusinessCentral/OData/IFilterBuilder.cs
@@ -1,0 +1,120 @@
+using System.Linq.Expressions;
+
+namespace Dynamics365.BusinessCentral.OData;
+
+/// <summary>
+/// <see cref="Filter"/>'s operator set with the entity type already fixed, so a query does
+/// not restate its type argument at every operator. Obtained inside
+/// <c>Query&lt;T&gt;().Where(f =&gt; ...)</c>:
+/// <code>
+/// client.Query&lt;SalesOrder&gt;()
+///     .Where(f =&gt; f.Equals(x =&gt; x.Status, "Open")
+///                  .And(f.GreaterThan(x =&gt; x.Amount, 100)))
+/// </code>
+/// Every method forwards to the corresponding <see cref="Filter"/> overload and returns the
+/// same <see cref="ODataFilter"/>, so <c>.And</c>/<c>.Or</c>/<c>.Not</c> composition and
+/// rendering are identical to the static form.
+/// </summary>
+/// <typeparam name="TEntity">Entity type the enclosing query is bound to.</typeparam>
+public interface IFilterBuilder<TEntity>
+{
+    /// <inheritdoc cref="Filter.Equals{TEntity}(Expression{Func{TEntity, object?}}, object?)"/>
+    ODataFilter Equals(Expression<Func<TEntity, object?>> field, object? value);
+
+    /// <inheritdoc cref="Filter.NotEquals{TEntity}(Expression{Func{TEntity, object?}}, object?)"/>
+    ODataFilter NotEquals(Expression<Func<TEntity, object?>> field, object? value);
+
+    /// <inheritdoc cref="Filter.GreaterThan{TEntity}(Expression{Func{TEntity, object?}}, object)"/>
+    ODataFilter GreaterThan(Expression<Func<TEntity, object?>> field, object value);
+
+    /// <inheritdoc cref="Filter.GreaterOrEqual{TEntity}(Expression{Func{TEntity, object?}}, object)"/>
+    ODataFilter GreaterOrEqual(Expression<Func<TEntity, object?>> field, object value);
+
+    /// <inheritdoc cref="Filter.LessThan{TEntity}(Expression{Func{TEntity, object?}}, object)"/>
+    ODataFilter LessThan(Expression<Func<TEntity, object?>> field, object value);
+
+    /// <inheritdoc cref="Filter.LessOrEqual{TEntity}(Expression{Func{TEntity, object?}}, object)"/>
+    ODataFilter LessOrEqual(Expression<Func<TEntity, object?>> field, object value);
+
+    /// <inheritdoc cref="Filter.Contains{TEntity}(Expression{Func{TEntity, object?}}, string)"/>
+    ODataFilter Contains(Expression<Func<TEntity, object?>> field, string value);
+
+    /// <inheritdoc cref="Filter.StartsWith{TEntity}(Expression{Func{TEntity, object?}}, string)"/>
+    ODataFilter StartsWith(Expression<Func<TEntity, object?>> field, string value);
+
+    /// <inheritdoc cref="Filter.EndsWith{TEntity}(Expression{Func{TEntity, object?}}, string)"/>
+    ODataFilter EndsWith(Expression<Func<TEntity, object?>> field, string value);
+
+    /// <inheritdoc cref="Filter.In{TEntity}(Expression{Func{TEntity, object?}}, object[])"/>
+    ODataFilter In(Expression<Func<TEntity, object?>> field, params object[] values);
+
+    /// <inheritdoc cref="Filter.In{TEntity}(Expression{Func{TEntity, object?}}, IEnumerable{object})"/>
+    ODataFilter In(Expression<Func<TEntity, object?>> field, IEnumerable<object> values);
+
+    /// <inheritdoc cref="Filter.IsNull{TEntity}(Expression{Func{TEntity, object?}})"/>
+    ODataFilter IsNull(Expression<Func<TEntity, object?>> field);
+
+    /// <inheritdoc cref="Filter.IsNotNull{TEntity}(Expression{Func{TEntity, object?}})"/>
+    ODataFilter IsNotNull(Expression<Func<TEntity, object?>> field);
+
+    /// <inheritdoc cref="Filter.All"/>
+    ODataFilter All { get; }
+
+    /// <inheritdoc cref="Filter.None"/>
+    ODataFilter None { get; }
+}
+
+/// <summary>
+/// The stateless forwarding implementation — one cached instance per closed generic.
+/// </summary>
+internal sealed class FilterBuilder<TEntity> : IFilterBuilder<TEntity>
+{
+    public static readonly FilterBuilder<TEntity> Instance = new();
+
+    private FilterBuilder()
+    {
+    }
+
+    public ODataFilter Equals(Expression<Func<TEntity, object?>> field, object? value) =>
+        Filter.Equals(field, value);
+
+    public ODataFilter NotEquals(Expression<Func<TEntity, object?>> field, object? value) =>
+        Filter.NotEquals(field, value);
+
+    public ODataFilter GreaterThan(Expression<Func<TEntity, object?>> field, object value) =>
+        Filter.GreaterThan(field, value);
+
+    public ODataFilter GreaterOrEqual(Expression<Func<TEntity, object?>> field, object value) =>
+        Filter.GreaterOrEqual(field, value);
+
+    public ODataFilter LessThan(Expression<Func<TEntity, object?>> field, object value) =>
+        Filter.LessThan(field, value);
+
+    public ODataFilter LessOrEqual(Expression<Func<TEntity, object?>> field, object value) =>
+        Filter.LessOrEqual(field, value);
+
+    public ODataFilter Contains(Expression<Func<TEntity, object?>> field, string value) =>
+        Filter.Contains(field, value);
+
+    public ODataFilter StartsWith(Expression<Func<TEntity, object?>> field, string value) =>
+        Filter.StartsWith(field, value);
+
+    public ODataFilter EndsWith(Expression<Func<TEntity, object?>> field, string value) =>
+        Filter.EndsWith(field, value);
+
+    public ODataFilter In(Expression<Func<TEntity, object?>> field, params object[] values) =>
+        Filter.In(field, values);
+
+    public ODataFilter In(Expression<Func<TEntity, object?>> field, IEnumerable<object> values) =>
+        Filter.In(field, values);
+
+    public ODataFilter IsNull(Expression<Func<TEntity, object?>> field) =>
+        Filter.IsNull(field);
+
+    public ODataFilter IsNotNull(Expression<Func<TEntity, object?>> field) =>
+        Filter.IsNotNull(field);
+
+    public ODataFilter All => Filter.All;
+
+    public ODataFilter None => Filter.None;
+}

--- a/src/Dynamics365.BusinessCentral/OData/PropertyPath.cs
+++ b/src/Dynamics365.BusinessCentral/OData/PropertyPath.cs
@@ -53,7 +53,13 @@ internal static class PropertyPath
             ? unary.Operand
             : expression;
 
-    private static string ResolveName(MemberInfo member) => _cache.GetOrAdd(member, static m =>
+    /// <summary>
+    /// Resolves a member to its wire name — <see cref="JsonPropertyNameAttribute"/> first,
+    /// then the shared naming policy. Internal so <c>EntitySelect</c> derives
+    /// <c>$select</c> lists through the exact same rules; a second implementation would
+    /// drift.
+    /// </summary>
+    internal static string ResolveName(MemberInfo member) => _cache.GetOrAdd(member, static m =>
     {
         var attribute = m.GetCustomAttribute<JsonPropertyNameAttribute>(inherit: true);
 

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptions.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptions.cs
@@ -65,6 +65,21 @@ public sealed class BusinessCentralOptions
     /// </remarks>
     public int? MaxPageSize { get; set; }
 
+    /// <summary>
+    /// Per-attempt timeout applied to the data <see cref="HttpClient"/> registered by
+    /// <c>AddBusinessCentral</c>. Defaults to <see langword="null"/> — the
+    /// <see cref="HttpClient"/> default of 100 seconds. A timeout surfaces as
+    /// <c>BusinessCentralConnectionException</c> and is retried under the normal replay
+    /// rules.
+    /// </summary>
+    /// <remarks>
+    /// Applies per attempt, not per logical call — budget for
+    /// <c>Retry.MaxAttempts × (RequestTimeout + backoff)</c> when composing with an outer
+    /// execution timeout. Only honoured on the DI registration path; a manually
+    /// constructed client owns its <see cref="HttpClient"/> and its timeout.
+    /// </remarks>
+    public TimeSpan? RequestTimeout { get; set; }
+
     /// <summary><see cref="BaseUrl"/> with all placeholders substituted.</summary>
     internal string ResolvedBaseUrl => ResolvePlaceholders(BaseUrl);
 

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptionsValidator.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptionsValidator.cs
@@ -39,8 +39,7 @@ internal sealed class BusinessCentralOptionsValidator : IValidateOptions<Busines
         {
             failures.Add(
                 $"{nameof(BusinessCentralOptions)}.{nameof(options.RequestTimeout)} must be positive " +
-                $"and at most {TimeSpan.FromMilliseconds(int.MaxValue).TotalDays:F1} days " +
-                "(HttpClient's maximum) when set.");
+                "and at most int.MaxValue milliseconds (~24.8 days, HttpClient's maximum) when set.");
         }
 
         return failures.Count == 0

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptionsValidator.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptionsValidator.cs
@@ -31,6 +31,9 @@ internal sealed class BusinessCentralOptionsValidator : IValidateOptions<Busines
         if (options.MaxPageSize is < 1)
             failures.Add($"{nameof(BusinessCentralOptions)}.{nameof(options.MaxPageSize)} must be at least 1 when set.");
 
+        if (options.RequestTimeout is { } timeout && timeout <= TimeSpan.Zero)
+            failures.Add($"{nameof(BusinessCentralOptions)}.{nameof(options.RequestTimeout)} must be positive when set.");
+
         return failures.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(failures);

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptionsValidator.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptionsValidator.cs
@@ -31,8 +31,17 @@ internal sealed class BusinessCentralOptionsValidator : IValidateOptions<Busines
         if (options.MaxPageSize is < 1)
             failures.Add($"{nameof(BusinessCentralOptions)}.{nameof(options.MaxPageSize)} must be at least 1 when set.");
 
-        if (options.RequestTimeout is { } timeout && timeout <= TimeSpan.Zero)
-            failures.Add($"{nameof(BusinessCentralOptions)}.{nameof(options.RequestTimeout)} must be positive when set.");
+        // Upper bound matches HttpClient.Timeout's own maximum (int.MaxValue ms, ~24.8
+        // days) — a larger value would pass here and then throw as a bare
+        // ArgumentOutOfRangeException when the client is created.
+        if (options.RequestTimeout is { } timeout &&
+            (timeout <= TimeSpan.Zero || timeout > TimeSpan.FromMilliseconds(int.MaxValue)))
+        {
+            failures.Add(
+                $"{nameof(BusinessCentralOptions)}.{nameof(options.RequestTimeout)} must be positive " +
+                $"and at most {TimeSpan.FromMilliseconds(int.MaxValue).TotalDays:F1} days " +
+                "(HttpClient's maximum) when set.");
+        }
 
         return failures.Count == 0
             ? ValidateOptionsResult.Success

--- a/src/Dynamics365.BusinessCentral/README.md
+++ b/src/Dynamics365.BusinessCentral/README.md
@@ -98,14 +98,26 @@ they survive renames and always match how the entity is deserialized.
 
 ```csharp
 var orders = await client.Query<SalesOrder>()
-    .Where(Filter.Equals<SalesOrder>(o => o.Status, "Open"))
-    .Where(Filter.GreaterThan<SalesOrder>(o => o.Amount, 100))
+    .Where(f => f.Equals(o => o.Status, "Open")
+                 .And(f.GreaterThan(o => o.Amount, 100)))
     .OrderByDescending(o => o.Amount)
     .ThenBy(o => o.No)
-    .Select(o => o.No, o => o.Amount)
     .Top(50)
     .ToListAsync();
 ```
+
+The `Where(f => ...)` builder infers the entity type from the query, so it is never
+restated per operator; the static `Filter.Equals<SalesOrder>(...)` form remains available
+and renders identically.
+
+**`$select` is derived from the entity by default**: the query above sends
+`$select=Sell_to_Customer_No,amount,no,status` — the settable scalar properties of
+`SalesOrder`, resolved exactly like deserialization. The entity class states the
+projection once; call sites stop restating it. An explicit `.Select(...)` narrows it,
+`.SelectAll()` requests every column. Two things to know: navigation properties and
+get-only computed properties are excluded automatically, and `$select` is
+**case-sensitive** on the server even though deserialization is not — a `[JsonPropertyName]`
+whose casing drifts from `$metadata` fails loudly here instead of silently deserializing.
 
 | Operation | Method |
 | --------- | ------ |
@@ -349,7 +361,27 @@ services.AddHttpClient(BusinessCentralHttpClients.Token).RemoveAllResilienceHand
 ```
 
 Exempting the token client is safe: token acquisition has its own retry under the same
-`Retry` options, so removing the outer handler does not leave it bare.
+`Retry` options, so removing the outer handler does not leave it bare. The per-attempt
+timeout of the data client is configurable via `options.RequestTimeout` (default: the
+`HttpClient` 100s) — budget `Retry.MaxAttempts × (RequestTimeout + backoff)` against any
+outer execution timeout.
+
+## Mapping exceptions in message-level retry policies
+
+If a message bus or job runner (Wolverine, MassTransit, Hangfire, Polly) retries around
+client calls, key its policies on this package's exception types — **not** on
+`HttpRequestException`, which the client never lets escape:
+
+| Match | Meaning | Suggested policy |
+| ----- | ------- | ---------------- |
+| `BusinessCentralConnectionException` | no response — connection failure / timeout (already retried in-process) | fast requeue curve |
+| `BusinessCentralThrottledException` | `429` — the client already honoured `Retry-After` | slow requeue curve |
+| `ex.IsTransient` | any retry-worthy failure | generic transient handling |
+| everything else | validation/auth/not-found — retrying cannot help | dead-letter / alert |
+
+A policy keyed on `HttpRequestException` written for 1.x **silently stops matching** on
+2.0 — transport failures surface as `BusinessCentralConnectionException` with the original
+exception as `InnerException`.
 
 Disabling the package's retry instead (`options.Retry.Enabled = false`) also resolves the
 composition, but leaves the generic outer handler in charge — including its unsafe `POST`

--- a/src/Dynamics365.BusinessCentral/ServiceCollectionExtensions.cs
+++ b/src/Dynamics365.BusinessCentral/ServiceCollectionExtensions.cs
@@ -97,12 +97,19 @@ public static class ServiceCollectionExtensions
         // Explicit factory rather than ActivatorUtilities: the constructor taking the
         // token provider is internal and would otherwise not be selected.
         services.AddHttpClient<IBusinessCentralClient, BusinessCentralClient>(
-            ClientHttpClientName,
-            (http, sp) => new BusinessCentralClient(
-                http,
-                sp.GetRequiredService<IOptions<BusinessCentralOptions>>(),
-                sp.GetRequiredService<BusinessCentralTokenProvider>(),
-                sp.GetService<IBusinessCentralObserver>()));
+                ClientHttpClientName,
+                (http, sp) => new BusinessCentralClient(
+                    http,
+                    sp.GetRequiredService<IOptions<BusinessCentralOptions>>(),
+                    sp.GetRequiredService<BusinessCentralTokenProvider>(),
+                    sp.GetService<IBusinessCentralObserver>()))
+            // The one place the package configures the HttpClient — at registration, not
+            // on the pooled instance (the client itself never mutates it).
+            .ConfigureHttpClient((sp, http) =>
+            {
+                if (sp.GetRequiredService<IOptions<BusinessCentralOptions>>().Value.RequestTimeout is { } timeout)
+                    http.Timeout = timeout;
+            });
 
         return services;
     }

--- a/test/Dynamics365.BusinessCentral.Tests/FluentSelectAndFilterBuilderTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/FluentSelectAndFilterBuilderTests.cs
@@ -40,8 +40,8 @@ public class FluentSelectAndFilterBuilderTests
     [Fact]
     public void Derived_Select_Includes_Only_Settable_Scalar_Columns_Sorted_Ordinally()
     {
-        // Uppercase sorts before lowercase ordinally, so the attribute-renamed and
-        // policy-named fields interleave deterministically.
+        // Ordinal ordering keeps the mix of policy-named and attribute-renamed fields
+        // deterministic, so URL assertions never depend on reflection order.
         Assert.Equal(
             ["amount", "ccoSpecial", "no", "postingDate"],
             EntitySelect.For<ProjectionEntity>());
@@ -55,9 +55,34 @@ public class FluentSelectAndFilterBuilderTests
 
         await bc.Client.Query<SalesOrder>().ToListAsync();
 
+        // Ordinal sort puts the uppercase attribute name first — deterministic across
+        // naming sources.
         Assert.Contains(
             "$select=Sell_to_Customer_No,amount,no,status",
             bc.Requests.Single().DecodedPathAndQuery);
+    }
+
+    // Select(...) and SelectAll() are mutually exclusive; the last call wins.
+    [Fact]
+    public async Task SelectAll_After_Select_Wins()
+    {
+        using var bc = new FakeBusinessCentral();
+        bc.EnqueuePage<SalesOrder>();
+
+        await bc.Client.Query<SalesOrder>().Select(o => o.No).SelectAll().ToListAsync();
+
+        Assert.DoesNotContain("$select", bc.Requests.Single().PathAndQuery);
+    }
+
+    [Fact]
+    public async Task Select_After_SelectAll_Wins()
+    {
+        using var bc = new FakeBusinessCentral();
+        bc.EnqueuePage<SalesOrder>();
+
+        await bc.Client.Query<SalesOrder>().SelectAll().Select(o => o.No).ToListAsync();
+
+        Assert.Contains("$select=no", bc.Requests.Single().DecodedPathAndQuery);
     }
 
     [Fact]

--- a/test/Dynamics365.BusinessCentral.Tests/FluentSelectAndFilterBuilderTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/FluentSelectAndFilterBuilderTests.cs
@@ -1,0 +1,191 @@
+using Dynamics365.BusinessCentral.OData;
+using Dynamics365.BusinessCentral.Testing;
+using Dynamics365.BusinessCentral.Tests.Utils;
+using System.Text.Json.Serialization;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+/// <summary>
+/// Pins alpha.6's two features: F1 (builder-inferred filters — must render identically to
+/// the static <c>Filter.X&lt;T&gt;</c> form) and F2 (the fluent builder derives
+/// <c>$select</c> from the entity type unless told otherwise).
+/// </summary>
+public class FluentSelectAndFilterBuilderTests
+{
+    #region F2 — derived $select
+
+    /// <summary>Exercises every inclusion rule at once.</summary>
+    private sealed class ProjectionEntity
+    {
+        public string No { get; set; } = "";                       // settable scalar → in
+        public decimal? Amount { get; set; }                       // nullable scalar → in
+        public DateOnly PostingDate { get; init; }                 // init counts as settable → in
+
+        [JsonPropertyName("ccoSpecial")]
+        public string Renamed { get; set; } = "";                  // attribute wins → "ccoSpecial"
+
+        [JsonPropertyName("@odata.etag")]
+        public string ETag { get; set; } = "";                     // annotation → out
+
+        [JsonIgnore]
+        public string ClientOnly { get; set; } = "";               // ignored → out
+
+        public bool IsOpen => No.Length > 0;                       // get-only computed → out
+
+        public SalesOrderCustomer? Customer { get; set; }          // navigation class → out
+
+        public List<SalesOrderLine> Lines { get; set; } = [];      // collection → out
+    }
+
+    [Fact]
+    public void Derived_Select_Includes_Only_Settable_Scalar_Columns_Sorted_Ordinally()
+    {
+        // Uppercase sorts before lowercase ordinally, so the attribute-renamed and
+        // policy-named fields interleave deterministically.
+        Assert.Equal(
+            ["amount", "ccoSpecial", "no", "postingDate"],
+            EntitySelect.For<ProjectionEntity>());
+    }
+
+    [Fact]
+    public async Task Fluent_Query_Derives_Select_From_The_Entity_By_Default()
+    {
+        using var bc = new FakeBusinessCentral();
+        bc.EnqueuePage<SalesOrder>();
+
+        await bc.Client.Query<SalesOrder>().ToListAsync();
+
+        Assert.Contains(
+            "$select=Sell_to_Customer_No,amount,no,status",
+            bc.Requests.Single().DecodedPathAndQuery);
+    }
+
+    [Fact]
+    public async Task Explicit_Select_Overrides_The_Derived_Projection()
+    {
+        using var bc = new FakeBusinessCentral();
+        bc.EnqueuePage<SalesOrder>();
+
+        await bc.Client.Query<SalesOrder>().Select(o => o.No).ToListAsync();
+
+        var query = bc.Requests.Single().DecodedPathAndQuery;
+        Assert.Contains("$select=no", query);
+        Assert.DoesNotContain("amount", query);
+    }
+
+    [Fact]
+    public async Task SelectAll_Suppresses_The_Derived_Projection()
+    {
+        using var bc = new FakeBusinessCentral();
+        bc.EnqueuePage<SalesOrder>();
+
+        await bc.Client.Query<SalesOrder>().SelectAll().ToListAsync();
+
+        Assert.DoesNotContain("$select", bc.Requests.Single().DecodedPathAndQuery);
+    }
+
+    [Fact]
+    public async Task Derived_Select_Rides_The_First_Request_And_Continuations_Stay_Verbatim()
+    {
+        using var bc = new FakeBusinessCentral();
+        bc.EnqueuePage([new SalesOrder { No = "1" }], nextLink: "page2")
+          .EnqueuePage([new SalesOrder { No = "2" }]);
+
+        var all = await bc.Client.Query<SalesOrder>().ToAllAsync();
+
+        Assert.Equal(2, all.Count);
+        Assert.Contains("$select=", bc.Requests[0].PathAndQuery);
+
+        // The server's cursor is followed untouched — it carries $select server-side.
+        Assert.Equal("/page2", bc.Requests[1].PathAndQuery);
+    }
+
+    [Fact]
+    public async Task CountAsync_Sends_No_Select()
+    {
+        using var bc = new FakeBusinessCentral();
+        bc.EnqueueJson("{\"@odata.count\":7,\"value\":[]}");
+
+        var count = await bc.Client.Query<SalesOrder>().CountAsync();
+
+        Assert.Equal(7, count);
+        Assert.DoesNotContain("$select", bc.Requests.Single().PathAndQuery);
+    }
+
+    #endregion
+
+    #region F1 — builder-inferred filters
+
+    // The F1 acceptance criterion: a builder-composed filter renders identically to the
+    // equivalent static Filter.X<TEntity>(...) chain, operator by operator.
+    [Fact]
+    public void Builder_Operators_Render_Identically_To_The_Static_Form()
+    {
+        IFilterBuilder<SalesOrder> f = GetBuilder<SalesOrder>();
+
+        Assert.Equal(Filter.Equals<SalesOrder>(x => x.Status, "Open").Value, f.Equals(x => x.Status, "Open").Value);
+        Assert.Equal(Filter.NotEquals<SalesOrder>(x => x.Status, "Open").Value, f.NotEquals(x => x.Status, "Open").Value);
+        Assert.Equal(Filter.GreaterThan<SalesOrder>(x => x.Amount, 100).Value, f.GreaterThan(x => x.Amount, 100).Value);
+        Assert.Equal(Filter.GreaterOrEqual<SalesOrder>(x => x.Amount, 100).Value, f.GreaterOrEqual(x => x.Amount, 100).Value);
+        Assert.Equal(Filter.LessThan<SalesOrder>(x => x.Amount, 100).Value, f.LessThan(x => x.Amount, 100).Value);
+        Assert.Equal(Filter.LessOrEqual<SalesOrder>(x => x.Amount, 100).Value, f.LessOrEqual(x => x.Amount, 100).Value);
+        Assert.Equal(Filter.Contains<SalesOrder>(x => x.No, "10").Value, f.Contains(x => x.No, "10").Value);
+        Assert.Equal(Filter.StartsWith<SalesOrder>(x => x.No, "10").Value, f.StartsWith(x => x.No, "10").Value);
+        Assert.Equal(Filter.EndsWith<SalesOrder>(x => x.No, "10").Value, f.EndsWith(x => x.No, "10").Value);
+        Assert.Equal(Filter.In<SalesOrder>(x => x.No, "a", "b").Value, f.In(x => x.No, "a", "b").Value);
+        Assert.Equal(Filter.IsNull<SalesOrder>(x => x.Status).Value, f.IsNull(x => x.Status).Value);
+        Assert.Equal(Filter.IsNotNull<SalesOrder>(x => x.Status).Value, f.IsNotNull(x => x.Status).Value);
+        Assert.Equal(Filter.All.Value, f.All.Value);
+        Assert.Equal(Filter.None.Value, f.None.Value);
+    }
+
+    [Fact]
+    public async Task Where_With_Builder_Composes_And_Renders_End_To_End()
+    {
+        using var bc = new FakeBusinessCentral();
+        bc.EnqueuePage<SalesOrder>();
+
+        await bc.Client.Query<SalesOrder>()
+            .Where(f => f.Equals(x => x.Status, "Open")
+                         .And(f.GreaterThan(x => x.Amount, 100)))
+            .ToListAsync();
+
+        Assert.Contains(
+            "$filter=(status eq 'Open') and (amount gt 100)",
+            bc.Requests.Single().DecodedPathAndQuery);
+    }
+
+    [Fact]
+    public async Task Builder_Where_Combines_With_Existing_Filters_Using_And()
+    {
+        using var bc = new FakeBusinessCentral();
+        bc.EnqueuePage<SalesOrder>();
+
+        await bc.Client.Query<SalesOrder>()
+            .Where(Filter.Equals<SalesOrder>(x => x.Status, "Open"))
+            .Where(f => f.GreaterThan(x => x.Amount, 100))
+            .ToListAsync();
+
+        Assert.Contains(
+            "$filter=(status eq 'Open') and (amount gt 100)",
+            bc.Requests.Single().DecodedPathAndQuery);
+    }
+
+    private static IFilterBuilder<TEntity> GetBuilder<TEntity>()
+    {
+        IFilterBuilder<TEntity>? captured = null;
+
+        // The builder instance is only reachable through Where — capture it the way a
+        // consumer's lambda sees it.
+        using var bc = new FakeBusinessCentral();
+        bc.Client.Query<TEntity>("x").Where(f =>
+        {
+            captured = f;
+            return Filter.All;
+        });
+
+        return captured!;
+    }
+
+    #endregion
+}

--- a/test/Dynamics365.BusinessCentral.Tests/OptionsValidatorTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/OptionsValidatorTests.cs
@@ -1,0 +1,66 @@
+using Dynamics365.BusinessCentral.Options;
+
+namespace Dynamics365.BusinessCentral.Tests;
+
+/// <summary>
+/// Direct pins on <see cref="BusinessCentralOptionsValidator"/> for the numeric options —
+/// misconfiguration must fail as a named options error at startup, never as a bare
+/// runtime exception when the client is first created.
+/// </summary>
+public class OptionsValidatorTests
+{
+    private static BusinessCentralOptions Valid() => new()
+    {
+        TenantId = "tenant",
+        ClientId = "client",
+        ClientSecret = "secret",
+        Company = "Test",
+        BaseUrl = "https://test",
+        TokenEndpoint = "https://auth/{TenantId}"
+    };
+
+    private static IEnumerable<string> Failures(BusinessCentralOptions options) =>
+        new BusinessCentralOptionsValidator().Validate(null, options).Failures ?? [];
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void Non_Positive_RequestTimeout_Fails_Validation(int seconds)
+    {
+        var options = Valid();
+        options.RequestTimeout = TimeSpan.FromSeconds(seconds);
+
+        Assert.Contains(Failures(options), f => f.Contains(nameof(options.RequestTimeout)));
+    }
+
+    // HttpClient.Timeout throws above int.MaxValue milliseconds (~24.8 days); the
+    // validator must reject it first with a message naming the option.
+    [Fact]
+    public void RequestTimeout_Above_HttpClient_Maximum_Fails_Validation()
+    {
+        var options = Valid();
+        options.RequestTimeout = TimeSpan.FromDays(25);
+
+        Assert.Contains(Failures(options), f => f.Contains(nameof(options.RequestTimeout)));
+    }
+
+    [Fact]
+    public void Reasonable_RequestTimeout_Passes()
+    {
+        var options = Valid();
+        options.RequestTimeout = TimeSpan.FromSeconds(60);
+
+        Assert.DoesNotContain(Failures(options), f => f.Contains(nameof(options.RequestTimeout)));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Non_Positive_MaxPageSize_Fails_Validation(int value)
+    {
+        var options = Valid();
+        options.MaxPageSize = value;
+
+        Assert.Contains(Failures(options), f => f.Contains(nameof(options.MaxPageSize)));
+    }
+}

--- a/test/Dynamics365.BusinessCentral.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ServiceCollectionExtensionsTests.cs
@@ -186,6 +186,36 @@ public class ServiceCollectionExtensionsTests
         Assert.Equal(1, tokenCalls);
     }
 
+    [Fact]
+    public void RequestTimeout_Is_Applied_To_The_Data_Client()
+    {
+        var services = new ServiceCollection();
+        services.AddBusinessCentral(options =>
+        {
+            DefaultOptions(options);
+            options.RequestTimeout = TimeSpan.FromSeconds(60);
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+
+        Assert.Equal(TimeSpan.FromSeconds(60),
+            factory.CreateClient(BusinessCentralHttpClients.Client).Timeout);
+    }
+
+    [Fact]
+    public void RequestTimeout_Defaults_To_The_HttpClient_Default()
+    {
+        var services = new ServiceCollection();
+        services.AddBusinessCentral(DefaultOptions);
+
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+
+        Assert.Equal(TimeSpan.FromSeconds(100),
+            factory.CreateClient(BusinessCentralHttpClients.Client).Timeout);
+    }
+
     private class TestObserver : IBusinessCentralObserver
     {
         public void OnRequestStarting(BusinessCentralRequestInfo info) { }

--- a/test/Dynamics365.BusinessCentral.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ServiceCollectionExtensionsTests.cs
@@ -212,7 +212,9 @@ public class ServiceCollectionExtensionsTests
         using var provider = services.BuildServiceProvider();
         var factory = provider.GetRequiredService<IHttpClientFactory>();
 
-        Assert.Equal(TimeSpan.FromSeconds(100),
+        // Whatever the framework default is — not a hard-coded 100s.
+        using var reference = new HttpClient();
+        Assert.Equal(reference.Timeout,
             factory.CreateClient(BusinessCentralHttpClients.Client).Timeout);
     }
 


### PR DESCRIPTION
The consumer-ergonomics round from `the feature requests (round five)`, shipped ahead of the consumer's fluent-builder migration. Feature + release prep in one PR — merge, then `gh release create v2.0.0-alpha.6 --prerelease`.

## F1 — builder-inferred filters
`Query<T>().Where(f => f.Equals(x => x.Status, "Open").And(f.GreaterThan(x => x.Amount, 100)))` — `IFilterBuilder<T>` mirrors every `Filter` operator (incl. `In`, `IsNull`, `IsNotNull`, `All`/`None`) with the type fixed, forwarding to the existing typed overloads. Operator-parity test pins identical rendering; new operators now have a three-surface sync rule recorded in CLAUDE.md.

## F2 — derived `$select` (fluent only; behaviour change)
No `Select(...)` and no `SelectAll()` → `$select` derives from the entity's **settable scalar** properties (tightened from the original proposal: get-only computed properties are excluded via the setter rule, killing the main 400 vector; classes/collections excluded as navigations; `[JsonIgnore]`/`@`-names out; ordinal-sorted for deterministic URLs). Explicit `Select` wins, `SelectAll()` opts out, `CountAsync` sends none, path-based API unchanged. Narrowing-only, so existing deserialization keeps working. **Documented caveat**: `$select` is case-sensitive server-side — latent `[JsonPropertyName]` casing drift (e.g. a `systemId` vs `SystemId` mismatch) now fails loudly instead of deserializing silently. MIGRATION tells adopters to verify wire names against `$metadata` once.

## `BusinessCentralOptions.RequestTimeout`
Per-attempt timeout for the DI-registered data client (default null = 100s), applied via `ConfigureHttpClient` at registration — replaces the consumer pattern of re-registering the named client. Validated positive; timeouts surface as `BusinessCentralConnectionException`.

## Docs
README (both): builder `Where` as the leading form, derived-`$select` paragraph, and a new **"Mapping exceptions in message-level retry policies"** table for Wolverine/MassTransit/Polly consumers — the silent-policy-gap fix from the consumer's field report. MIGRATION: F2 + retry re-keying entries. CHANGELOG rolled to `[2.0.0-alpha.6]`; both csprojs bumped in lockstep (pack verified).

## Tests
258 green (11 new): `EntitySelect` inclusion-rule matrix on a purpose-built entity, derived/override/opt-out/`CountAsync` URL pins through `FakeBusinessCentral`, multi-page derived-select with verbatim continuation, F1 operator parity + end-to-end composition, `RequestTimeout` application + default.