### PR TITLE
2.0.0-rc.1: external review fixes, API freeze, release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,116 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0-rc.1] - 2026-08-05
+
+**Release candidate.** The 2.0.0 surface, frozen — no further API changes are planned before
+stable, and both packages now fail their own `pack` on a breaking change (see *Added* below).
+What remains before `2.0.0` is validation, not development: exercise this against a real
+tenant and report anything that contradicts the documentation.
+
+Six findings from an external full-solution review, all confirmed against the code before
+being fixed. Two of them — the company-name escaping and the swallowed token `404` — are
+correctness bugs that produce a wrong answer rather than an error.
+
+### Added
+
+- **`BusinessCentralProtocolException`** and the `IsProtocolViolation` predicate. Raised when
+  the client refuses to act on a continuation: see *Security* and *Fixed* below. `StatusCode`
+  is `0` and `Method` is empty, like `BusinessCentralUrlTooLongException` — both are refusals
+  to send rather than results of sending. `RequestUrl` carries the offending `@odata.nextLink`.
+
+- **`BusinessCentralException.IsTokenAcquisitionFailure`**, `true` when a failure came from the
+  OAuth2 token endpoint rather than from Business Central. Both report through the same
+  hierarchy, so nothing could previously tell them apart.
+
+### Security
+
+- **An `@odata.nextLink` is followed only on the configured service origin.** Continuations are
+  the one URL the client sends that it did not build: they go out verbatim and, like every
+  request, carry the bearer token. A response naming `https://attacker.example/page` would
+  therefore have disclosed the token to whoever answered there, and made the client fetch any
+  host the response chose. Scheme, host and port must now match
+  `BusinessCentralOptions.ResolvedBaseUrl`, or a `BusinessCentralProtocolException` is thrown
+  before the request is sent.
+
+  Origin, not prefix — the path is deliberately not compared, because a continuation
+  legitimately differs from the request path. Matching the scheme is what stops an `https`
+  deployment being talked down to `http`; a base URL that is itself `http` (on-premises, or a
+  test service) is left alone rather than broken by a rule its deployment never opted into.
+  Business Central issues continuations on the origin it was asked, so this costs nothing real.
+
+### Fixed
+
+- **Company names containing an apostrophe produced an unparseable URL.** The company was
+  percent-encoded but never escaped as an OData string literal first, so `O'Brien Ltd` became
+  `Company('O%27Brien Ltd')` — and `%27` decodes to a bare quote before the OData parser sees
+  it, ending the literal at the wrong place. The quote is now doubled first and encoded second:
+  `Company('O%27%27Brien%20Ltd')`. Affects the configured `Company`, `ForCompany(...)` and any
+  name returned by `GetCompaniesAsync`. Every request from such a tenant failed.
+
+- **`GetAsync` no longer swallows a `404` from the token endpoint.** Its `try` spans token
+  acquisition as well as the entity request, and the token provider reports through the same
+  exception hierarchy — so a misconfigured `TokenEndpoint` answering `404` was read as "no such
+  entity" and returned as `null`. Every read came back silently empty, with nothing thrown to
+  say authentication had never happened. Only a `404` from the entity request itself is
+  swallowed now; the entity's own `404` is still a `null`, which is the point of the catch.
+
+- **A continuation cursor that repeats now throws instead of looping.** The no-progress guard
+  required an *empty* page, on the stated reasoning that a repeated cursor carrying rows was
+  legitimate. It is not: re-fetching it returns the page already emitted, so an uncapped
+  `StreamAsync`/`ToAllAsync` repeated those rows forever. Every cursor followed is now tracked,
+  which also catches cycles longer than one (`A → B → A`), and a repeat throws
+  `BusinessCentralProtocolException`. Empty repeated pages throw too: a nextLink asserts that
+  continuation remains, so stopping quietly would report a potentially truncated result as
+  success.
+
+- **`CountAsync` answers the same number on both paths.** The server path sends `$top=0` and
+  gets the count of everything the filter matches, because `$count` is independent of the page
+  window; the walk-the-collection fallback — used when an endpoint ignores `$count` — reapplied
+  the builder's `Top` and `Skip`. `.Top(10).CountAsync()` therefore returned the full total on
+  one endpoint and `10` on another. The fallback now walks unpaged. **`Top` and `Skip` do not
+  narrow a count**, on either path.
+
+- **A malformed `200` from the token endpoint stays inside the exception contract.** Unparseable
+  JSON threw a raw `JsonException`, straight through the documented
+  `catch (BusinessCentralException)`; a well-formed body carrying no `access_token` was cached
+  as an empty string and then sent as a bare `Bearer` header, surfacing as a `401` loop that
+  blamed Business Central for what the token endpoint did. Both are now a
+  `BusinessCentralServerException` carrying the endpoint, and neither is cached. The raw token
+  response is deliberately omitted from exceptions and observer events because malformed JSON
+  can still contain access, refresh or ID tokens that must not enter logs. That redaction is
+  scoped to the success path: a non-2xx from the token endpoint still carries its body, since
+  an OAuth2 error response cannot contain a token and its `error_description` (the `AADSTS…`
+  code) is the whole diagnosis for a credential misconfiguration.
+
+### Added — release infrastructure
+
+- **Package validation on both packages.** `EnablePackageValidation` compares the packed API
+  surface against `PackageValidationBaselineVersion` and fails `pack` on a breaking change;
+  `EnableStrictModeForCompatibleTfms` also catches a member present on one target framework
+  but not another — which compiles cleanly and breaks any consumer who multi-targets. The
+  baseline is a moving pin: bump it to the previous stable on each release. An offline build
+  needs `/p:DisablePackageBaselineValidation=true`, since the baseline is restored from
+  nuget.org.
+
+  This is what makes "release candidate" mean something. Two public members were added during
+  the review above without anyone noticing until the surface was diffed by hand.
+
+- **A `LICENSE` file at the repository root.** Both packages have always declared
+  `PackageLicenseExpression=MIT` — so nuget.org rendered the licence correctly — but the
+  repository itself had none, which is a genuine adoption blocker for anyone whose legal
+  review reads the repo rather than the package.
+
+### Documentation
+
+- `MaxQueryStringLength` said the guard throws `ArgumentException`. It has thrown
+  `BusinessCentralUrlTooLongException` since alpha.7.
+
+- The `⚠️ Inconclusive` note on server-driven paging under **[2.0.0-alpha]** now says it was
+  superseded. It has read as an open question ever since, and it is not one: the probe behind
+  it used the old client's `$top=1000` pacing, which never exceeded the server's page size and
+  so never gave the server cause to emit a `nextLink`. See the annotation there.
+
 ## [2.0.0-alpha.7] - 2026-08-04
 
 **Prerelease.** The URL-length guard (from the pre-stable review, sharpened by the
@@ -694,10 +804,21 @@ Known gaps in this prerelease, to be confirmed before 2.0.0 stable
   `PATCH`, so the header is redundant there (and harmless). The `204` path remains as a
   safety net; `POST` echo behaviour was left untested by choice (it would require creating
   a real record).
-- ⚠️ **Inconclusive 2026-07-30**: server-driven `@odata.nextLink` paging. A 118k-row query
-  against an `ODataV4` published-page endpoint did not produce server-driven paging;
-  those endpoints may not emit `nextLink` at all, unlike `/api/v2.0`. The nextLink
-  handling remains covered by tests but unobserved in the wild.
+- ⚠️ **Inconclusive 2026-07-30** — ✅ **superseded the same day; see [2.0.0-alpha.5]**:
+  server-driven `@odata.nextLink` paging. A 118k-row query against an `ODataV4`
+  published-page endpoint did not produce server-driven paging; those endpoints may not emit
+  `nextLink` at all, unlike `/api/v2.0`. The nextLink handling remains covered by tests but
+  unobserved in the wild.
+
+  *Superseding note (added 2026-08-05).* The conclusion above was wrong, and the reason is
+  worth keeping: that probe ran through the **old client's `$top=1000` pacing**, so no request
+  ever asked for more rows than the server's 20,000-row Max Page Size — the server had no
+  cause to truncate, and therefore none to emit a `nextLink`. The absence measured the client,
+  not the endpoint. The nextLink measurement round re-probed directly: with no `$top` the
+  endpoint returned ~20,000 rows **and an open `$skiptoken` cursor**, and with
+  `Prefer: odata.maxpagesize=1000` it returned exactly 1,000 rows and a cursor. Published-page
+  endpoints do server-drive paging. That measurement is what [2.0.0-alpha.5] was built on, and
+  the README's "verified against a live BC SaaS tenant" refers to it.
 
 ## [1.0.0] - 2026-01-20
 
@@ -721,6 +842,13 @@ First stable release.
 Initial pre-release line: OData querying with fluent filters, client-credentials
 authentication, DI integration, multi-targeting and NuGet packaging.
 
-[Unreleased]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v2.0.0-alpha...HEAD
+[Unreleased]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v2.0.0-rc.1...HEAD
+[2.0.0-rc.1]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v2.0.0-alpha.7...v2.0.0-rc.1
+[2.0.0-alpha.7]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v2.0.0-alpha.6...v2.0.0-alpha.7
+[2.0.0-alpha.6]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v2.0.0-alpha.5...v2.0.0-alpha.6
+[2.0.0-alpha.5]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v2.0.0-alpha.4...v2.0.0-alpha.5
+[2.0.0-alpha.4]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v2.0.0-alpha.3...v2.0.0-alpha.4
+[2.0.0-alpha.3]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v2.0.0-alpha.2...v2.0.0-alpha.3
+[2.0.0-alpha.2]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v2.0.0-alpha...v2.0.0-alpha.2
 [2.0.0-alpha]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v1.0.0...v2.0.0-alpha
 [1.0.0]: https://github.com/KralGmbh/Dynamics365-BusinessCentral/compare/v0.1.10...v1.0.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 KRAL GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -351,13 +351,68 @@ every resolution of `IBusinessCentralClient` triggered a fresh token request. 2.
 cache to a singleton. Expect a large drop in calls to your identity provider. No code
 change required.
 
-### Two bugs whose fixes change URLs
+### Three bugs whose fixes change URLs
 
 - `QueryRawAsync("salesOrders?$top=5")` previously percent-encoded the query string into the
   path (`salesOrders%3F%24top%3D5`). It now works as documented.
 - Alternate keys such as `No='1000'` were mangled to `No%3D%271000%27`. They now survive.
+- A company name containing an apostrophe was percent-encoded but never escaped as an OData
+  string literal, so `O'Brien Ltd` went out as `Company('O%27Brien Ltd')` — which decodes to a
+  bare quote and ends the literal early. It is now `Company('O%27%27Brien%20Ltd')`. Every
+  request from such a tenant used to fail; if you renamed a company to work around it, you can
+  rename it back. Tests asserting the old URL shape need updating.
 
-If you built workarounds for either, remove them.
+If you built workarounds for any of them, remove them.
+
+### `CountAsync` ignores `Top` and `Skip` — on both paths
+
+`$count` is independent of the page window, so the server path always answered the count of
+everything the filter matched, whatever `Top` said. The fallback used when an endpoint ignores
+`$count` reapplied the builder's `Top` and `Skip`, so `.Top(10).CountAsync()` returned `10`
+there and the full total on an endpoint that honours `$count` — the same query, two answers.
+The fallback now walks unpaged, so the full total is the answer everywhere.
+
+If you used `.Top(n).CountAsync()` as a bounded probe, it never worked as one against a
+`$count`-honouring endpoint. Use a `Top(n)` read and inspect its length instead:
+
+```csharp
+var probe = await client.Query<SalesOrder>().Where(...).Top(101).ToListAsync();
+var atLeast100 = probe.Count > 100;
+```
+
+### A token-endpoint `404` surfaces instead of becoming `null`
+
+`GetAsync` returns `null` for a missing entity, and its `try` spans token acquisition — which
+reports through the same exception hierarchy. A misconfigured `TokenEndpoint` answering `404`
+was therefore read as "no such entity": every read came back empty, with nothing thrown to say
+authentication had never happened. It now throws.
+
+If a `GetAsync` that "found nothing" starts throwing `BusinessCentralNotFoundException` with
+`IsTokenAcquisitionFailure` set, your `TokenEndpoint` was wrong all along and the reads were
+never reaching Business Central.
+
+### A bad `@odata.nextLink` is refused rather than followed
+
+Two continuation faults now throw `BusinessCentralProtocolException` — new in this release,
+`StatusCode` `0`, `Method` empty, `RequestUrl` carrying the offending link:
+
+- **Off-origin.** Continuations are sent verbatim and carry the bearer token, so one pointing
+  at another scheme, host or port than `ResolvedBaseUrl` is not followed. Business Central
+  issues continuations on the origin it was asked; nothing legitimate changes. If you have a
+  proxy that rewrites continuations to a different host, point `BaseUrl` at the proxy.
+- **Non-advancing.** A cursor already followed used to be re-followed if its page had rows,
+  which replayed those rows forever — an uncapped `StreamAsync` or `ToAllAsync` never returned.
+  Cycles (`A → B → A`) are caught too.
+
+  **This is the one that can change a call that used to succeed.** When the repeated cursor
+  arrived on an *empty* page, the pager stopped and returned the rows it had. That looked like
+  a clean result and was reported as one, but a `nextLink` asserts continuation remains — so
+  the set may have been truncated, with nothing to say so. It now throws. A `ToAllAsync` that
+  starts throwing `BusinessCentralProtocolException` was previously returning a silently short
+  result; treat the row count it used to produce as unreliable rather than as the baseline.
+
+Retry-policy code that dead-letters on non-transient failures already covers both; neither is
+transient.
 
 ---
 
@@ -491,4 +546,6 @@ There is no deprecation on the path-based API; migrate at your own pace, or not 
       them; not every published page exposes them
 - [ ] Re-check chunk sizes on bulk key lookups against `MaxQueryStringLength` (an `or`-chain costs
       ~2× per key what `in (...)` would — 38 encoded characters against 17 for an 8-character key)
+- [ ] Re-check any `.Top(n).CountAsync()` — `Top`/`Skip` never narrow a count
+- [ ] Re-check `GetAsync` calls that "always return null" — a token-endpoint `404` now throws
 - [ ] Optionally simplify configuration and drop hand-built `BaseUrl`

--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ client calls, key its policies on this package's exception types — **not** on
 | `BusinessCentralThrottledException` | `429` — the client already honoured `Retry-After` | slow requeue curve |
 | `ex.IsTransient` | any retry-worthy failure | generic transient handling |
 | `ex.IsUrlTooLong` | the query string exceeded `MaxQueryStringLength`; never sent | dead-letter / alert — chunk the input |
+| `ex.IsProtocolViolation` | a continuation pointed off-origin or stopped advancing | dead-letter / alert — the response is at fault |
 | everything else | validation/auth/not-found — retrying cannot help | dead-letter / alert |
 
 A policy keyed on `HttpRequestException` written for 1.x **silently stops matching** on
@@ -596,11 +597,13 @@ for logging; the detail lives on properties, and `ToString()` renders everything
 | `BusinessCentralThrottledException` | `429` |
 | `BusinessCentralConnectionException` | no response — connection failure or client-side timeout; `StatusCode` is `0` |
 | `BusinessCentralUrlTooLongException` | refused before sending: query string past `MaxQueryStringLength`; `StatusCode` is `0`, `Method` empty |
+| `BusinessCentralProtocolException` | refused to follow a bad `@odata.nextLink` — wrong origin, or a cursor that never advances; `StatusCode` is `0`, `Method` empty |
 | `BusinessCentralServerException` | everything else, and deserialization failures |
 
-Two types carry `StatusCode` `0`, because in neither case did a response arrive. Tell them
-apart with `IsConnectionFailure` (the network was tried and failed) and `IsUrlTooLong` (the
-client refused to send).
+Three types carry `StatusCode` `0`, because no HTTP status is associated with the failure
+itself. Tell them apart with `IsConnectionFailure` (the network was tried and failed),
+`IsUrlTooLong` (the client refused to send) and `IsProtocolViolation` (the client refused to
+follow where a response pointed).
 
 ```csharp
 catch (BusinessCentralException ex)
@@ -624,8 +627,14 @@ catch (BusinessCentralException ex) when (ex.IsNotFound)
 }
 ```
 
-`IsNotFound`, `IsThrottled`, `IsValidation`, `IsAuth`, `IsConnectionFailure` and
-`IsTransient` cover the same distinctions as the subtypes, without the trap.
+`IsNotFound`, `IsThrottled`, `IsValidation`, `IsAuth`, `IsConnectionFailure`,
+`IsUrlTooLong`, `IsProtocolViolation` and `IsTransient` cover the same distinctions as the
+subtypes, without the trap.
+
+One more flag cuts across all of them: `IsTokenAcquisitionFailure` is `true` when the failure
+came from the OAuth2 token endpoint rather than from Business Central. Both report through
+this hierarchy, so without it a misconfigured `TokenEndpoint` answering `404` is
+indistinguishable from “no such entity”.
 
 # 📊 Diagnostics
 

--- a/src/Dynamics365.BusinessCentral.Testing/Dynamics365.BusinessCentral.Testing.csproj
+++ b/src/Dynamics365.BusinessCentral.Testing/Dynamics365.BusinessCentral.Testing.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>Dynamics365.BusinessCentral.Testing</PackageId>
-        <Version>2.0.0-alpha.7</Version>
+        <Version>2.0.0-rc.1</Version>
         <Authors>Daniel Rückenbach</Authors>
         <Company>KRAL GmbH</Company>
 
@@ -40,6 +40,13 @@
         </PackageReleaseNotes>
 
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+        <!-- Same contract as the main package: the fake's surface is what consumers write
+             their tests against, so breaking it breaks their suites. See the main csproj for
+             why the baseline moves. -->
+        <EnablePackageValidation>true</EnablePackageValidation>
+        <PackageValidationBaselineVersion>2.0.0-alpha.7</PackageValidationBaselineVersion>
+        <EnableStrictModeForCompatibleTfms>true</EnableStrictModeForCompatibleTfms>
 
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -428,8 +428,11 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
     /// </remarks>
     private void EnsureTrustedContinuation(string nextLink)
     {
-        if (Uri.TryCreate(nextLink, UriKind.Absolute, out var link) &&
-            Uri.TryCreate(_options.ResolvedBaseUrl, UriKind.Absolute, out var serviceRoot) &&
+        var serviceRootParsed =
+            Uri.TryCreate(_options.ResolvedBaseUrl, UriKind.Absolute, out var serviceRoot);
+
+        if (serviceRootParsed &&
+            Uri.TryCreate(nextLink, UriKind.Absolute, out var link) &&
             Uri.Compare(
                 link, serviceRoot,
                 UriComponents.Scheme | UriComponents.HostAndPort,
@@ -439,10 +442,19 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             return;
         }
 
+        // The origin, not BaseUrl. BaseUrl carries a path
+        // (…/v2.0/{tenant}/{environment}/ODataV4) that this check deliberately ignores, so
+        // printing it would send a reader comparing paths — the one part that is allowed to
+        // differ. The message names exactly what was compared.
+        var expectedOrigin = serviceRootParsed
+            ? serviceRoot!.GetLeftPart(UriPartial.Authority)
+            : _options.ResolvedBaseUrl;
+
         throw new BusinessCentralProtocolException(
-            "Refusing to follow an @odata.nextLink that is not on the configured Business Central " +
-            $"service origin ({_options.ResolvedBaseUrl}). Continuations are sent with the access " +
-            "token, so one pointing elsewhere is not followed.",
+            $"Refusing to follow an @odata.nextLink outside the configured service origin " +
+            $"({expectedOrigin}). Only the scheme, host and port are compared; the path may " +
+            "differ. Continuations are sent with the access token, so one pointing elsewhere " +
+            "is not followed.",
             nextLink);
     }
 

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralClient.cs
@@ -182,9 +182,15 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
                 "Failed to deserialize Business Central response.",
                 cancellationToken).ConfigureAwait(false);
         }
-        catch (BusinessCentralNotFoundException)
+        catch (BusinessCentralNotFoundException ex) when (!ex.IsTokenAcquisitionFailure)
         {
             // "Does this entity exist" is a question, not an error.
+            //
+            // The filter matters: this try also spans token acquisition, which reports
+            // failures through the same exception hierarchy. Without it, a misconfigured
+            // TokenEndpoint answering 404 was read as "no such entity" and returned as null —
+            // every GetAsync silently empty, with nothing thrown to say authentication never
+            // happened.
             return default;
         }
     }
@@ -385,6 +391,8 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
         int? maxPageSize,
         CancellationToken cancellationToken)
     {
+        EnsureTrustedContinuation(absoluteUrl);
+
         // The nextLink is sent verbatim — it arrives pre-encoded and carries an opaque
         // $skiptoken; rebuilding it would corrupt the cursor. The maxpagesize preference
         // is re-sent because it applies per request, not per cursor.
@@ -395,6 +403,47 @@ public sealed class BusinessCentralClient : IBusinessCentralClient, IBusinessCen
             res,
             "Failed to deserialize Business Central response.",
             cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Rejects an <c>@odata.nextLink</c> that does not share an origin with the configured
+    /// service root, before it is sent.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Continuations are the one URL the client sends that it did not build. They go out
+    /// verbatim and, like every request, carry the bearer token — so a response naming
+    /// <c>https://attacker.example/page</c> would hand that token to whoever answers there,
+    /// and would make the client fetch any host the response chose. Business Central issues
+    /// continuations on the same origin it was asked, so requiring that costs nothing real.
+    /// </para>
+    /// <para>
+    /// Origin, not prefix: scheme, host and port must match
+    /// <c>BusinessCentralOptions.ResolvedBaseUrl</c>. The path is deliberately not compared,
+    /// because a continuation legitimately differs from the request path. Matching the scheme
+    /// is what keeps an <c>https</c> deployment from being talked down to <c>http</c>; a base
+    /// URL that is itself <c>http</c> (an on-premises or test service) is left alone rather
+    /// than broken by a rule its deployment never opted into.
+    /// </para>
+    /// </remarks>
+    private void EnsureTrustedContinuation(string nextLink)
+    {
+        if (Uri.TryCreate(nextLink, UriKind.Absolute, out var link) &&
+            Uri.TryCreate(_options.ResolvedBaseUrl, UriKind.Absolute, out var serviceRoot) &&
+            Uri.Compare(
+                link, serviceRoot,
+                UriComponents.Scheme | UriComponents.HostAndPort,
+                UriFormat.UriEscaped,
+                StringComparison.OrdinalIgnoreCase) == 0)
+        {
+            return;
+        }
+
+        throw new BusinessCentralProtocolException(
+            "Refusing to follow an @odata.nextLink that is not on the configured Business Central " +
+            $"service origin ({_options.ResolvedBaseUrl}). Continuations are sent with the access " +
+            "token, so one pointing elsewhere is not followed.",
+            nextLink);
     }
 
     private HttpRequestMessage CreatePageRequest(string url, int? maxPageSize)

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralTokenProvider.cs
@@ -103,8 +103,7 @@ internal sealed class BusinessCentralTokenProvider : IDisposable
                     {
                         var json = await res.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
-                        var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(json, _jsonOptions)
-                                            ?? throw new JsonException("Token response was null.");
+                        var tokenResponse = ReadTokenResponse(json, res, endpoint);
 
                         var expiresAt = DateTime.UtcNow + CacheLifetime(tokenResponse.ExpiresIn);
 
@@ -132,6 +131,11 @@ internal sealed class BusinessCentralTokenProvider : IDisposable
                         RetryHelper.NetworkFailureMessage(ex, "the token endpoint"),
                         HttpMethod.Post.Method, endpoint, ex);
                 }
+
+                // Both surfaces are the same exception hierarchy, so the caller — and
+                // BusinessCentralClient.GetAsync, which swallows a 404 as "no such entity" —
+                // needs to be able to tell a token failure from an answer about the entity.
+                failure.IsTokenAcquisitionFailure = true;
 
                 // The client_credentials grant has no side effects, so replay is
                 // unconditionally safe — none of the POST-ambiguity reasoning from the data
@@ -163,6 +167,89 @@ internal sealed class BusinessCentralTokenProvider : IDisposable
         {
             _tokenLock.Release();
         }
+    }
+
+    /// <summary>
+    /// Parses a <c>200</c> from the token endpoint, failing inside the client's own exception
+    /// contract rather than outside it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two ways a success response can still be unusable. Malformed JSON threw a raw
+    /// <see cref="JsonException"/>, which escaped <see cref="BusinessCentralException"/>
+    /// entirely — a caller doing <c>catch (BusinessCentralException)</c> around every call,
+    /// which is the documented contract, never saw it. And a well-formed body carrying no
+    /// <c>access_token</c> was cached as an empty string, then sent as a bare <c>Bearer</c> on
+    /// every subsequent request, surfacing as a <c>401</c> loop that blames Business Central
+    /// for what the token endpoint did.
+    /// </para>
+    /// <para>
+    /// Both become a <see cref="BusinessCentralServerException"/> carrying the endpoint, but
+    /// deliberately not the raw body: even malformed token responses can contain an access,
+    /// refresh or ID token, and exception/observer payloads routinely enter logs. The status
+    /// is the response's own — a <c>200</c> here is exactly the surprise worth reporting.
+    /// </para>
+    /// <para>
+    /// The redaction is scoped to the success path <b>on purpose</b>. A non-2xx from the token
+    /// endpoint still carries its body, because an OAuth2 error response cannot contain a token
+    /// by construction, and its <c>error</c>/<c>error_description</c> pair (the <c>AADSTS…</c>
+    /// code, for Entra) is the entire diagnosis for a credential or tenant misconfiguration.
+    /// Withholding that would cost the one thing worth having and protect nothing.
+    /// </para>
+    /// </remarks>
+    private TokenResponse ReadTokenResponse(string json, HttpResponseMessage res, string endpoint)
+    {
+        TokenResponse? parsed;
+
+        try
+        {
+            parsed = JsonSerializer.Deserialize<TokenResponse>(json, _jsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            throw TokenResponseFailure(
+                "Could not parse the response from the token endpoint.", res, endpoint, ex);
+        }
+
+        if (parsed is null)
+            throw TokenResponseFailure("The token endpoint returned an empty response.", res, endpoint);
+
+        if (string.IsNullOrWhiteSpace(parsed.AccessToken))
+        {
+            throw TokenResponseFailure(
+                "The token endpoint returned a response with no access_token.", res, endpoint);
+        }
+
+        return parsed;
+    }
+
+    private BusinessCentralServerException TokenResponseFailure(
+        string message,
+        HttpResponseMessage res,
+        string endpoint,
+        Exception? inner = null)
+    {
+        var failure = new BusinessCentralServerException(
+            message, res.StatusCode, HttpMethod.Post.Method, endpoint, null, null, null, inner)
+        {
+            IsTokenAcquisitionFailure = true
+        };
+
+        // Reported as the failure itself, not as the inner JsonException: a missing
+        // access_token has no inner exception at all, and BusinessCentralErrorInfo.Exception
+        // is not nullable.
+        _observer.OnDeserializationFailed(new BusinessCentralErrorInfo
+        {
+            Method = HttpMethod.Post.Method,
+            Url = endpoint,
+            StatusCode = (int)res.StatusCode,
+            // Never expose an identity-provider response through diagnostics: malformed JSON
+            // can still contain credential material that must not reach logs.
+            ResponseBody = null,
+            Exception = failure
+        });
+
+        return failure;
     }
 
     /// <summary>

--- a/src/Dynamics365.BusinessCentral/Client/BusinessCentralUrlBuilder.cs
+++ b/src/Dynamics365.BusinessCentral/Client/BusinessCentralUrlBuilder.cs
@@ -354,10 +354,23 @@ internal sealed class BusinessCentralUrlBuilder
         return count;
     }
 
+    /// <summary>
+    /// Builds <c>{BaseUrl}/Company('{company}')</c>, escaping the name as an OData string
+    /// literal <b>before</b> percent-encoding it.
+    /// </summary>
+    /// <remarks>
+    /// Both steps are needed and the order matters. Percent-encoding alone is not enough:
+    /// <see cref="Uri.EscapeDataString(string)"/> renders <c>'</c> as <c>%27</c>, which the
+    /// server decodes back to a bare quote before the OData parser sees it — so a company
+    /// named <c>O'Brien Ltd</c> arrives as <c>Company('O'Brien Ltd')</c>, whose literal ends
+    /// at the second quote. Doubling the quote first (the OData escape) and encoding second
+    /// gives <c>Company('O%27%27Brien%20Ltd')</c>, which decodes to the intended literal.
+    /// Doing it the other way round would escape the percent signs.
+    /// </remarks>
     private string BuildCompanyBase()
     {
-        var encodedCompany = Uri.EscapeDataString(_company);
-        return $"{_baseUrl}/Company('{encodedCompany}')";
+        var literal = _company.Replace("'", "''", StringComparison.Ordinal);
+        return $"{_baseUrl}/Company('{Uri.EscapeDataString(literal)}')";
     }
 
     /// <summary>

--- a/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
+++ b/src/Dynamics365.BusinessCentral/Dynamics365.BusinessCentral.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>Dynamics365.BusinessCentral</PackageId>
-        <Version>2.0.0-alpha.7</Version>
+        <Version>2.0.0-rc.1</Version>
         <Authors>Daniel Rückenbach</Authors>
         <Company>KRAL GmbH</Company>
 
@@ -35,38 +35,38 @@
         <!-- Shown on the nuget.org package page. Kept short and pointed at CHANGELOG.md
              rather than duplicated, since nuget.org renders this as plain text. -->
         <PackageReleaseNotes>
-            PRERELEASE — 2.0.0-alpha.7 adds the URL-length guard and corrects an alpha.6
-            claim about the derived $select.
+            RELEASE CANDIDATE — 2.0.0-rc.1 is the 2.0.0 surface, frozen. Please exercise it
+            against a real tenant and report anything that differs from the documentation;
+            no further API changes are planned before stable.
 
-            BusinessCentralOptions.MaxQueryStringLength (default 8000) refuses an over-long
-            request before it is sent, so the failure names the filter that caused it rather
-            than arriving as a bare 414 URI Too Long from the gateway;
-            QueryStringLengthWarningThreshold (default 6000) reports long query strings
-            through the new IBusinessCentralObserver.OnUrlLengthWarning while still sending
-            them, so a deployment can measure before it tunes. Both measure the query string,
-            not the whole URL. Bulk key lookups are the case that matters: Filter.In renders
-            an or-chain, which costs about twice per key what "in (...)" would.
+            This build fixes six defects found in an external review of the whole solution.
+            Two produce a wrong answer rather than an error, so read these two even if you
+            read nothing else:
 
-            Over the limit the client throws BusinessCentralUrlTooLongException, which derives
-            from BusinessCentralException like every other failure and carries the lengths, the
-            limit and the or-clause count as properties.
+            A company name containing an apostrophe built an unparseable URL. It was
+            percent-encoded but never escaped as an OData string literal, so O'Brien Ltd went
+            out as Company('O%27Brien Ltd') — which decodes to a bare quote and ends the
+            literal early. Every request from such a tenant failed.
 
-            Filters Business Central cannot answer are no longer sent. It has no boolean-literal
-            filter, so Filter.In(field, []) now short-circuits to an empty result with no request
-            at all, and Filter.All composed with anything reduces away instead of going out as
-            "(true) and (...)".
+            GetAsync swallowed a 404 from the token endpoint. Its catch spans token
+            acquisition, so a misconfigured TokenEndpoint answering 404 was read as "no such
+            entity" and returned as null — every read silently empty, nothing thrown to say
+            authentication never happened.
 
-            Also: a 400 caused by the derived $select now explains where the projection came
-            from and how to opt out, and the companion Testing package ships
-            BusinessCentralMetadata.AssertProjectionsResolveAsync — one assertion that checks
-            every entity type's derived $select against a tenant's live $metadata and reports
-            every unresolved name at once.
+            Also fixed: an @odata.nextLink is now followed only on the configured service
+            origin, because continuations are sent verbatim and carry the access token; a
+            continuation cursor that repeats throws instead of looping or truncating;
+            CountAsync returns the same number whether or not the endpoint honours $count
+            (Top and Skip never narrow a count); and a malformed 200 from the token endpoint
+            fails inside BusinessCentralException instead of leaking a raw JsonException,
+            without copying the identity provider's body into logs.
 
-            IMPORTANT — a property mapping to no Business Central column fails such a query
-            outright, which alpha.6's documentation wrongly described as merely surfacing
-            existing drift. alpha.6 also claimed $select was case-sensitive server-side;
-            live-tenant measurement showed the opposite, and that claim is retracted. See
-            MIGRATION.md before upgrading from alpha.6.
+            New: BusinessCentralProtocolException with the IsProtocolViolation predicate, and
+            BusinessCentralException.IsTokenAcquisitionFailure to tell a token-endpoint
+            failure from an answer about the entity.
+
+            Behaviour changes that are silent by nature — a ToAllAsync that starts throwing
+            was previously returning a possibly truncated result — are listed in MIGRATION.md.
 
             Breaking changes — see the migration guide before upgrading:
             https://github.com/KralGmbh/Dynamics365-BusinessCentral/blob/master/MIGRATION.md
@@ -77,6 +77,20 @@
 
         <!-- Ship XML docs so consumers get IntelliSense for the public API. -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+        <!-- Package validation: compares the packed API surface against the last published
+             version and fails the pack on a breaking change. Strict mode also catches the
+             asymmetric case — a member present on one TFM but not another, which compiles
+             fine and breaks a consumer who multi-targets.
+
+             The baseline is a moving pin: bump it to the previous *stable* on every release
+             once 2.0.0 ships. Until then it points at the last prerelease, which is what
+             makes the rc a real freeze rather than a label. Note this needs the baseline
+             package to be restorable, so an offline build must pass
+             /p:DisablePackageBaselineValidation=true. -->
+        <EnablePackageValidation>true</EnablePackageValidation>
+        <PackageValidationBaselineVersion>2.0.0-alpha.7</PackageValidationBaselineVersion>
+        <EnableStrictModeForCompatibleTfms>true</EnableStrictModeForCompatibleTfms>
 
         <!-- SourceLink is built into the .NET 8+ SDK; these make the snupkg actually
              usable for step-into debugging. -->

--- a/src/Dynamics365.BusinessCentral/Errors/BusinessCentralException.cs
+++ b/src/Dynamics365.BusinessCentral/Errors/BusinessCentralException.cs
@@ -45,6 +45,16 @@ public abstract class BusinessCentralException : Exception
     public TimeSpan? RetryAfter { get; internal set; }
 
     /// <summary>
+    /// The failure happened while acquiring the OAuth2 token, not while calling Business
+    /// Central. The two share this exception hierarchy, so without this flag a misconfigured
+    /// <c>TokenEndpoint</c> is indistinguishable from an answer about the entity: a token
+    /// endpoint returning <c>404</c> produced a
+    /// <see cref="BusinessCentralNotFoundException"/> that <c>GetAsync</c> read as "no such
+    /// entity" and swallowed into a <see langword="null"/>.
+    /// </summary>
+    public bool IsTokenAcquisitionFailure { get; internal set; }
+
+    /// <summary>
     /// Whether retrying the same request could plausibly succeed. <see langword="true"/> for
     /// throttling and transient server failures, <see langword="false"/> for validation,
     /// authentication and not-found errors.
@@ -73,9 +83,8 @@ public abstract class BusinessCentralException : Exception
     /// <summary>No response was received: connection failure or client-side timeout.</summary>
     /// <remarks>
     /// Matches on the exception type rather than on <see cref="StatusCode"/> being <c>0</c>.
-    /// Both no-response types carry status <c>0</c> — the other being
-    /// <see cref="BusinessCentralUrlTooLongException"/>, which is a refusal to send rather
-    /// than a failure to reach — and only this one means the network was actually tried.
+    /// Several pre-response or protocol failures carry status <c>0</c>; matching the subtype
+    /// ensures only a connection failure or timeout is classified as a network failure.
     /// </remarks>
     public bool IsConnectionFailure => this is BusinessCentralConnectionException;
 
@@ -85,6 +94,13 @@ public abstract class BusinessCentralException : Exception
     /// produces the same length every time.
     /// </summary>
     public bool IsUrlTooLong => this is BusinessCentralUrlTooLongException;
+
+    /// <summary>
+    /// The response broke the OData contract in a way the client refused to act on — a
+    /// continuation pointing somewhere other than the configured service, or one that never
+    /// advances. Never transient: the same response repeats the same violation.
+    /// </summary>
+    public bool IsProtocolViolation => this is BusinessCentralProtocolException;
 
     /// <summary>Creates a new <see cref="BusinessCentralException"/>.</summary>
     /// <param name="message">Short, single-line description of the failure.</param>
@@ -125,9 +141,8 @@ public abstract class BusinessCentralException : Exception
             ? $"Business Central request failed."
             : message.Trim().ReplaceLineEndings(" ");
 
-        // A request refused before it was built has no method to name, and its message
-        // already says what happened — decorating it with "( → no response)" would only
-        // add noise. Only BusinessCentralUrlTooLongException takes this branch.
+        // A client-side refusal has no method to name, and its message already says what
+        // happened — decorating it with "( → no response)" would only add noise.
         if (string.IsNullOrEmpty(method))
             return trimmed;
 
@@ -148,7 +163,9 @@ public abstract class BusinessCentralException : Exception
         sb.AppendLine();
         sb.AppendLine("--- Business Central details ---");
         sb.AppendLine(StatusCode == 0
-            ? "Status: (no response received)"
+            ? IsConnectionFailure
+                ? "Status: (no response received)"
+                : "Status: (no HTTP status associated)"
             : $"Status: {(int)StatusCode} {StatusCode}");
         sb.AppendLine($"Method: {Method}");
         sb.AppendLine($"URL: {RequestUrl}");
@@ -362,6 +379,46 @@ public sealed class BusinessCentralUrlTooLongException : BusinessCentralExceptio
         Limit = limit;
         OrClauseCount = orClauseCount;
     }
+}
+
+/// <summary>
+/// The client refused to act on a response that broke the OData contract. Never transient.
+/// <see cref="BusinessCentralException.StatusCode"/> is <c>0</c> and
+/// <see cref="BusinessCentralException.Method"/> is empty, because this is a refusal to send
+/// the *next* request rather than the result of one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Raised for two continuation faults, both of which would otherwise turn a bad response
+/// into something worse than an error:
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// An <c>@odata.nextLink</c> whose origin is not the configured service root. Continuations
+/// are sent verbatim and carry the bearer token, so following one to another host would
+/// disclose the token and turn the client into an SSRF vector on behalf of whoever wrote
+/// the response.
+/// </description></item>
+/// <item><description>
+/// A continuation cursor that has already been followed. When its page carried rows,
+/// refetching yields the page already emitted, so an uncapped stream would repeat those rows
+/// forever. When the page was empty the fault is the opposite one: a <c>nextLink</c> asserts
+/// that continuation remains, so the client cannot conclude the collection is complete —
+/// stopping quietly would hand back a possibly truncated result as success. Neither is
+/// something the caller can be left to notice, so both throw.
+/// </description></item>
+/// </list>
+/// <para>
+/// <see cref="BusinessCentralException.RequestUrl"/> carries the offending continuation.
+/// </para>
+/// </remarks>
+public sealed class BusinessCentralProtocolException : BusinessCentralException
+{
+    /// <summary>Creates a new <see cref="BusinessCentralProtocolException"/>.</summary>
+    /// <param name="message">Short, single-line description of the violation.</param>
+    /// <param name="requestUrl">The continuation URL that was rejected.</param>
+    public BusinessCentralProtocolException(string message, string? requestUrl)
+        : base(message, 0, string.Empty, requestUrl, null, null, null, null) { }
 }
 
 internal sealed class BusinessCentralODataError

--- a/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
+++ b/src/Dynamics365.BusinessCentral/OData/BusinessCentralQuery.cs
@@ -174,21 +174,39 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
     public async IAsyncEnumerable<TEntity> StreamAsync(
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        await foreach (var entity in StreamCoreAsync(_top, _skip ?? 0, cancellationToken).ConfigureAwait(false))
+            yield return entity;
+    }
+
+    /// <summary>
+    /// Streams every row the filter matches, ignoring the builder's <c>Top</c> and
+    /// <c>Skip</c>. Used only by <see cref="CountAsync"/>'s fallback, whose answer must not
+    /// depend on the page window — see the comment there.
+    /// </summary>
+    private async IAsyncEnumerable<TEntity> StreamUnpagedAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await foreach (var entity in StreamCoreAsync(null, 0, cancellationToken).ConfigureAwait(false))
+            yield return entity;
+    }
+
+    private IAsyncEnumerable<TEntity> StreamCoreAsync(
+        int? limit,
+        int skip,
+        CancellationToken cancellationToken)
+    {
         // The paging state machine lives in QueryPager, shared with the path-based
         // QueryStreamAsync; only the fetch delegates differ. Paging is server-driven: the
         // per-query PageSize (else the registration-level MaxPageSize, else nothing) is
         // sent as Prefer: odata.maxpagesize and continuation follows @odata.nextLink.
         var maxPageSize = _pageSize ?? _executor.DefaultMaxPageSize;
 
-        var stream = QueryPager.StreamAsync(
-            _top,
-            _skip ?? 0,
-            (top, skip, ct) => FetchAsync(top, skip, maxPageSize, ct),
+        return QueryPager.StreamAsync(
+            limit,
+            skip,
+            (top, offset, ct) => FetchAsync(top, offset, maxPageSize, ct),
             (link, ct) => _executor.FetchNextPageAsync<TEntity>(link, maxPageSize, ct),
             cancellationToken);
-
-        await foreach (var entity in stream.ConfigureAwait(false))
-            yield return entity;
     }
 
     private Task<ODataResponse<TEntity>> FetchAsync(
@@ -263,9 +281,16 @@ internal sealed class BusinessCentralQuery<TEntity> : IBusinessCentralQuery<TEnt
         // path CountAsync's remarks warn about: it pages the whole set to produce one number.
         // Kept because a wrong count is worse than a slow one, but it is why the interface
         // documents "without fetching them" as conditional rather than as a guarantee.
+        //
+        // The walk deliberately ignores Top and Skip, because $count does: the server path
+        // above sends $top=0 and gets the count of everything the filter matches, so a walk
+        // honouring the builder's paging would make .Top(10).CountAsync() answer 10 here and
+        // the full total there — the same query returning different numbers depending on
+        // which endpoint served it. The filter is what defines the count; the page window
+        // is not part of it.
         var walked = 0L;
 
-        await foreach (var _ in StreamAsync(cancellationToken).ConfigureAwait(false))
+        await foreach (var _ in StreamUnpagedAsync(cancellationToken).ConfigureAwait(false))
             walked++;
 
         return walked;

--- a/src/Dynamics365.BusinessCentral/OData/IBusinessCentralQuery.cs
+++ b/src/Dynamics365.BusinessCentral/OData/IBusinessCentralQuery.cs
@@ -122,6 +122,13 @@ public interface IBusinessCentralQuery<TEntity>
     /// page. It is a correctness guarantee, not a performance one.
     /// </para>
     /// <para>
+    /// <b><see cref="Top"/> and <see cref="Skip"/> do not narrow the count.</b> It counts
+    /// everything the filter matches, on both paths — the server one because <c>$count</c> is
+    /// independent of the page window, and the fallback because it deliberately walks the set
+    /// unpaged to match. <c>.Top(10).CountAsync()</c> therefore returns the full total, not
+    /// <c>10</c>.
+    /// </para>
+    /// <para>
     /// If the cost matters more than the exact number, prefer a bounded probe — a
     /// <c>Top(n)</c> read whose length you inspect — or verify once that your endpoint honours
     /// <c>$count</c> before relying on this in a hot path.

--- a/src/Dynamics365.BusinessCentral/OData/QueryPager.cs
+++ b/src/Dynamics365.BusinessCentral/OData/QueryPager.cs
@@ -76,11 +76,15 @@ internal static class QueryPager
             // Both self-loops and longer cycles land here.
             if (!visited.Add(nextLink))
             {
+                // No correlation ID to offer: this is thrown on a *successful* page, and the
+                // client only ever parses one out of an OData error body. The rejected cursor
+                // on RequestUrl and an observer's request log are what a caller actually has.
                 throw new BusinessCentralProtocolException(
                     "Business Central returned an @odata.nextLink that has already been followed, " +
                     "so paging is not advancing. Following it again would repeat rows already " +
-                    "returned. Retry the query; if it persists, the correlation ID from the page " +
-                    "request identifies it to Microsoft support.",
+                    "returned, and stopping here could hide rows never returned. The repeated " +
+                    "cursor is on RequestUrl; register an IBusinessCentralObserver to capture the " +
+                    "full sequence of page requests that led to it.",
                     nextLink);
             }
 

--- a/src/Dynamics365.BusinessCentral/OData/QueryPager.cs
+++ b/src/Dynamics365.BusinessCentral/OData/QueryPager.cs
@@ -1,3 +1,4 @@
+using Dynamics365.BusinessCentral.Errors;
 using System.Runtime.CompilerServices;
 
 namespace Dynamics365.BusinessCentral.OData;
@@ -22,6 +23,11 @@ namespace Dynamics365.BusinessCentral.OData;
 /// <c>limit</c> (<c>$top</c> semantics) caps emitted rows, enforced mid-page client-side
 /// and also sent to the server so it never over-serves a capped query.
 /// </para>
+/// <para>
+/// Continuation is trusted only as far as it advances: a cursor that has already been
+/// followed throws <see cref="BusinessCentralProtocolException"/> rather than replaying the
+/// rows it produced the first time.
+/// </para>
 /// </remarks>
 internal static class QueryPager
 {
@@ -40,9 +46,10 @@ internal static class QueryPager
 
         var page = await fetchFirstPage(limit, initialSkip, cancellationToken).ConfigureAwait(false);
 
-        // The cursor that produced the page in hand, so a server that fails to advance it
-        // cannot spin this loop forever.
-        string? followed = null;
+        // Every cursor already followed. A single previous-cursor check would catch only a
+        // self-loop; a cycle (A → B → A) needs the whole history. Bounded by page count, which
+        // at BC's page sizes is small even for a full-table stream.
+        var visited = new HashSet<string>(StringComparer.Ordinal);
 
         while (true)
         {
@@ -58,24 +65,26 @@ internal static class QueryPager
 
             // No continuation means the collection (or the caller's $top budget) is
             // exhausted — BC offers a nextLink on every page it truncates.
-            if (string.IsNullOrWhiteSpace(page.NextLink))
+            var nextLink = page.NextLink;
+            if (string.IsNullOrWhiteSpace(nextLink))
                 yield break;
 
-            // No-progress guard. An empty page whose nextLink is the cursor we just followed
-            // would return the same empty page forever; following it again cannot produce a
-            // row that following it once did not. Terminating therefore loses nothing, which
-            // is why this stops rather than throws. Both conditions are required: an empty
-            // page with a *new* cursor is legitimate (a page whose every row was filtered
-            // server-side), and so is a repeated cursor that still carried rows.
-            if (page.Value.Count == 0 &&
-                string.Equals(page.NextLink, followed, StringComparison.Ordinal))
+            // Every repeated cursor is a protocol fault, whether or not this page carried
+            // rows. A nextLink asserts that continuation remains; an empty page does not let
+            // the client conclude the result is complete. Stopping quietly would report a
+            // potentially truncated result as success, while following it can loop forever.
+            // Both self-loops and longer cycles land here.
+            if (!visited.Add(nextLink))
             {
-                yield break;
+                throw new BusinessCentralProtocolException(
+                    "Business Central returned an @odata.nextLink that has already been followed, " +
+                    "so paging is not advancing. Following it again would repeat rows already " +
+                    "returned. Retry the query; if it persists, the correlation ID from the page " +
+                    "request identifies it to Microsoft support.",
+                    nextLink);
             }
 
-            followed = page.NextLink;
-
-            page = await fetchNextPage(followed!, cancellationToken).ConfigureAwait(false);
+            page = await fetchNextPage(nextLink, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptions.cs
+++ b/src/Dynamics365.BusinessCentral/Options/BusinessCentralOptions.cs
@@ -190,9 +190,10 @@ public sealed class BusinessCentralOptions
     /// </para>
     /// <para>
     /// Past the server's own ceiling Business Central answers <c>414 URI Too Long</c>, which is
-    /// not opaque. The value of failing client-side first is the diagnosis: this throws an
-    /// <see cref="ArgumentException"/> naming the actual length, the limit, the <c>or</c>-clause
-    /// count and <c>Filter.In</c> as the likely cause, before the request leaves the process.
+    /// not opaque. The value of failing client-side first is the diagnosis: this throws a
+    /// <see cref="Errors.BusinessCentralUrlTooLongException"/> naming the actual length, the limit,
+    /// the <c>or</c>-clause count and <c>Filter.In</c> as the likely cause, before the request
+    /// leaves the process.
     /// </para>
     /// <para>
     /// The usual cause is a bulk key lookup. <c>Filter.In</c> renders a same-field

--- a/src/Dynamics365.BusinessCentral/README.md
+++ b/src/Dynamics365.BusinessCentral/README.md
@@ -573,6 +573,7 @@ client calls, key its policies on this package's exception types — **not** on
 | `BusinessCentralThrottledException` | `429` — the client already honoured `Retry-After` | slow requeue curve |
 | `ex.IsTransient` | any retry-worthy failure | generic transient handling |
 | `ex.IsUrlTooLong` | the query string exceeded `MaxQueryStringLength`; never sent | dead-letter / alert — chunk the input |
+| `ex.IsProtocolViolation` | a continuation pointed off-origin or stopped advancing | dead-letter / alert — the response is at fault |
 | everything else | validation/auth/not-found — retrying cannot help | dead-letter / alert |
 
 A policy keyed on `HttpRequestException` written for 1.x **silently stops matching** on
@@ -596,11 +597,13 @@ for logging; the detail lives on properties, and `ToString()` renders everything
 | `BusinessCentralThrottledException` | `429` |
 | `BusinessCentralConnectionException` | no response — connection failure or client-side timeout; `StatusCode` is `0` |
 | `BusinessCentralUrlTooLongException` | refused before sending: query string past `MaxQueryStringLength`; `StatusCode` is `0`, `Method` empty |
+| `BusinessCentralProtocolException` | refused to follow a bad `@odata.nextLink` — wrong origin, or a cursor that never advances; `StatusCode` is `0`, `Method` empty |
 | `BusinessCentralServerException` | everything else, and deserialization failures |
 
-Two types carry `StatusCode` `0`, because in neither case did a response arrive. Tell them
-apart with `IsConnectionFailure` (the network was tried and failed) and `IsUrlTooLong` (the
-client refused to send).
+Three types carry `StatusCode` `0`, because no HTTP status is associated with the failure
+itself. Tell them apart with `IsConnectionFailure` (the network was tried and failed),
+`IsUrlTooLong` (the client refused to send) and `IsProtocolViolation` (the client refused to
+follow where a response pointed).
 
 ```csharp
 catch (BusinessCentralException ex)
@@ -624,8 +627,14 @@ catch (BusinessCentralException ex) when (ex.IsNotFound)
 }
 ```
 
-`IsNotFound`, `IsThrottled`, `IsValidation`, `IsAuth`, `IsConnectionFailure` and
-`IsTransient` cover the same distinctions as the subtypes, without the trap.
+`IsNotFound`, `IsThrottled`, `IsValidation`, `IsAuth`, `IsConnectionFailure`,
+`IsUrlTooLong`, `IsProtocolViolation` and `IsTransient` cover the same distinctions as the
+subtypes, without the trap.
+
+One more flag cuts across all of them: `IsTokenAcquisitionFailure` is `true` when the failure
+came from the OAuth2 token endpoint rather than from Business Central. Both report through
+this hierarchy, so without it a misconfigured `TokenEndpoint` answering `404` is
+indistinguishable from “no such entity”.
 
 # 📊 Diagnostics
 

--- a/test/Dynamics365.BusinessCentral.Tests/ExceptionPredicateTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ExceptionPredicateTests.cs
@@ -61,6 +61,19 @@ public class ExceptionPredicateTests
         Assert.True(ex.IsConnectionFailure);
         Assert.True(ex.IsTransient);
         Assert.False(ex.IsNotFound);
+        Assert.Contains("Status: (no response received)", ex.ToString());
+    }
+
+    [Fact]
+    public void Protocol_Violation_Uses_A_Neutral_Status_Description()
+    {
+        var ex = new BusinessCentralProtocolException("x", "https://example.test/next");
+
+        Assert.True(ex.IsProtocolViolation);
+        Assert.False(ex.IsConnectionFailure);
+        Assert.False(ex.IsTransient);
+        Assert.Contains("Status: (no HTTP status associated)", ex.ToString());
+        Assert.DoesNotContain("no response received", ex.ToString());
     }
 
     [Fact]

--- a/test/Dynamics365.BusinessCentral.Tests/ODataWireContractTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/ODataWireContractTests.cs
@@ -1,3 +1,4 @@
+using Dynamics365.BusinessCentral.Errors;
 using Dynamics365.BusinessCentral.OData;
 using Dynamics365.BusinessCentral.Options;
 using Dynamics365.BusinessCentral.Tests.Utils;
@@ -286,11 +287,11 @@ public class ODataWireContractTests : TestBase
     #region Paging
 
     /// <summary>
-    /// A server that hands back the cursor just followed, on a page with no rows, cannot be
-    /// advanced by following it again — so the pager stops instead of spinning forever.
+    /// A server that hands back the cursor just followed, even on an empty page, has violated
+    /// the continuation contract. Throw rather than spinning or reporting a truncated success.
     /// </summary>
     [Fact]
-    public async Task Pager_Stops_When_The_Cursor_Stops_Advancing()
+    public async Task Pager_Throws_When_The_Cursor_Stops_Advancing()
     {
         var requests = 0;
 
@@ -304,9 +305,8 @@ public class ODataWireContractTests : TestBase
                 : """{"value":[],"@odata.nextLink":"https://test/next"}""");
         }));
 
-        var rows = await client.Query<SalesOrder>().ToAllAsync();
-
-        Assert.Single(rows);
+        await Assert.ThrowsAsync<BusinessCentralProtocolException>(
+            () => client.Query<SalesOrder>().ToAllAsync());
 
         // First page, then one continuation that made no progress. Without the guard this
         // never returns.

--- a/test/Dynamics365.BusinessCentral.Tests/PagingGuardTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/PagingGuardTests.cs
@@ -198,6 +198,50 @@ public class PagingGuardTests
     }
 
     /// <summary>
+    /// The rejection message must name the origin that was compared, not <c>BaseUrl</c>. A real
+    /// BaseUrl carries a path (<c>…/v2.0/{tenant}/{environment}/ODataV4</c>) that this check
+    /// deliberately ignores, so printing it would send a reader comparing the one part that is
+    /// allowed to differ.
+    /// </summary>
+    [Fact]
+    public async Task Foreign_Origin_Message_Names_The_Origin_Not_The_Base_Url()
+    {
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(_ => TestBase.Json(
+                "{\"value\":[{\"no\":\"a\"}],\"@odata.nextLink\":\"https://attacker.example/p2\"}")),
+            configure: o => o.BaseUrl = "https://test/v2.0/tenant/Production/ODataV4");
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralProtocolException>(
+            () => client.Query<SalesOrder>().ToAllAsync());
+
+        Assert.Contains("https://test)", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("ODataV4", ex.Message, StringComparison.Ordinal);
+
+        // And it says which components were compared, so "but the paths differ" is not the
+        // conclusion a reader reaches.
+        Assert.Contains("scheme, host and port", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The non-advancing-cursor message must not send the caller after a correlation ID: this
+    /// is thrown on a successful page, and the client only ever parses one out of an OData
+    /// error body, so there is none to find.
+    /// </summary>
+    [Fact]
+    public async Task Non_Advancing_Cursor_Message_Offers_Only_Actionable_Diagnostics()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ => TestBase.Json(
+            "{\"value\":[{\"no\":\"a\"}],\"@odata.nextLink\":\"https://test/stuck\"}")));
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralProtocolException>(
+            () => client.Query<SalesOrder>().ToAllAsync());
+
+        Assert.DoesNotContain("correlation", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(ex.CorrelationId);
+        Assert.Equal("https://test/stuck", ex.RequestUrl);
+    }
+
+    /// <summary>
     /// Same origin, different path, is the normal shape of a continuation and stays allowed —
     /// the check compares scheme, host and port, not the path.
     /// </summary>

--- a/test/Dynamics365.BusinessCentral.Tests/PagingGuardTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/PagingGuardTests.cs
@@ -164,6 +164,165 @@ public class PagingGuardTests
 
     #endregion
 
+    #region Continuations are only trusted as far as they advance
+
+    /// <summary>
+    /// A continuation is the one URL the client sends that it did not build, and it carries
+    /// the bearer token. One pointing at another origin is not followed: doing so would
+    /// disclose the token to whoever answers there and make the client fetch any host the
+    /// response named.
+    /// </summary>
+    [Fact]
+    public async Task Continuation_To_A_Foreign_Origin_Is_Refused()
+    {
+        var hosts = new List<string>();
+
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
+        {
+            hosts.Add(req.RequestUri!.Host);
+
+            return TestBase.Json(
+                "{\"value\":[{\"no\":\"a\"}],\"@odata.nextLink\":\"https://attacker.example/page2\"}");
+        }));
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralProtocolException>(
+            () => client.Query<SalesOrder>().ToAllAsync());
+
+        Assert.Equal("https://attacker.example/page2", ex.RequestUrl);
+        Assert.True(ex.IsProtocolViolation);
+        Assert.False(ex.IsTransient);
+
+        // The point of the guard: the foreign host was never contacted, so the token
+        // never left the configured service origin.
+        Assert.DoesNotContain("attacker.example", hosts);
+    }
+
+    /// <summary>
+    /// Same origin, different path, is the normal shape of a continuation and stays allowed —
+    /// the check compares scheme, host and port, not the path.
+    /// </summary>
+    [Fact]
+    public async Task Continuation_On_The_Service_Origin_Is_Followed()
+    {
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            TestBase.Json(++dataCalls == 1
+                ? "{\"value\":[{\"no\":\"a\"}],\"@odata.nextLink\":\"https://test/anything?$skiptoken=x\"}"
+                : "{\"value\":[{\"no\":\"b\"}]}")));
+
+        var all = await client.Query<SalesOrder>().ToAllAsync();
+
+        Assert.Equal(2, all.Count);
+    }
+
+    /// <summary>
+    /// A plaintext continuation off an https base is a different origin by scheme, so it is
+    /// refused — that is what stops the token being talked down to http.
+    /// </summary>
+    [Fact]
+    public async Task Continuation_Downgraded_To_Http_Is_Refused()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            TestBase.Json("{\"value\":[{\"no\":\"a\"}],\"@odata.nextLink\":\"http://test/p2\"}")));
+
+        await Assert.ThrowsAsync<BusinessCentralProtocolException>(
+            () => client.Query<SalesOrder>().ToAllAsync());
+    }
+
+    /// <summary>
+    /// A cursor pointing at itself while still returning rows: following it replays the rows
+    /// already emitted, so an uncapped stream would repeat them forever. The guard used to
+    /// require an empty page, which this case never produces.
+    /// </summary>
+    [Fact]
+    public async Task Continuation_Cursor_That_Never_Advances_Throws()
+    {
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            if (++dataCalls > 25)
+                throw new InvalidOperationException("Paging loop did not terminate.");
+
+            return TestBase.Json(
+                "{\"value\":[{\"no\":\"a\"}],\"@odata.nextLink\":\"https://test/stuck\"}");
+        }));
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralProtocolException>(
+            () => client.Query<SalesOrder>().ToAllAsync());
+
+        Assert.Equal("https://test/stuck", ex.RequestUrl);
+
+        // First page, then the one fetch of /stuck; its repeat of the same cursor throws.
+        Assert.Equal(2, dataCalls);
+    }
+
+    /// <summary>A → B → A. Only the full visited set catches a cycle longer than one.</summary>
+    [Fact]
+    public async Task Cycling_Continuation_Cursors_Throw()
+    {
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            if (++dataCalls > 25)
+                throw new InvalidOperationException("Paging loop did not terminate.");
+
+            // p1 -> p2 -> p1 -> ...
+            return TestBase.Json(dataCalls % 2 == 1
+                ? "{\"value\":[{\"no\":\"a\"}],\"@odata.nextLink\":\"https://test/p2\"}"
+                : "{\"value\":[{\"no\":\"b\"}],\"@odata.nextLink\":\"https://test/p1\"}");
+        }));
+
+        await Assert.ThrowsAsync<BusinessCentralProtocolException>(
+            () => client.Query<SalesOrder>().ToAllAsync());
+    }
+
+    /// <summary>
+    /// A nextLink asserts that continuation remains. Even when the repeated page is empty,
+    /// stopping quietly would claim the result is complete without evidence; the repeated
+    /// cursor is therefore the same protocol violation as one carrying rows.
+    /// </summary>
+    [Fact]
+    public async Task Empty_Page_Repeating_Its_Cursor_Throws()
+    {
+        var dataCalls = 0;
+
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+        {
+            if (++dataCalls > 25)
+                throw new InvalidOperationException("Paging loop did not terminate.");
+
+            return TestBase.Json(dataCalls == 1
+                ? "{\"value\":[{\"no\":\"a\"}],\"@odata.nextLink\":\"https://test/stuck\"}"
+                : "{\"value\":[],\"@odata.nextLink\":\"https://test/stuck\"}");
+        }));
+
+        await Assert.ThrowsAsync<BusinessCentralProtocolException>(
+            () => client.Query<SalesOrder>().ToAllAsync());
+
+        Assert.Equal(2, dataCalls);
+    }
+
+    /// <summary>The path-based surface shares QueryPager, so it inherits both guards.</summary>
+    [Fact]
+    public async Task Path_Based_Stream_Refuses_A_Foreign_Continuation()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            TestBase.Json(
+                "{\"value\":[{\"no\":\"a\"}],\"@odata.nextLink\":\"https://attacker.example/p2\"}")));
+
+        await Assert.ThrowsAsync<BusinessCentralProtocolException>(async () =>
+        {
+            await foreach (var _ in client.QueryStreamAsync<SalesOrder>("salesOrders"))
+            {
+            }
+        });
+    }
+
+    #endregion
+
     #region Token lifetime and user agent
 
     [Theory]

--- a/test/Dynamics365.BusinessCentral.Tests/QueryBuilderTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/QueryBuilderTests.cs
@@ -223,6 +223,47 @@ public class QueryBuilderTests
         Assert.Contains("$top=0", Decode(urls[0]));
     }
 
+    /// <summary>
+    /// The count is defined by the filter, not by the page window — on both paths. The server
+    /// path already answered the full total for a capped query, because <c>$count</c> is
+    /// independent of <c>$top</c>; the walk-the-collection fallback used to reapply the
+    /// builder's Top and Skip, so <c>.Top(10).CountAsync()</c> answered 10 on an endpoint that
+    /// ignores <c>$count</c> and the real total on one that honours it.
+    /// </summary>
+    [Fact]
+    public async Task CountAsync_Fallback_Ignores_Top_And_Skip()
+    {
+        var urls = new List<string>();
+        var walkCalls = 0;
+
+        // No @odata.count anywhere: this endpoint ignores $count, forcing the fallback.
+        var client = TestBase.CreateClient(TestBase.WithToken(req =>
+        {
+            var url = req.RequestUri!.AbsoluteUri;
+            urls.Add(url);
+
+            // The count probe ($top=0) answers with neither rows nor a count.
+            if (Decode(url).Contains("$top=0"))
+                return TestBase.Json("{\"value\":[]}");
+
+            // The walk that follows: four rows, then three — seven in total.
+            return TestBase.Json(++walkCalls == 1
+                ? "{\"value\":[{\"no\":\"a\"},{\"no\":\"b\"},{\"no\":\"c\"},{\"no\":\"d\"}]," +
+                  "\"@odata.nextLink\":\"https://test/p2\"}"
+                : "{\"value\":[{\"no\":\"e\"},{\"no\":\"f\"},{\"no\":\"g\"}]}");
+        }));
+
+        var count = await client.Query<SalesOrder>().Top(2).Skip(5).CountAsync();
+
+        Assert.Equal(7, count);
+
+        // The count request itself still carries $top=0; the walk that follows carries
+        // neither the builder's cap nor its offset.
+        Assert.Contains("$top=0", Decode(urls[0]));
+        Assert.DoesNotContain("$top=2", Decode(urls[1]));
+        Assert.DoesNotContain("$skip", Decode(urls[1]));
+    }
+
     #endregion
 
     #region Paging and streaming
@@ -357,6 +398,44 @@ public class QueryBuilderTests
 
         // The token cache is shared with the scoped client.
         Assert.Equal(1, tokenCalls);
+    }
+
+    /// <summary>
+    /// A company name is an OData string literal before it is a URL segment, so its quote is
+    /// doubled first and percent-encoded second. Percent-encoding alone produced
+    /// <c>Company('O%27Brien Ltd')</c>, which the server decodes to a bare quote — closing
+    /// the literal early and making every request from that tenant a parse error.
+    /// </summary>
+    [Fact]
+    public async Task Company_Name_With_An_Apostrophe_Is_Escaped_As_An_OData_Literal()
+    {
+        var (client, urls) = Capturing();
+
+        await client.ForCompany("O'Brien Ltd").Query<SalesOrder>().ToListAsync();
+
+        Assert.Contains("Company('O%27%27Brien%20Ltd')", urls[0]);
+
+        // What the server sees after percent-decoding: a doubled quote inside the literal.
+        Assert.Contains("Company('O''Brien Ltd')", Uri.UnescapeDataString(urls[0]));
+    }
+
+    /// <summary>The same escaping applies to the configured company, not just ForCompany.</summary>
+    [Fact]
+    public async Task Configured_Company_With_An_Apostrophe_Is_Escaped()
+    {
+        var urls = new List<string>();
+
+        var client = TestBase.CreateClient(
+            TestBase.WithToken(req =>
+            {
+                urls.Add(req.RequestUri!.AbsoluteUri);
+                return TestBase.Json("{\"value\":[]}");
+            }),
+            configure: o => o.Company = "O'Brien Ltd");
+
+        await client.Query<SalesOrder>().ToListAsync();
+
+        Assert.Contains("Company('O%27%27Brien%20Ltd')", urls[0]);
     }
 
     [Fact]

--- a/test/Dynamics365.BusinessCentral.Tests/TokenProviderTests.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/TokenProviderTests.cs
@@ -1,14 +1,17 @@
 using Dynamics365.BusinessCentral.Client;
+using Dynamics365.BusinessCentral.Errors;
 using Dynamics365.BusinessCentral.Options;
 using Dynamics365.BusinessCentral.Tests.Utils;
 using System.Net;
+using System.Text.Json;
 
 namespace Dynamics365.BusinessCentral.Tests;
 
 public class TokenProviderTests
 {
     private static BusinessCentralTokenProvider CreateProvider(
-        Func<HttpRequestMessage, HttpResponseMessage> handler)
+        Func<HttpRequestMessage, HttpResponseMessage> handler,
+        TestObserver? observer = null)
     {
         var options = new BusinessCentralOptions
         {
@@ -28,7 +31,8 @@ public class TokenProviderTests
 
         return new BusinessCentralTokenProvider(
             new HttpClient(new FakeHttpHandler(handler)),
-            Microsoft.Extensions.Options.Options.Create(options));
+            Microsoft.Extensions.Options.Options.Create(options),
+            observer);
     }
 
     private static HttpResponseMessage Token(string value) =>
@@ -82,4 +86,138 @@ public class TokenProviderTests
         Assert.Equal("token-2", second);
         Assert.Equal(2, tokenRequests);
     }
+
+    #region A 200 from the token endpoint is not automatically a token
+
+    /// <summary>
+    /// Malformed JSON threw a raw <c>JsonException</c>, straight through the documented
+    /// <c>catch (BusinessCentralException)</c> contract.
+    /// </summary>
+    [Fact]
+    public async Task Malformed_Token_Response_Throws_Inside_The_Exception_Contract()
+    {
+        var provider = CreateProvider(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{not json")
+        });
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralServerException>(
+            () => provider.GetTokenAsync(CancellationToken.None));
+
+        Assert.True(ex.IsTokenAcquisitionFailure);
+        Assert.Equal("https://auth/tenant", ex.RequestUrl);
+        Assert.Null(ex.ResponseBody);
+        Assert.IsType<JsonException>(ex.InnerException);
+    }
+
+    /// <summary>
+    /// A well-formed body with no <c>access_token</c> used to be cached as an empty string and
+    /// then sent as a bare <c>Bearer</c> header, surfacing as a 401 loop that blamed Business
+    /// Central for what the token endpoint did.
+    /// </summary>
+    [Theory]
+    [InlineData("{\"expires_in\":3600}")]
+    [InlineData("{\"access_token\":\"\",\"expires_in\":3600}")]
+    [InlineData("{\"access_token\":\"   \",\"expires_in\":3600}")]
+    [InlineData("null")]
+    public async Task Token_Response_Without_An_Access_Token_Is_Rejected(string body)
+    {
+        var provider = CreateProvider(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body)
+        });
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralServerException>(
+            () => provider.GetTokenAsync(CancellationToken.None));
+
+        Assert.True(ex.IsTokenAcquisitionFailure);
+        Assert.False(ex.IsTransient);
+        Assert.Null(ex.ResponseBody);
+    }
+
+    /// <summary>
+    /// A malformed success can still contain an access token. Neither the exception nor the
+    /// observer may copy identity-provider bodies into data that is commonly logged.
+    /// </summary>
+    [Fact]
+    public async Task Rejected_Token_Response_Is_Redacted_From_Diagnostics()
+    {
+        const string secret = "credential-that-must-not-be-logged";
+        var observer = new TestObserver();
+
+        var provider = CreateProvider(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent($"{{\"access_token\":\"{secret}\",not-json")
+        }, observer);
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralServerException>(
+            () => provider.GetTokenAsync(CancellationToken.None));
+
+        Assert.Null(ex.ResponseBody);
+        Assert.DoesNotContain(secret, ex.ToString(), StringComparison.Ordinal);
+
+        var diagnostic = Assert.Single(observer.DeserializationFailures);
+        Assert.Null(diagnostic.ResponseBody);
+        Assert.DoesNotContain(secret, diagnostic.Exception.ToString(), StringComparison.Ordinal);
+    }
+
+    /// <summary>A malformed response is never cached, so the next call retries the endpoint.</summary>
+    [Fact]
+    public async Task A_Rejected_Token_Response_Is_Not_Cached()
+    {
+        var calls = 0;
+
+        var provider = CreateProvider(_ =>
+            ++calls == 1
+                ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}") }
+                : Token("good"));
+
+        await Assert.ThrowsAsync<BusinessCentralServerException>(
+            () => provider.GetTokenAsync(CancellationToken.None));
+
+        Assert.Equal("good", await provider.GetTokenAsync(CancellationToken.None));
+        Assert.Equal(2, calls);
+    }
+
+    #endregion
+
+    #region Token failures are distinguishable from answers about the entity
+
+    /// <summary>
+    /// <c>GetAsync</c> swallows a 404 as "no such entity". Its try also spans token
+    /// acquisition, and the token provider reports through the same hierarchy — so a
+    /// misconfigured TokenEndpoint answering 404 was returned as a null entity, leaving every
+    /// read silently empty with nothing thrown to say authentication never happened.
+    /// </summary>
+    [Fact]
+    public async Task Token_Endpoint_404_Is_Not_Swallowed_As_A_Missing_Entity()
+    {
+        var client = TestBase.CreateClient(req =>
+            req.RequestUri!.AbsoluteUri.Contains("auth")
+                ? new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    Content = new StringContent("{\"error\":{\"code\":\"NotFound\"}}")
+                }
+                : TestBase.Json("{\"id\":1}"));
+
+        var ex = await Assert.ThrowsAsync<BusinessCentralNotFoundException>(
+            () => client.GetAsync<SalesOrder>("salesOrders", "1"));
+
+        Assert.True(ex.IsTokenAcquisitionFailure);
+    }
+
+    /// <summary>The entity's own 404 is still a null, which is the whole point of the catch.</summary>
+    [Fact]
+    public async Task Entity_404_Is_Still_Returned_As_Null()
+    {
+        var client = TestBase.CreateClient(TestBase.WithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("{\"error\":{\"code\":\"NotFound\"}}")
+            }));
+
+        Assert.Null(await client.GetAsync<SalesOrder>("salesOrders", "1"));
+    }
+
+    #endregion
 }

--- a/test/Dynamics365.BusinessCentral.Tests/Utils/TestObserver.cs
+++ b/test/Dynamics365.BusinessCentral.Tests/Utils/TestObserver.cs
@@ -31,6 +31,8 @@ public sealed class TestObserver : IBusinessCentralObserver
 
     public readonly List<BusinessCentralUrlLengthInfo> UrlWarnings = [];
 
+    public readonly List<BusinessCentralErrorInfo> DeserializationFailures = [];
+
     public void OnUrlLengthWarning(BusinessCentralUrlLengthInfo info)
     {
         Events.Add($"url-length:{info.QueryStringLength}");
@@ -38,5 +40,8 @@ public sealed class TestObserver : IBusinessCentralObserver
     }
 
     public void OnDeserializationFailed(BusinessCentralErrorInfo info)
-        => Events.Add("deserialization-failed");
+    {
+        Events.Add("deserialization-failed");
+        DeserializationFailures.Add(info);
+    }
 }


### PR DESCRIPTION
Cuts `2.0.0-rc.1`. Six defects from an external full-solution review, plus the release
infrastructure that makes "release candidate" mean something.

**Why rc and not stable.** The review found six real defects — two of which return a wrong
answer rather than an error — after nine feedback rounds and 423 tests. That says the
defect-discovery rate hasn't converged: nine rounds were all shaped by one consumer's usage,
and the first look from a different angle immediately found things they hadn't. The API is
settled; the validation isn't. `rc` is the honest label for that.

## Fixed — the two that return a wrong answer

**A company name containing an apostrophe built an unparseable URL.** It was percent-encoded
but never escaped as an OData string literal first, so `O'Brien Ltd` went out as
`Company('O%27Brien Ltd')` — and `%27` decodes to a bare quote before the OData parser sees
it, ending the literal early. Doubled first, encoded second:
`Company('O%27%27Brien%20Ltd')`. Affects the configured `Company`, `ForCompany(...)` and any
name from `GetCompaniesAsync`. Every request from such a tenant failed.

That it survived to alpha.7 is the useful signal: no test and no live round ever used a
company name with a quote in it. The code wasn't sloppy — the inputs were narrow.

**`GetAsync` swallowed a `404` from the token endpoint.** Its `try` spans token acquisition,
and the token provider reports through the same exception hierarchy, so a misconfigured
`TokenEndpoint` answering `404` was read as "no such entity" and returned as `null` — every
read silently empty, nothing thrown to say authentication never happened. New
`IsTokenAcquisitionFailure` gates the catch; the entity's own `404` is still a `null`.

## Fixed — the other four

- **An `@odata.nextLink` is followed only on the configured service origin.** Continuations
  are the one URL the client sends that it did not build: they go out verbatim and carry the
  bearer token, so a response naming `https://attacker.example/page` would have disclosed it
  and made the client fetch any host the response chose. Scheme, host and port must match
  `ResolvedBaseUrl`. Origin, not prefix — the path legitimately differs. Matching the scheme
  stops an `https` deployment being talked down to `http`; an `http` base is left alone rather
  than broken by a rule it never opted into.
- **A repeated continuation cursor throws instead of looping or truncating.** The old guard
  required an *empty* page, on the reasoning that a repeated cursor carrying rows was
  legitimate — it isn't, refetching replays the page already emitted. And the empty case isn't
  safe to stop on either: a `nextLink` asserts continuation remains, so stopping quietly
  reported a possibly truncated result as success. Every followed cursor is tracked, so cycles
  (`A → B → A`) are caught too.
- **`CountAsync` answers the same number on both paths.** `$count` is independent of the page
  window, but the walk-the-collection fallback reapplied the builder's `Top`/`Skip` — so
  `.Top(10).CountAsync()` returned the full total on one endpoint and `10` on another.
- **A malformed `200` from the token endpoint stays inside the exception contract.**
  Unparseable JSON threw a raw `JsonException` straight through the documented
  `catch (BusinessCentralException)`; a body with no `access_token` was cached as an empty
  string and sent as a bare `Bearer`, surfacing as a `401` loop that blamed Business Central.
  The response body is kept out of exceptions and observer events — a malformed success can
  still contain a token. Deliberately scoped to the success path: a non-2xx keeps its body,
  because an OAuth2 error response cannot contain a token and its `AADSTS…` code is the whole
  diagnosis.

## Added

- `BusinessCentralProtocolException` + `IsProtocolViolation`; `IsTokenAcquisitionFailure`.
- **Package validation on both packages** — `EnablePackageValidation`, baseline `2.0.0-alpha.7`,
  `EnableStrictModeForCompatibleTfms` (catches a member on one TFM but not another, which
  compiles fine and breaks multi-targeting consumers). Verified running, not just configured:
  `pack` fails on an unresolvable baseline and passes on the real one. Offline builds need
  `/p:DisablePackageBaselineValidation=true`.
- **`LICENSE` at the repo root.** Both packages always declared MIT via
  `PackageLicenseExpression`, but the repository had no file — an adoption blocker for anyone
  whose legal review reads the repo rather than the package.

## Release metadata

`<Version>` → `2.0.0-rc.1` in both csprojs. `PackageReleaseNotes` rewritten — it still
described alpha.7. CHANGELOG link definitions added for alpha.2 → rc.1: there were 10 version
headings and 3 definitions, so six rendered as unlinked text and `[Unreleased]` diffed against
`v2.0.0-alpha`, the first prerelease.

The alpha entry's `⚠️ Inconclusive: server-driven nextLink paging` is annotated as superseded
rather than the README being weakened to match it. That probe ran through the old client's
`$top=1000` pacing, which never exceeded the server's 20k page size — so the server had no
cause to emit a `nextLink`, and the absence measured the client, not the endpoint. Re-probing
without `$top` returned ~20k rows and an open `$skiptoken` cursor.

## Verification

- 443 tests green (423 → 443); Release clean on net8.0/net9.0/net10.0 with 0 warnings.
- Both packages pack and install into a fresh consumer project, exercising the fluent builder,
  derived `$select`, paging through the new origin check and the apostrophe fix end to end.
  (Tested against `rc.1` specifically — a local feed does *not* win over nuget.org for a
  version published on both, so testing a published version proves nothing.)

## Not in this PR

- **The KRALTEST integration-test project.** All 443 tests run through `FakeHttpHandler`, so
  every measured BC behaviour — the 8,099-character ceiling, `$schemaversion=2.1` gating `in`,
  case-insensitive `$select`, 20k page sizes, `nextLink` on published pages — is asserted only
  in prose and would survive a refactor that broke it. Highest-value item left before stable.
- **PublicApiAnalyzers.** `PublicAPI.Shipped.txt` needs exact Roslyn formatting including
  nullable annotations; generating it outside an IDE code-fix session is error-prone. Package
  validation covers the actual risk today.

## Reviewer notes

Two behaviour changes are silent by nature and are documented in MIGRATION.md: a `ToAllAsync`
that starts throwing `BusinessCentralProtocolException` was previously returning a possibly
truncated result, and `.Top(n).CountAsync()` now answers the full total everywhere.